### PR TITLE
refactor(indexer): streamline epoch rewards processing and storage

### DIFF
--- a/packages/indexer/src/services/consensus/controllers/epoch.ts
+++ b/packages/indexer/src/services/consensus/controllers/epoch.ts
@@ -2,12 +2,10 @@ import chunk from 'lodash/chunk.js';
 
 import { EpochControllerHelpers } from './helpers/epochControllerHelpers.js';
 
-import createLogger from '@/src/lib/pino.js';
 import { BeaconClient } from '@/src/services/consensus/beacon.js';
 import { EpochStorage } from '@/src/services/consensus/storage/epoch.js';
 import { ValidatorsStorage } from '@/src/services/consensus/storage/validators.js';
 import { BeaconTime } from '@/src/services/consensus/utils/beaconTime.js';
-import { getUTCDatetimeFlooredToHour } from '@/src/utils/date/index.js';
 
 export class EpochController extends EpochControllerHelpers {
   static readonly maxUnprocessedEpochs: number = 5;
@@ -88,13 +86,8 @@ export class EpochController extends EpochControllerHelpers {
    *
    * 1. Fetches rewards from the beacon chain in batches
    * 2. Processes and calculates missed rewards using ideal rewards
-   * 3. Directly aggregates rewards into HourlyValidatorData and HourlyValidatorStats
+   * 3. Stores rewards directly in epoch_rewards table
    * 4. Marks epoch as rewardsFetched = true
-   *
-   * The old EpochRewards table is no longer used, and rewards are stored directly
-   * in HourlyValidatorData.epochRewards using the format:
-   * 'epoch:head:target:source:inactivity:missedHead:missedTarget:missedSource:missedInactivity'
-   * comma separated
    */
   async fetchEpochRewards(epoch: number) {
     const epochDb = await this.epochStorage.getEpochByNumber(epoch);
@@ -110,9 +103,14 @@ export class EpochController extends EpochControllerHelpers {
 
     let allProcessedRewards: Array<{
       validatorIndex: number;
-      clRewards: bigint;
-      clMissedRewards: bigint;
-      rewards: string; // Format: 'epoch:head:target:source:inactivity:missedHead:missedTarget:missedSource:missedInactivity'
+      head: bigint;
+      target: bigint;
+      source: bigint;
+      inactivity: bigint;
+      missedHead: bigint;
+      missedTarget: bigint;
+      missedSource: bigint;
+      missedInactivity: bigint;
     }> = [];
 
     // Fetch rewards in batches and process them
@@ -138,12 +136,11 @@ export class EpochController extends EpochControllerHelpers {
       }
 
       // Process rewards: get validator balances, find ideal rewards by balance,
-      // calculate missed rewards (ideal - actual), and format for new storage strategy
+      // calculate missed rewards (ideal - actual)
       const epochRewardsData = this.processEpochReward(
         epochRewards.data.total_rewards,
         validatorsBalancesMap,
         idealRewardsLookup!,
-        epoch,
       );
 
       // Use concat instead of spread operator to avoid stack overflow with large arrays
@@ -151,12 +148,8 @@ export class EpochController extends EpochControllerHelpers {
       allProcessedRewards = allProcessedRewards.concat(epochRewardsData);
     }
 
-    // Calculate datetime for hourly aggregation using BeaconTime
-    const epochTimestamp = this.beaconTime.getTimestampFromEpochNumber(epoch);
-    const datetime = getUTCDatetimeFlooredToHour(epochTimestamp);
-
-    // Process and aggregate rewards in a single atomic transaction
-    await this.epochStorage.processEpochRewardsAndAggregate(epoch, datetime, allProcessedRewards);
+    // Process and store rewards in a single atomic transaction
+    await this.epochStorage.processEpochRewardsAndAggregate(epoch, allProcessedRewards);
   }
 
   /**

--- a/packages/indexer/src/services/consensus/controllers/helpers/epochControllerHelpers.ts
+++ b/packages/indexer/src/services/consensus/controllers/helpers/epochControllerHelpers.ts
@@ -60,28 +60,30 @@ export abstract class EpochControllerHelpers {
   }
 
   /**
-   * Process a batch of rewards and return formatted data
+   * Process a batch of rewards and return data ready for storage
    *
-   * - Calculates clRewards and clMissedRewards for aggregation
-   * - Formats rewards string for HourlyValidatorData storage
-   * - Returns data ready for storage layer
+   * - Calculates missed rewards based on ideal rewards
+   * - Returns individual reward values ready for direct database storage
    *
    * @param rewards - Array of total rewards from beacon chain
    * @param validatorsBalancesMap - Map of validator balances for ideal reward calculation
    * @param idealRewardsLookup - Lookup map for ideal rewards by balance
-   * @param epoch - The epoch number for the rewards string format
    * @returns Array of processed reward data ready for storage
    */
   protected processEpochReward(
     rewards: TotalReward[],
     validatorsBalancesMap: Map<string, string>,
     idealRewardsLookup: Map<string, IdealReward>,
-    epoch: number,
   ): Array<{
     validatorIndex: number;
-    clRewards: bigint;
-    clMissedRewards: bigint;
-    rewards: string; // Format: 'epoch:head:target:source:inactivity:missedHead:missedTarget:missedSource:missedInactivity'
+    head: bigint;
+    target: bigint;
+    source: bigint;
+    inactivity: bigint;
+    missedHead: bigint;
+    missedTarget: bigint;
+    missedSource: bigint;
+    missedInactivity: bigint;
   }> {
     return rewards.map((validatorInfo) => {
       const balance = validatorsBalancesMap.get(validatorInfo.validator_index) || '0';
@@ -108,18 +110,16 @@ export abstract class EpochControllerHelpers {
         missedInactivity = BigInt(idealReward.inactivity || '0') - inactivity;
       }
 
-      // Calculate aggregated values for storage
-      const clRewards = head + target + source + inactivity;
-      const clMissedRewards = missedHead + missedTarget + missedSource + missedInactivity;
-
-      // Format rewards string for HourlyValidatorData storage
-      const rewardsString = `${epoch}:${head}:${target}:${source}:${inactivity}:${missedHead}:${missedTarget}:${missedSource}:${missedInactivity}`;
-
       return {
         validatorIndex: Number(validatorInfo.validator_index),
-        clRewards,
-        clMissedRewards,
-        rewards: rewardsString,
+        head,
+        target,
+        source,
+        inactivity,
+        missedHead,
+        missedTarget,
+        missedSource,
+        missedInactivity,
       };
     });
   }

--- a/packages/indexer/src/services/consensus/storage/epoch.ts
+++ b/packages/indexer/src/services/consensus/storage/epoch.ts
@@ -139,20 +139,23 @@ export class EpochStorage {
   }
 
   /**
-   * Process epoch rewards and aggregate them into hourly validator data in a single atomic transaction.
+   * Process epoch rewards and store them in the database in a single atomic transaction.
    *
    * @param epoch - The epoch number to process
-   * @param datetime - The datetime for the hourly aggregation
    * @param processedRewards - Array of pre-processed reward data ready for storage
    */
   async processEpochRewardsAndAggregate(
     epoch: number,
-    datetime: Date,
     processedRewards: Array<{
       validatorIndex: number;
-      clRewards: bigint;
-      clMissedRewards: bigint;
-      rewards: string; // Format: 'epoch:head:target:source:inactivity:missedHead:missedTarget:missedSource:missedInactivity'
+      head: bigint;
+      target: bigint;
+      source: bigint;
+      inactivity: bigint;
+      missedHead: bigint;
+      missedTarget: bigint;
+      missedSource: bigint;
+      missedInactivity: bigint;
     }>,
   ) {
     await this.prisma.$transaction(
@@ -164,35 +167,17 @@ export class EpochStorage {
           CREATE TEMPORARY TABLE tmp_epoch_rewards (LIKE epoch_rewards) ON COMMIT DROP;
         `;
 
-        // Parse all rewards strings before bulk insert
-        const parsedRewards = processedRewards.map((validator) => {
-          // Parse rewards string: 'epoch:head:target:source:inactivity:missedHead:missedTarget:missedSource:missedInactivity'
-          const rewardsParts = validator.rewards.split(':');
-          return {
-            epoch,
-            validatorIndex: validator.validatorIndex,
-            head: BigInt(rewardsParts[1] || '0'),
-            target: BigInt(rewardsParts[2] || '0'),
-            source: BigInt(rewardsParts[3] || '0'),
-            inactivity: BigInt(rewardsParts[4] || '0'),
-            missedHead: BigInt(rewardsParts[5] || '0'),
-            missedTarget: BigInt(rewardsParts[6] || '0'),
-            missedSource: BigInt(rewardsParts[7] || '0'),
-            missedInactivity: BigInt(rewardsParts[8] || '0'),
-          };
-        });
-
         // Bulk insert into temporary table using VALUES in batches
         // PostgreSQL limit: 32,767 bind variables per prepared statement
         // With 10 columns per row, max batch size = 32,767 / 10 ≈ 3,200 rows
         // Using 5,000 rows per batch for better performance (using executeRawUnsafe)
         const batchSize = 5_000;
-        const batches = chunk(parsedRewards, batchSize);
+        const batches = chunk(processedRewards, batchSize);
         for (const batch of batches) {
           const valuesClause = batch
             .map(
               (r) =>
-                `(${r.epoch}, ${r.validatorIndex}, ${r.head.toString()}, ${r.target.toString()}, ${r.source.toString()}, ${r.inactivity.toString()}, ${r.missedHead.toString()}, ${r.missedTarget.toString()}, ${r.missedSource.toString()}, ${r.missedInactivity.toString()})`,
+                `(${epoch}, ${r.validatorIndex}, ${r.head.toString()}, ${r.target.toString()}, ${r.source.toString()}, ${r.inactivity.toString()}, ${r.missedHead.toString()}, ${r.missedTarget.toString()}, ${r.missedSource.toString()}, ${r.missedInactivity.toString()})`,
             )
             .join(',');
 
@@ -214,35 +199,7 @@ export class EpochStorage {
           FROM tmp_epoch_rewards
         `;
 
-        // Aggregate rewards into HourlyValidatorStats using pre-calculated values
-        // Process in batches to avoid SQL parameter limits
-        // const statsBatchSize = 1000;
-        // const statsBatches = chunk(processedRewards, statsBatchSize);
-
-        // for (const statsBatch of statsBatches) {
-        //   const valuesClause = statsBatch
-        //     .map(
-        //       (r) =>
-        //         `(${r.validatorIndex}, ${r.clRewards.toString()}, ${r.clMissedRewards.toString()})`,
-        //     )
-        //     .join(',');
-
-        //   await tx.$executeRawUnsafe(`
-        //     INSERT INTO hourly_validator_stats
-        //       (datetime, validator_index, cl_rewards, cl_missed_rewards)
-        //     SELECT
-        //       '${datetime.toISOString()}'::timestamp as datetime,
-        //       validator_index,
-        //       cl_rewards,
-        //       cl_missed_rewards
-        //     FROM (VALUES ${valuesClause}) AS rewards(validator_index, cl_rewards, cl_missed_rewards)
-        //     ON CONFLICT (datetime, validator_index) DO UPDATE SET
-        //       cl_rewards = hourly_validator_stats.cl_rewards + EXCLUDED.cl_rewards,
-        //       cl_missed_rewards = hourly_validator_stats.cl_missed_rewards + EXCLUDED.cl_missed_rewards
-        //   `);
-        // }
-
-        // Mark epoch as rewardsFetched = true (rewardsAggregated is no longer needed)
+        // Mark epoch as rewardsFetched = true
         await tx.epoch.update({
           where: { epoch },
           data: { rewardsFetched: true },


### PR DESCRIPTION
- Updated the EpochController to directly store rewards in the epoch_rewards table, removing the old aggregation method.
- Refactored the processEpochReward method to return individual reward values instead of a formatted string.
- Simplified the processEpochRewardsAndAggregate method to eliminate unnecessary datetime calculations and streamline the transaction process.
- Enhanced code clarity by removing deprecated comments and improving variable naming conventions.