### PR TITLE
feat(indexer): implement parallel epoch processing with exclusion of …

### DIFF
--- a/packages/indexer/src/services/consensus/controllers/epoch.ts
+++ b/packages/indexer/src/services/consensus/controllers/epoch.ts
@@ -31,6 +31,17 @@ export class EpochController extends EpochControllerHelpers {
     return this.epochStorage.getMinEpochToProcess();
   }
 
+  /**
+   * Get the minimum unprocessed epoch excluding active epochs.
+   * Useful for parallel processing to avoid duplicates.
+   *
+   * @param activeEpochs - Array of epoch numbers currently being processed
+   * @returns The next epoch to process, or null if none available
+   */
+  async getMinEpochToProcessExcluding(activeEpochs: number[]) {
+    return this.epochStorage.getMinEpochToProcessExcluding(activeEpochs);
+  }
+
   getBeaconTime() {
     return this.beaconTime;
   }

--- a/packages/indexer/src/services/consensus/storage/epoch.ts
+++ b/packages/indexer/src/services/consensus/storage/epoch.ts
@@ -130,6 +130,33 @@ export class EpochStorage {
     };
   }
 
+  /**
+   * Get the minimum unprocessed epoch excluding the provided active epochs.
+   * This is useful when processing multiple epochs in parallel to avoid duplicates.
+   *
+   * @param activeEpochs - Array of epoch numbers that are currently being processed
+   * @returns The next epoch to process, or null if none available
+   */
+  async getMinEpochToProcessExcluding(activeEpochs: number[]) {
+    const nextEpoch = await this.prisma.epoch.findFirst({
+      where: {
+        processed: false,
+        epoch: {
+          notIn: activeEpochs.length > 0 ? activeEpochs : undefined,
+        },
+      },
+      orderBy: { epoch: 'asc' },
+    });
+
+    if (!nextEpoch) {
+      return null;
+    }
+
+    return {
+      ...nextEpoch,
+    };
+  }
+
   async markEpochAsProcessed(epoch: number) {
     await this.prisma.epoch.update({
       where: { epoch },

--- a/packages/indexer/src/xstate/epoch/epochOrchestrator.machine.test.ts
+++ b/packages/indexer/src/xstate/epoch/epochOrchestrator.machine.test.ts
@@ -1,18 +1,38 @@
-import { test, expect, vi, beforeEach } from 'vitest';
-import { createActor, createMachine, sendParent, SnapshotFrom } from 'xstate';
+import { test, expect, vi, beforeEach, afterEach, describe } from 'vitest';
+import { createMachine, sendParent } from 'xstate';
 
-import { createControllablePromise } from '@/src/__tests__/utils.js';
+import {
+  createAndStartActor,
+  createControllablePromise,
+  getNestedState,
+} from '@/src/__tests__/utils.js';
+import { gnosisConfig } from '@/src/config/chain.js';
 import { EpochController } from '@/src/services/consensus/controllers/epoch.js';
 import { PartitionController } from '@/src/services/consensus/controllers/partition.js';
 import { SlotController } from '@/src/services/consensus/controllers/slot.js';
-// eslint-disable-next-line import/order
 import { BeaconTime } from '@/src/services/consensus/utils/beaconTime.js';
 
+// ============================================================================
+// Test Constants - Use Gnosis chain real values (except slotDuration for fast tests)
+// ============================================================================
+const SLOT_DURATION = 10; // 10ms - small for fast tests (real Gnosis: 5s)
+const {
+  slotsPerEpoch: SLOTS_PER_EPOCH,
+  genesisTimestamp: GENESIS_TIMESTAMP,
+  epochsPerSyncCommitteePeriod: EPOCHS_PER_SYNC_COMMITTEE_PERIOD,
+} = gnosisConfig.beacon;
+const LOOKBACK_SLOT = 32;
+const POLLING_DELAY = SLOT_DURATION / 2;
+
+// ============================================================================
+// Mock Controllers
+// ============================================================================
 const mockEpochController = {
   getLastCreated: vi.fn(),
   getEpochsToCreate: vi.fn(),
   createEpochs: vi.fn(),
   getMinEpochToProcess: vi.fn(),
+  getMinEpochToProcessExcluding: vi.fn(),
   markEpochAsProcessed: vi.fn(),
 } as unknown as EpochController;
 
@@ -20,25 +40,60 @@ const mockPartitionController = {
   createPartitionsToProcessEpoch: vi.fn(),
 } as unknown as PartitionController;
 
-// Mock BeaconTime instance for testing
-const GENESIS_TIMESTAMP = 1606824000000; // Example genesis timestamp
-const SLOT_DURATION_MS = 100; // 100ms per slot for fast tests
-const SLOTS_PER_EPOCH = 32;
 const mockBeaconTime = new BeaconTime({
   genesisTimestamp: GENESIS_TIMESTAMP,
-  slotDurationMs: SLOT_DURATION_MS,
+  slotDurationMs: SLOT_DURATION,
   slotsPerEpoch: SLOTS_PER_EPOCH,
-  epochsPerSyncCommitteePeriod: 256, // 256 epochs per sync committee period
-  lookbackSlot: 32,
+  epochsPerSyncCommitteePeriod: EPOCHS_PER_SYNC_COMMITTEE_PERIOD,
+  lookbackSlot: LOOKBACK_SLOT,
 });
 
-// Minimal SlotController mock for tests
 const mockSlotController = {} as unknown as SlotController;
 
-// Mock the logging functions - simple mocks that do nothing
-const mockLogActor = vi.fn();
+// ============================================================================
+// Helper Functions
+// ============================================================================
 
-// Mock the modules
+/** Create a mock epoch object with all required properties */
+function createMockEpoch(epoch: number) {
+  return {
+    epoch,
+    processed: false,
+    allSlotsProcessed: false,
+    committeesFetched: false,
+    syncCommitteesFetched: false,
+    validatorProposerDutiesFetched: false,
+    validatorsBalancesFetched: false,
+    validatorsActivationFetched: false,
+    rewardsFetched: false,
+  };
+}
+
+/** Create default input for the orchestrator machine */
+function createOrchestratorInput() {
+  return {
+    slotDuration: SLOT_DURATION,
+    slotsPerEpoch: SLOTS_PER_EPOCH,
+    lookbackSlot: LOOKBACK_SLOT,
+    epochController: mockEpochController,
+    partitionController: mockPartitionController,
+    beaconTime: mockBeaconTime,
+    slotController: mockSlotController,
+  };
+}
+
+/**
+ * Resolve a promise and advance timers past the polling delay
+ * to allow XState to process the result and cycle back to spawningEpochs.
+ */
+async function resolvePromiseAndAdvance<T>(promise: { resolve: (value: T) => void }, value: T) {
+  promise.resolve(value);
+  await vi.advanceTimersByTimeAsync(POLLING_DELAY + 1);
+}
+
+// ============================================================================
+// Mocks
+// ============================================================================
 vi.mock('@/src/xstate/pinoLog.js', () => ({
   pinoLog: vi.fn(() => () => {}),
 }));
@@ -47,336 +102,323 @@ vi.mock('@/src/xstate/multiMachineLogger.js', () => ({
   logActor: vi.fn(),
 }));
 
-// Mock the epoch processor machine to avoid database and network calls
-vi.mock('@/src/xstate/epoch/epochProcessor.machine.js', () => {
-  const mockMachine = createMachine({
-    id: 'EpochProcessor',
+// Mock the epoch worker machine
+vi.mock('@/src/xstate/epoch/epochWorker.machine.js', () => {
+  const mockWorkerMachine = createMachine({
+    id: 'EpochWorker',
     types: {} as {
-      events: { type: 'complete' };
+      input: { epoch: number };
+      events: { type: 'EPOCH_COMPLETED'; machineId: string } | { type: 'COMPLETE' };
     },
-    initial: 'idle',
+    initial: 'running',
+    context: ({ input }) => ({ epoch: input.epoch }),
     states: {
-      idle: {
+      running: {
         on: {
-          complete: 'completed',
+          COMPLETE: {
+            target: 'completed',
+            actions: sendParent(({ context }) => ({
+              type: 'EPOCH_COMPLETED',
+              epoch: context.epoch,
+              machineId: `epochProcessor:${context.epoch}`,
+            })),
+          },
         },
       },
       completed: {
-        entry: [
-          sendParent(() => ({
-            type: 'EPOCH_COMPLETED',
-            machineId: `epochProcessor:100`,
-          })),
-          () => console.log('Sending EPOCH_COMPLETED to parent'),
-        ],
         type: 'final',
       },
     },
   });
 
   return {
-    epochProcessorMachine: mockMachine,
+    epochWorkerMachine: mockWorkerMachine,
   };
 });
 
 // Import the orchestrator after mocks are set up
 import { epochOrchestratorMachine } from '@/src/xstate/epoch/epochOrchestrator.machine.js';
 
-// Reset mocks before each test
+// ============================================================================
+// Test Setup
+// ============================================================================
 beforeEach(() => {
+  vi.useFakeTimers();
   vi.clearAllMocks();
-  mockLogActor.mockReturnValue(undefined);
 });
 
-describe.skip('epochOrchestratorMachine', () => {
-  test('should initialize with correct context and transition to pollingEpoch', async () => {
-    // Arrange
-    const controllableGetMinEpochPromise = createControllablePromise<null>();
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllTimers();
+});
 
-    vi.mocked(mockEpochController.getMinEpochToProcess).mockImplementation(
-      () => controllableGetMinEpochPromise.promise,
+// ============================================================================
+// Tests
+// ============================================================================
+describe('epochOrchestratorMachine', () => {
+  test('should initialize and cycle through states when no epochs found', async () => {
+    // Arrange - first call returns null (no epochs), second call blocks
+    type EpochType = ReturnType<typeof createMockEpoch> | null;
+    const firstCallPromise = createControllablePromise<EpochType>();
+    const blockingPromise = createControllablePromise<EpochType>();
+
+    vi.mocked(mockEpochController.getMinEpochToProcessExcluding)
+      .mockReturnValueOnce(firstCallPromise.promise)
+      .mockReturnValue(blockingPromise.promise); // Never resolved, blocks the machine
+
+    const { actor, stateTransitions, subscription } = createAndStartActor(
+      epochOrchestratorMachine,
+      createOrchestratorInput(),
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stateTransitions: SnapshotFrom<any>[] = [];
-    const actor = createActor(epochOrchestratorMachine, {
-      input: {
-        slotDuration: 0.1, // 100ms for faster tests
-        slotsPerEpoch: SLOTS_PER_EPOCH,
-        lookbackSlot: 32,
-        epochController: mockEpochController,
-        partitionController: mockPartitionController,
-        beaconTime: mockBeaconTime,
-        slotController: mockSlotController,
-      },
-    });
+    // Assert initial state is spawningEpochs
+    expect(getNestedState(stateTransitions[0], 'orchestrating')).toBe('spawningEpochs');
 
-    const subscription = actor.subscribe((snapshot) => {
-      stateTransitions.push(snapshot.value);
-    });
+    // Resolve first call with null (no epoch found) and let XState process the transition
+    firstCallPromise.resolve(null);
+    await vi.advanceTimersByTimeAsync(0);
 
-    // Act
-    actor.start();
+    // stateTransitions[0] = spawningEpochs (initial)
+    // stateTransitions[1] = pollingDelay (after promise resolved with null)
+    expect(getNestedState(stateTransitions[1], 'orchestrating')).toBe('pollingDelay');
 
-    // Assert - Check initial state
-    expect(stateTransitions[0]).toBe('pollingEpoch');
+    // Verify getMinEpochToProcessExcluding was called with empty array
+    expect(vi.mocked(mockEpochController.getMinEpochToProcessExcluding)).toHaveBeenCalledWith([]);
 
-    // Verify that getMinEpochToProcess was called at least once
-    expect(vi.mocked(mockEpochController.getMinEpochToProcess)).toHaveBeenCalledTimes(1);
+    // Verify context remains empty
+    expect(actor.getSnapshot().context.epochs).toEqual({});
 
-    // Now resolve the promise to complete the async operation
-    controllableGetMinEpochPromise.resolve(null);
-
-    // Wait for the state transition to complete
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    // Assert - Should transition to idleNoEpoch after resolving with null
-    const lastState = stateTransitions[stateTransitions.length - 1];
-    expect(lastState).toBe('idleNoEpoch');
-
-    // Verify context using final snapshot
-    const finalSnapshot = actor.getSnapshot();
-    expect(finalSnapshot.context.epochData).toBe(null);
-    expect(finalSnapshot.context.epochActor).toBe(null);
-    expect(finalSnapshot.context.slotDuration).toBe(0.1);
-    expect(finalSnapshot.context.lookbackSlot).toBe(32);
-
-    // Clean up
-    subscription.unsubscribe();
     actor.stop();
+    subscription.unsubscribe();
   });
 
-  test('should handle getMinEpochToProcess error and retry after delay', async () => {
+  test('should spawn up to 3 epochs in parallel and not exceed capacity', async () => {
     // Arrange
-    const controllableGetMinEpochPromise = createControllablePromise<null>();
+    type EpochType = ReturnType<typeof createMockEpoch> | null;
+    const epoch100Promise = createControllablePromise<EpochType>();
+    const epoch101Promise = createControllablePromise<EpochType>();
+    const epoch102Promise = createControllablePromise<EpochType>();
+    const epoch103Promise = createControllablePromise<EpochType>();
+    const blockingPromise = createControllablePromise<EpochType>(); // Never resolved
 
-    vi.mocked(mockEpochController.getMinEpochToProcess).mockImplementation(
-      () => controllableGetMinEpochPromise.promise,
+    vi.mocked(mockEpochController.getMinEpochToProcessExcluding)
+      .mockReturnValueOnce(epoch100Promise.promise)
+      .mockReturnValueOnce(epoch101Promise.promise)
+      .mockReturnValueOnce(epoch102Promise.promise)
+      .mockReturnValueOnce(epoch103Promise.promise) // Returns epoch but should NOT be spawned
+      .mockReturnValue(blockingPromise.promise);
+
+    const { actor, stateTransitions, subscription } = createAndStartActor(
+      epochOrchestratorMachine,
+      createOrchestratorInput(),
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stateTransitions: SnapshotFrom<any>[] = [];
-    const actor = createActor(epochOrchestratorMachine, {
-      input: {
-        slotDuration: 0.1, // 100ms for faster tests
-        slotsPerEpoch: SLOTS_PER_EPOCH,
-        lookbackSlot: 32,
-        epochController: mockEpochController,
-        partitionController: mockPartitionController,
-        beaconTime: mockBeaconTime,
-        slotController: mockSlotController,
-      },
-    });
+    // Machine starts in spawningEpochs, waiting for first promise
+    expect(getNestedState(stateTransitions[0], 'orchestrating')).toBe('spawningEpochs');
 
-    const subscription = actor.subscribe((snapshot) => {
-      stateTransitions.push(snapshot.value);
-    });
+    // Resolve first epoch and advance timers to complete polling cycle
+    await resolvePromiseAndAdvance(epoch100Promise, createMockEpoch(100));
 
-    // Act
-    actor.start();
+    // Should have spawned epoch 100
+    let snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[100]).toBe('processing');
 
-    // Assert - Should be in pollingEpoch state initially
-    expect(stateTransitions[0]).toBe('pollingEpoch');
-    expect(vi.mocked(mockEpochController.getMinEpochToProcess)).toHaveBeenCalledTimes(1);
+    // Resolve second epoch
+    await resolvePromiseAndAdvance(epoch101Promise, createMockEpoch(101));
 
-    // Now reject the promise to trigger error handling
-    controllableGetMinEpochPromise.reject(new Error('Test error: failed to get min epoch'));
+    // Should have spawned epoch 101
+    snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[100]).toBe('processing');
+    expect(snapshot.context.epochs[101]).toBe('processing');
 
-    // Wait for the state transition to complete
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Resolve third epoch - now at capacity (3 epochs)
+    await resolvePromiseAndAdvance(epoch102Promise, createMockEpoch(102));
 
-    // Assert - Should transition to idleNoEpoch after error
-    const stateAfterError = stateTransitions[stateTransitions.length - 1];
-    expect(stateAfterError).toBe('idleNoEpoch');
+    // Should have 3 epochs processing
+    snapshot = actor.getSnapshot();
+    expect(Object.keys(snapshot.context.epochs).length).toBe(3);
+    expect(snapshot.context.epochs[100]).toBe('processing');
+    expect(snapshot.context.epochs[101]).toBe('processing');
+    expect(snapshot.context.epochs[102]).toBe('processing');
 
-    // Wait for retry (33ms delay + some buffer)
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Resolve epoch 103 - query returns an epoch but it should NOT be spawned (at capacity)
+    await resolvePromiseAndAdvance(epoch103Promise, createMockEpoch(103));
 
-    // Assert - Should have been called at least 2 times (initial + retry)
-    expect(
-      vi.mocked(mockEpochController.getMinEpochToProcess).mock.calls.length,
-    ).toBeGreaterThanOrEqual(2);
+    // Should still have only 3 epochs (100, 101, 102) - epoch 103 was NOT spawned
+    snapshot = actor.getSnapshot();
+    expect(Object.keys(snapshot.context.epochs).length).toBe(3);
+    expect(snapshot.context.epochs[100]).toBe('processing');
+    expect(snapshot.context.epochs[101]).toBe('processing');
+    expect(snapshot.context.epochs[102]).toBe('processing');
+    expect(snapshot.context.epochs[103]).toBeUndefined();
 
-    // Verify state sequence includes expected states
-    const pollingCount = stateTransitions.filter((state) => state === 'pollingEpoch').length;
-    const idleCount = stateTransitions.filter((state) => state === 'idleNoEpoch').length;
-    expect(pollingCount).toBeGreaterThanOrEqual(1);
-    expect(idleCount).toBeGreaterThanOrEqual(1);
+    // Machine is blocked in spawningEpochs waiting for the blocking promise
+    expect(getNestedState(snapshot.value, 'orchestrating')).toBe('spawningEpochs');
 
-    // Clean up
-    subscription.unsubscribe();
     actor.stop();
+    subscription.unsubscribe();
   });
 
-  test('should handle null epoch data and transition to idleNoEpoch, then retry after delay', async () => {
+  test('should handle ordered release - only release consecutive completed epochs from lowest', async () => {
     // Arrange
-    const controllableGetMinEpochPromise = createControllablePromise<null>();
+    type EpochType = ReturnType<typeof createMockEpoch> | null;
+    const epoch100Promise = createControllablePromise<EpochType>();
+    const epoch101Promise = createControllablePromise<EpochType>();
+    const epoch102Promise = createControllablePromise<EpochType>();
+    const blockingPromise1 = createControllablePromise<EpochType>(); // Blocks at capacity
+    const epoch103Promise = createControllablePromise<EpochType>();
+    const blockingPromise2 = createControllablePromise<EpochType>(); // Blocks after new spawn
 
-    vi.mocked(mockEpochController.getMinEpochToProcess).mockImplementation(
-      () => controllableGetMinEpochPromise.promise,
+    vi.mocked(mockEpochController.getMinEpochToProcessExcluding)
+      .mockReturnValueOnce(epoch100Promise.promise)
+      .mockReturnValueOnce(epoch101Promise.promise)
+      .mockReturnValueOnce(epoch102Promise.promise)
+      .mockReturnValueOnce(blockingPromise1.promise) // Blocks when at capacity
+      .mockReturnValueOnce(epoch103Promise.promise) // After releasing 100
+      .mockReturnValue(blockingPromise2.promise); // Blocks after spawning 103
+
+    const { actor, subscription } = createAndStartActor(
+      epochOrchestratorMachine,
+      createOrchestratorInput(),
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stateTransitions: SnapshotFrom<any>[] = [];
-    const actor = createActor(epochOrchestratorMachine, {
-      input: {
-        slotDuration: 0.1, // 100ms for faster tests
-        slotsPerEpoch: SLOTS_PER_EPOCH,
-        lookbackSlot: 32,
-        epochController: mockEpochController,
-        partitionController: mockPartitionController,
-        beaconTime: mockBeaconTime,
-        slotController: mockSlotController,
-      },
-    });
+    // Spawn 3 epochs
+    await resolvePromiseAndAdvance(epoch100Promise, createMockEpoch(100));
+    await resolvePromiseAndAdvance(epoch101Promise, createMockEpoch(101));
+    await resolvePromiseAndAdvance(epoch102Promise, createMockEpoch(102));
 
-    const subscription = actor.subscribe((snapshot) => {
-      stateTransitions.push(snapshot.value);
-    });
+    // Should have 3 epochs processing, machine blocked on blockingPromise1
+    let snapshot = actor.getSnapshot();
+    expect(Object.keys(snapshot.context.epochs).length).toBe(3);
+    expect(snapshot.context.epochs[100]).toBe('processing');
+    expect(snapshot.context.epochs[101]).toBe('processing');
+    expect(snapshot.context.epochs[102]).toBe('processing');
 
-    // Act
-    actor.start();
+    // Complete epoch 102 (highest, not lowest) - global event handler updates context immediately
+    actor.send({ type: 'EPOCH_COMPLETED', epoch: 102, machineId: 'epochProcessor:102' });
 
-    // Assert - Should be in pollingEpoch state initially
-    expect(stateTransitions[0]).toBe('pollingEpoch');
-    expect(vi.mocked(mockEpochController.getMinEpochToProcess)).toHaveBeenCalledTimes(1);
+    // Epoch 102 should be marked as completed but NOT released yet (waiting for lowest)
+    snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[102]).toBe('completed');
+    expect(snapshot.context.epochs[100]).toBe('processing');
+    expect(snapshot.context.epochs[101]).toBe('processing');
+    expect(Object.keys(snapshot.context.epochs).length).toBe(3);
 
-    // Now resolve the promise with null to trigger the null handling
-    controllableGetMinEpochPromise.resolve(null);
+    // Complete epoch 100 (lowest) - this triggers release cycle
+    actor.send({ type: 'EPOCH_COMPLETED', epoch: 100, machineId: 'epochProcessor:100' });
 
-    // Wait for the state transition to complete
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Resolve blockingPromise1 to allow transition to pollingDelay then to releasing
+    await resolvePromiseAndAdvance(blockingPromise1, null);
 
-    // Assert - Should transition to idleNoEpoch after resolving with null
-    const stateAfterNull = stateTransitions[stateTransitions.length - 1];
-    expect(stateAfterNull).toBe('idleNoEpoch');
+    // After releasing epoch 100, machine should query for new epoch
+    await resolvePromiseAndAdvance(epoch103Promise, createMockEpoch(103));
 
-    // Wait for the 33ms delay to complete and retry
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Epoch 100 should be released, epoch 103 spawned
+    snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[100]).toBeUndefined(); // Released
+    expect(snapshot.context.epochs[101]).toBe('processing');
+    expect(snapshot.context.epochs[102]).toBe('completed'); // Still not released (waiting for 101)
+    expect(snapshot.context.epochs[103]).toBe('processing');
 
-    // Assert - Should have been called at least 2 times (initial + retry)
-    expect(
-      vi.mocked(mockEpochController.getMinEpochToProcess).mock.calls.length,
-    ).toBeGreaterThanOrEqual(2);
-
-    // Verify we went through the expected states at least the expected number of times
-    const pollingEpochCount = stateTransitions.filter((state) => state === 'pollingEpoch').length;
-    const idleNoEpochCount = stateTransitions.filter((state) => state === 'idleNoEpoch').length;
-
-    expect(pollingEpochCount).toBeGreaterThanOrEqual(2);
-    expect(idleNoEpochCount).toBeGreaterThanOrEqual(2);
-
-    // Clean up
-    subscription.unsubscribe();
     actor.stop();
+    subscription.unsubscribe();
   });
 
-  test('should complete full workflow: pollingEpoch -> processingEpoch -> EPOCH_COMPLETED -> pollingEpoch', async () => {
+  test('should handle global EPOCH_COMPLETED event from any state', async () => {
     // Arrange
-    const mockEpochData = {
-      epoch: 100,
-      processed: false,
-      validatorsBalancesFetched: false,
-      validatorsActivationFetched: false,
-      rewardsFetched: false,
-      validatorProposerDutiesFetched: false,
-      committeesFetched: false,
-      allSlotsProcessed: false,
-      syncCommitteesFetched: false,
-    };
+    type EpochType = ReturnType<typeof createMockEpoch> | null;
+    const epoch100Promise = createControllablePromise<EpochType>();
+    const blockingPromise1 = createControllablePromise<EpochType>();
+    const blockingPromise2 = createControllablePromise<EpochType>();
 
-    // Create a controllable promise for getMinEpochToProcess
-    const getMinEpochPromise = createControllablePromise<{
-      epoch: number;
-      processed: boolean;
-      validatorsBalancesFetched: boolean;
-      validatorsActivationFetched: boolean;
-      rewardsFetched: boolean;
-      validatorProposerDutiesFetched: boolean;
-      committeesFetched: boolean;
-      allSlotsProcessed: boolean;
-      syncCommitteesFetched: boolean;
-    } | null>();
+    vi.mocked(mockEpochController.getMinEpochToProcessExcluding)
+      .mockReturnValueOnce(epoch100Promise.promise)
+      .mockReturnValueOnce(blockingPromise1.promise) // Blocks after spawning 100
+      .mockReturnValue(blockingPromise2.promise); // Blocks after releasing 100
 
-    vi.mocked(mockEpochController.getMinEpochToProcess).mockImplementation(
-      () => getMinEpochPromise.promise,
+    const { actor, subscription } = createAndStartActor(
+      epochOrchestratorMachine,
+      createOrchestratorInput(),
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const stateTransitions: SnapshotFrom<any>[] = [];
-    const epochOrchestratorActor = createActor(epochOrchestratorMachine, {
-      input: {
-        slotDuration: 0.1, // 100ms for faster tests
-        slotsPerEpoch: SLOTS_PER_EPOCH,
-        lookbackSlot: 32,
-        epochController: mockEpochController,
-        partitionController: mockPartitionController,
-        beaconTime: mockBeaconTime,
-        slotController: mockSlotController,
-      },
-    });
+    // Spawn first epoch
+    await resolvePromiseAndAdvance(epoch100Promise, createMockEpoch(100));
 
-    const subscription = epochOrchestratorActor.subscribe((snapshot) => {
-      stateTransitions.push(snapshot.value);
-    });
+    // Should have one active epoch processing, machine blocked on blockingPromise1
+    let snapshot = actor.getSnapshot();
+    expect(Object.keys(snapshot.context.epochs).length).toBe(1);
+    expect(snapshot.context.epochs[100]).toBe('processing');
 
-    // Act
-    epochOrchestratorActor.start();
+    // Send EPOCH_COMPLETED while machine is blocked - global handler updates context immediately
+    actor.send({ type: 'EPOCH_COMPLETED', epoch: 100, machineId: 'epochProcessor:100' });
 
-    // Assert - Should be in pollingEpoch state initially
-    expect(stateTransitions[0]).toBe('pollingEpoch');
+    // Should have marked the epoch as completed immediately
+    snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[100]).toBe('completed');
 
-    // Now resolve the promise, providing the mock epoch data to continue the workflow
-    getMinEpochPromise.resolve(mockEpochData);
+    // Resolve blockingPromise1 to trigger pollingDelay -> releasingCompletedEpochs cycle
+    await resolvePromiseAndAdvance(blockingPromise1, null);
 
-    // Wait for the state transitions to complete (pollingEpoch -> processingEpoch)
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    // Should have released the epoch after transition to releasingCompletedEpochs
+    snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[100]).toBeUndefined();
 
-    // Assert - Should be in processingEpoch with epoch actor spawned
-    const stateAfterResolve = stateTransitions[stateTransitions.length - 1];
-    expect(stateAfterResolve).toBe('processingEpoch');
-
-    // Verify context from stored snapshot
-    const snapshotAtProcessing = epochOrchestratorActor.getSnapshot();
-    expect(snapshotAtProcessing.context.epochData).toEqual(mockEpochData);
-    expect(snapshotAtProcessing.context.epochActor).not.toBe(null);
-
-    // Update mock to return null for subsequent calls to prevent further processing
-    vi.mocked(mockEpochController.getMinEpochToProcess).mockResolvedValue(null);
-
-    // Send EPOCH_COMPLETED event directly to the orchestrator to simulate completion
-    epochOrchestratorActor.send({ type: 'EPOCH_COMPLETED', machineId: 'epochProcessor:100' });
-
-    // Wait for the epoch processor to complete and send EPOCH_COMPLETED event
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // Wait a bit more for any pending state transitions
-    await new Promise((resolve) => setTimeout(resolve, 5));
-
-    // Assert - Should be back to idleNoEpoch with cleaned context
-    const finalState = stateTransitions[stateTransitions.length - 1];
-    expect(finalState).toBe('idleNoEpoch');
-
-    // Verify cleanup using final snapshot
-    const finalSnapshot = epochOrchestratorActor.getSnapshot();
-    expect(finalSnapshot.context.epochData).toBe(null);
-    expect(finalSnapshot.context.epochActor).toBe(null);
-
-    // Note: markEpochAsProcessed is called by the epochProcessor, not the orchestrator
-    // The orchestrator just receives the EPOCH_COMPLETED event and cleans up
-
-    // Verify the state sequence
-    expect(stateTransitions.length).toBeGreaterThanOrEqual(3);
-    expect(stateTransitions[0]).toBe('pollingEpoch');
-    const processingIndex = stateTransitions.findIndex((state) => state === 'processingEpoch');
-    expect(processingIndex).toBeGreaterThan(0);
-    const idleIndex = stateTransitions.findIndex(
-      (state, idx) => state === 'idleNoEpoch' && idx > processingIndex,
-    );
-    expect(idleIndex).toBeGreaterThan(processingIndex);
-
-    // Clean up
+    actor.stop();
     subscription.unsubscribe();
-    epochOrchestratorActor.stop();
+  });
+
+  test('should release multiple consecutive completed epochs in order', async () => {
+    // Arrange
+    type EpochType = ReturnType<typeof createMockEpoch> | null;
+    const epoch100Promise = createControllablePromise<EpochType>();
+    const epoch101Promise = createControllablePromise<EpochType>();
+    const epoch102Promise = createControllablePromise<EpochType>();
+    const blockingPromise1 = createControllablePromise<EpochType>(); // Blocks at capacity
+    const blockingPromise2 = createControllablePromise<EpochType>(); // Blocks after release
+
+    vi.mocked(mockEpochController.getMinEpochToProcessExcluding)
+      .mockReturnValueOnce(epoch100Promise.promise)
+      .mockReturnValueOnce(epoch101Promise.promise)
+      .mockReturnValueOnce(epoch102Promise.promise)
+      .mockReturnValueOnce(blockingPromise1.promise) // Blocks when at capacity
+      .mockReturnValue(blockingPromise2.promise); // Blocks after release
+
+    const { actor, subscription } = createAndStartActor(
+      epochOrchestratorMachine,
+      createOrchestratorInput(),
+    );
+
+    // Spawn all 3 epochs
+    await resolvePromiseAndAdvance(epoch100Promise, createMockEpoch(100));
+    await resolvePromiseAndAdvance(epoch101Promise, createMockEpoch(101));
+    await resolvePromiseAndAdvance(epoch102Promise, createMockEpoch(102));
+
+    // Machine is now blocked on blockingPromise1 (at capacity)
+    let snapshot = actor.getSnapshot();
+    expect(Object.keys(snapshot.context.epochs).length).toBe(3);
+
+    // Complete all three epochs - global handler updates context immediately
+    actor.send({ type: 'EPOCH_COMPLETED', epoch: 100, machineId: 'epochProcessor:100' });
+    actor.send({ type: 'EPOCH_COMPLETED', epoch: 101, machineId: 'epochProcessor:101' });
+    actor.send({ type: 'EPOCH_COMPLETED', epoch: 102, machineId: 'epochProcessor:102' });
+
+    // All three should be marked as completed immediately
+    snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[100]).toBe('completed');
+    expect(snapshot.context.epochs[101]).toBe('completed');
+    expect(snapshot.context.epochs[102]).toBe('completed');
+
+    // Resolve blockingPromise1 to trigger polling -> releasingCompletedEpochs cycle
+    await resolvePromiseAndAdvance(blockingPromise1, null);
+
+    // All three should be released since they completed consecutively from the lowest
+    snapshot = actor.getSnapshot();
+    expect(snapshot.context.epochs[100]).toBeUndefined();
+    expect(snapshot.context.epochs[101]).toBeUndefined();
+    expect(snapshot.context.epochs[102]).toBeUndefined();
+    expect(Object.keys(snapshot.context.epochs).length).toBe(0);
+
+    actor.stop();
+    subscription.unsubscribe();
   });
 });

--- a/packages/indexer/src/xstate/epoch/epochOrchestrator.machine.ts
+++ b/packages/indexer/src/xstate/epoch/epochOrchestrator.machine.ts
@@ -1,51 +1,81 @@
-import { Epoch } from '@beacon-indexer/db';
-import { setup, assign, stopChild, ActorRefFrom, fromPromise } from 'xstate';
+import { setup, assign, stopChild, spawnChild, fromPromise, and } from 'xstate';
 
-import { epochProcessorMachine } from './epochProcessor.machine.js';
+import { epochWorkerMachine } from './epochWorker.machine.js';
 
-import type { CustomLogger } from '@/src/lib/pino.js';
 import { EpochController } from '@/src/services/consensus/controllers/epoch.js';
 import { PartitionController } from '@/src/services/consensus/controllers/partition.js';
 import { SlotController } from '@/src/services/consensus/controllers/slot.js';
 import { ValidatorsController } from '@/src/services/consensus/controllers/validators.js';
 import { BeaconTime } from '@/src/services/consensus/utils/beaconTime.js';
-import { logActor } from '@/src/xstate/multiMachineLogger.js';
 import { pinoLog } from '@/src/xstate/pinoLog.js';
 
 /**
- * @fileoverview The epoch orchestrator is a state machine that is responsible for orchestrating the processing of epochs.
+ * @fileoverview The epoch orchestrator manager is responsible for scheduling and managing parallel epoch processing.
  *
  * It is responsible for:
- * - Polling for the minimum unprocessed epoch
- * - Spawning the epoch processor machine when epoch data is available
- * - Monitoring epoch completion
+ * - Managing capacity (up to N epochs in parallel)
+ * - Polling for unprocessed epochs (excluding active ones)
+ * - Spawning worker machines for each epoch
+ * - Monitoring epoch completion and refilling capacity in order
  *
- * This machine processes one epoch at a time.
+ * This machine processes multiple epochs in parallel with polling-based status checking:
+ * - Polls periodically to check epoch status and capacity
+ * - Event handler only marks epochs as completed (doesn't trigger transitions)
+ * - Explicit states for orchestrating with internal states for releasing, spawning, and polling
  *
  * States:
- * - pollingEpoch: Invokes getMinEpochToProcess and transitions based on result
- * - processingEpoch: Spawns epoch processor actor and handles completion
- * - idleNoEpoch: Waits when no epoch is available before polling again
+ * - orchestrating: Main state with internal states:
+ *   - releasingCompletedEpochs: Removes completed epochs from active list
+ *   - spawningEpochs: Queries and spawns new epoch workers (loops to itself if more capacity)
+ *   - pollingDelay: Waits before checking again
  */
 
-// TODO: make this machine to process N epochs at a time.
+// Maximum number of epochs to process in parallel
+const MAX_PARALLEL_EPOCHS = 3;
+
+type EpochStatus = 'processing' | 'completed';
+
+// Helper function to get consecutive completed epochs from the lowest
+const getEpochsToRelease = (epochs: Record<number, EpochStatus>): number[] => {
+  const activeEpochs = Object.keys(epochs)
+    .map((e) => parseInt(e))
+    .sort((a, b) => a - b);
+
+  if (activeEpochs.length === 0) return [];
+
+  const epochsToRelease: number[] = [];
+  for (const epoch of activeEpochs) {
+    if (epochs[epoch] === 'completed') {
+      epochsToRelease.push(epoch);
+    } else {
+      break; // Stop at first non-completed epoch (ordered release)
+    }
+  }
+
+  return epochsToRelease;
+};
 
 export const epochOrchestratorMachine = setup({
   types: {} as {
     context: {
-      epochData: Epoch | null;
-      epochActor: ActorRefFrom<typeof epochProcessorMachine> | null;
-      logger?: CustomLogger;
-      slotDuration: number;
-      slotsPerEpoch: number;
-      lookbackSlot: number;
-      epochController: EpochController;
-      partitionController: PartitionController;
-      beaconTime: BeaconTime;
-      validatorsController?: ValidatorsController;
-      slotController: SlotController;
+      // Active epochs tracking with status
+      epochs: Record<number, EpochStatus>;
+      // Config
+      config: {
+        slotDuration: number;
+        slotsPerEpoch: number;
+        lookbackSlot: number;
+      };
+      // Services
+      services: {
+        epochController: EpochController;
+        partitionController: PartitionController;
+        beaconTime: BeaconTime;
+        validatorsController?: ValidatorsController;
+        slotController: SlotController;
+      };
     };
-    events: { type: 'EPOCH_COMPLETED'; machineId: string };
+    events: { type: 'EPOCH_COMPLETED'; epoch: number; machineId: string };
     input: {
       slotDuration: number;
       slotsPerEpoch: number;
@@ -58,165 +88,170 @@ export const epochOrchestratorMachine = setup({
     };
   },
   actors: {
-    getMinEpochToProcess: fromPromise(
-      async ({ input }: { input: { epochController: EpochController } }) => {
-        return input.epochController.getMinEpochToProcess();
+    getMinEpochToProcessExcluding: fromPromise(
+      async ({
+        input,
+      }: {
+        input: { epochController: EpochController; activeEpochs: number[] };
+      }) => {
+        return input.epochController.getMinEpochToProcessExcluding(input.activeEpochs);
       },
     ),
-    createPartitionsForTables: fromPromise(
-      async ({ input }: { input: { partitionController: PartitionController; epoch: number } }) => {
-        await input.partitionController.createPartitionsToProcessEpoch(input.epoch);
-      },
-    ),
-    epochProcessorMachine,
+    epochWorkerMachine,
   },
   guards: {
-    hasEpochData: ({ context }) => {
-      return context.epochData !== null;
+    hasEpochFound: ({ event }) => {
+      return 'output' in event && event.output !== null;
+    },
+    hasCapacity: ({ context }) => {
+      return Object.keys(context.epochs).length < MAX_PARALLEL_EPOCHS;
     },
   },
   delays: {
-    slotDuration: ({ context }) => context.slotDuration,
-    noMinEpochDelay: ({ context }) => context.slotDuration / 3,
+    pollingDelay: ({ context }) => context.config.slotDuration / 2,
   },
 }).createMachine({
   id: 'EpochOrchestrator',
-  initial: 'pollingEpoch',
+  initial: 'orchestrating',
   context: ({ input }) => ({
-    epochData: null,
-    epochActor: null,
-    slotDuration: input.slotDuration,
-    slotsPerEpoch: input.slotsPerEpoch,
-    lookbackSlot: input.lookbackSlot,
-    epochController: input.epochController,
-    partitionController: input.partitionController,
-    beaconTime: input.beaconTime,
-    validatorsController: input.validatorsController,
-    slotController: input.slotController,
+    epochs: {},
+    config: {
+      slotDuration: input.slotDuration,
+      slotsPerEpoch: input.slotsPerEpoch,
+      lookbackSlot: input.lookbackSlot,
+    },
+    services: {
+      epochController: input.epochController,
+      partitionController: input.partitionController,
+      beaconTime: input.beaconTime,
+      validatorsController: input.validatorsController,
+      slotController: input.slotController,
+    },
   }),
   states: {
-    pollingEpoch: {
-      invoke: {
-        src: 'getMinEpochToProcess',
-        input: ({ context }) => ({ epochController: context.epochController }),
-        onDone: [
-          {
-            guard: ({ event }) => event.output !== null,
-            target: 'creatingPartitionsForTables',
-            actions: [
-              assign({
-                epochData: ({ event }) => event.output,
-              }),
-              pinoLog(
-                ({ event }) => `Found epoch ${event.output?.epoch} to process`,
-                'EpochOrchestrator',
-              ),
-            ],
-          },
-          {
-            target: 'idleNoEpoch',
-            actions: pinoLog('No epoch to process, entering idle state', 'EpochOrchestrator'),
-          },
-        ],
-        onError: {
-          target: 'idleNoEpoch',
-          actions: pinoLog(
-            ({ event }) => `Error getting min epoch to process: ${event.error}`,
-            'EpochOrchestrator',
-            'error',
-          ),
-        },
-      },
-    },
-    creatingPartitionsForTables: {
-      entry: pinoLog(
-        ({ context }) =>
-          `Ensuring tables partitions for epoch ${context.epochData?.epoch} exist before processing`,
-        'EpochOrchestrator',
-      ),
-      invoke: {
-        src: 'createPartitionsForTables',
-        input: ({ context }) => ({
-          partitionController: context.partitionController,
-          epoch: context.epochData!.epoch,
-        }),
-        onDone: {
-          target: 'processingEpoch',
-          actions: pinoLog(
-            ({ context }) => `Partitions ensured for epoch ${context.epochData?.epoch}`,
-            'EpochOrchestrator',
-          ),
-        },
-        onError: {
-          target: 'idleNoEpoch',
-          actions: pinoLog(
-            ({ context, event }) =>
-              `Error ensuring partitions for epoch ${context.epochData?.epoch}: ${event.error}`,
-            'EpochOrchestrator',
-            'error',
-          ),
-        },
-      },
-    },
-    processingEpoch: {
-      entry: [
-        assign({
-          epochActor: ({ context, spawn }) => {
-            if (!context.epochData) return null;
-
-            const { epoch } = context.epochData;
-            const epochId = `epochProcessor:${epoch}`;
-
-            const actor = spawn('epochProcessorMachine', {
-              id: epochId,
-              input: {
-                epoch,
-                config: {
-                  slotDuration: context.slotDuration,
-                  slotsPerEpoch: context.slotsPerEpoch,
-                  lookbackSlot: context.lookbackSlot,
-                },
-                services: {
-                  beaconTime: context.beaconTime,
-                  epochController: context.epochController,
-                  validatorsController: context.validatorsController,
-                  slotController: context.slotController,
-                },
-              },
-            });
-
-            logActor(actor, epochId);
-
-            return actor;
-          },
-        }),
-        pinoLog(
-          ({ context }) => `Processing epoch ${context.epochData?.epoch}`,
-          'EpochOrchestrator',
-        ),
-      ],
-      on: {
-        EPOCH_COMPLETED: {
-          target: 'pollingEpoch',
-          actions: [
-            pinoLog(
-              ({ event }) => `Epoch processing completed for ${event.machineId}`,
-              'EpochOrchestrator',
-            ),
-            stopChild(({ event }) => event.machineId),
+    orchestrating: {
+      initial: 'spawningEpochs',
+      states: {
+        releasingCompletedEpochs: {
+          entry: [
+            pinoLog(({ context }) => {
+              const epochsToRelease = getEpochsToRelease(context.epochs);
+              if (epochsToRelease.length) {
+                return `Releasing epochs: [${epochsToRelease.join(', ')}]`;
+              }
+            }, 'EpochOrchestrator'),
             assign({
-              epochData: null,
-              epochActor: null,
+              epochs: ({ context }) => {
+                const epochsToRelease = getEpochsToRelease(context.epochs);
+
+                if (epochsToRelease.length === 0) return context.epochs;
+
+                const updatedEpochs = { ...context.epochs };
+                epochsToRelease.forEach((epoch) => {
+                  delete updatedEpochs[epoch];
+                });
+
+                return updatedEpochs;
+              },
             }),
           ],
+          after: {
+            0: { target: 'spawningEpochs' },
+          },
+        },
+        spawningEpochs: {
+          invoke: {
+            src: 'getMinEpochToProcessExcluding',
+            input: ({ context }) => {
+              const activeEpochs = Object.keys(context.epochs)
+                .map((e) => parseInt(e))
+                .sort((a, b) => a - b);
+              return {
+                epochController: context.services.epochController,
+                activeEpochs,
+              };
+            },
+            onDone: [
+              {
+                guard: and(['hasEpochFound', 'hasCapacity']),
+                target: 'pollingDelay',
+                actions: [
+                  spawnChild('epochWorkerMachine', {
+                    id: ({ event }) => {
+                      const epoch = (event as unknown as { output: { epoch: number } }).output
+                        .epoch;
+                      return `epochWorker:${epoch}`;
+                    },
+                    input: ({ context, event }) => {
+                      const epoch = (event as unknown as { output: { epoch: number } }).output
+                        .epoch;
+                      return {
+                        epoch,
+                        slotDuration: context.config.slotDuration,
+                        slotsPerEpoch: context.config.slotsPerEpoch,
+                        lookbackSlot: context.config.lookbackSlot,
+                        epochController: context.services.epochController,
+                        partitionController: context.services.partitionController,
+                        beaconTime: context.services.beaconTime,
+                        validatorsController: context.services.validatorsController,
+                        slotController: context.services.slotController,
+                      };
+                    },
+                  }),
+                  assign({
+                    epochs: ({ context, event }) => ({
+                      ...context.epochs,
+                      [event.output!.epoch]: 'processing' as EpochStatus,
+                    }),
+                  }),
+                  pinoLog(
+                    ({ event }) => `Spawned worker for epoch ${event.output!.epoch}`,
+                    'EpochOrchestrator',
+                  ),
+                ],
+              },
+              {
+                target: 'pollingDelay',
+              },
+            ],
+            onError: {
+              target: 'pollingDelay',
+              actions: pinoLog(
+                ({ event }) => `Error getting min epoch to process: ${event.error}`,
+                'EpochOrchestrator',
+                'error',
+              ),
+            },
+          },
+        },
+        pollingDelay: {
+          after: {
+            pollingDelay: 'releasingCompletedEpochs',
+          },
         },
       },
     },
-    idleNoEpoch: {
-      entry: pinoLog('No epoch available, waiting before next poll', 'EpochOrchestrator'),
-      after: {
-        noMinEpochDelay: 'pollingEpoch',
-      },
+  },
+  on: {
+    // Handle epoch completion from any state (global event handler)
+    // Marks epoch as completed and stops the worker
+    EPOCH_COMPLETED: {
+      actions: [
+        pinoLog(({ event }) => `Epoch ${event.epoch} completed`, 'EpochOrchestrator'),
+        stopChild(({ event }) => `epochWorker:${event.epoch}`),
+        assign({
+          epochs: ({ context, event }) => {
+            // Mark epoch as completed if it exists and is processing
+            if (context.epochs[event.epoch] === 'processing') {
+              return {
+                ...context.epochs,
+                [event.epoch]: 'completed' as EpochStatus,
+              };
+            }
+            return context.epochs;
+          },
+        }),
+      ],
     },
   },
 });

--- a/packages/indexer/src/xstate/epoch/epochWorker.machine.ts
+++ b/packages/indexer/src/xstate/epoch/epochWorker.machine.ts
@@ -1,0 +1,167 @@
+import { setup, assign, sendParent, ActorRefFrom, fromPromise } from 'xstate';
+
+import { epochProcessorMachine } from './epochProcessor.machine.js';
+
+import { EpochController } from '@/src/services/consensus/controllers/epoch.js';
+import { PartitionController } from '@/src/services/consensus/controllers/partition.js';
+import { SlotController } from '@/src/services/consensus/controllers/slot.js';
+import { ValidatorsController } from '@/src/services/consensus/controllers/validators.js';
+import { BeaconTime } from '@/src/services/consensus/utils/beaconTime.js';
+import { logActor } from '@/src/xstate/multiMachineLogger.js';
+import { pinoLog } from '@/src/xstate/pinoLog.js';
+
+/**
+ * @fileoverview The epoch worker is a state machine responsible for processing a single epoch.
+ *
+ * It handles:
+ * - Creating table partitions for the epoch
+ * - Spawning the epoch processor machine
+ * - Forwarding completion events to the parent manager
+ *
+ * This machine is spawned by the epoch orchestrator manager for each epoch to process.
+ */
+
+export const epochWorkerMachine = setup({
+  types: {} as {
+    context: {
+      epoch: number;
+      epochActor: ActorRefFrom<typeof epochProcessorMachine> | null;
+      slotDuration: number;
+      slotsPerEpoch: number;
+      lookbackSlot: number;
+      epochController: EpochController;
+      partitionController: PartitionController;
+      beaconTime: BeaconTime;
+      validatorsController?: ValidatorsController;
+      slotController: SlotController;
+    };
+    events: { type: 'EPOCH_COMPLETED'; machineId: string };
+    input: {
+      epoch: number;
+      slotDuration: number;
+      slotsPerEpoch: number;
+      lookbackSlot: number;
+      epochController: EpochController;
+      partitionController: PartitionController;
+      beaconTime: BeaconTime;
+      validatorsController?: ValidatorsController;
+      slotController: SlotController;
+    };
+  },
+  actors: {
+    createPartitionsForTables: fromPromise(
+      async ({ input }: { input: { partitionController: PartitionController; epoch: number } }) => {
+        await input.partitionController.createPartitionsToProcessEpoch(input.epoch);
+      },
+    ),
+    epochProcessorMachine,
+  },
+  delays: {},
+}).createMachine({
+  id: 'EpochWorker',
+  initial: 'creatingPartitions',
+  context: ({ input }) => ({
+    epoch: input.epoch,
+    epochActor: null,
+    slotDuration: input.slotDuration,
+    slotsPerEpoch: input.slotsPerEpoch,
+    lookbackSlot: input.lookbackSlot,
+    epochController: input.epochController,
+    partitionController: input.partitionController,
+    beaconTime: input.beaconTime,
+    validatorsController: input.validatorsController,
+    slotController: input.slotController,
+  }),
+  states: {
+    creatingPartitions: {
+      entry: pinoLog(
+        ({ context }) =>
+          `Ensuring tables partitions for epoch ${context.epoch} exist before processing`,
+        'EpochWorker',
+      ),
+      invoke: {
+        src: 'createPartitionsForTables',
+        input: ({ context }) => ({
+          partitionController: context.partitionController,
+          epoch: context.epoch,
+        }),
+        onDone: {
+          target: 'runningProcessor',
+          actions: pinoLog(
+            ({ context }) => `Partitions ensured for epoch ${context.epoch}`,
+            'EpochWorker',
+          ),
+        },
+        onError: {
+          target: 'failed',
+          actions: pinoLog(
+            ({ context, event }) =>
+              `Error ensuring partitions for epoch ${context.epoch}: ${event.error}`,
+            'EpochWorker',
+            'error',
+          ),
+        },
+      },
+    },
+    runningProcessor: {
+      entry: [
+        assign({
+          epochActor: ({ context, spawn }) => {
+            const epochId = `epochProcessor:${context.epoch}`;
+
+            const actor = spawn('epochProcessorMachine', {
+              id: epochId,
+              input: {
+                epoch: context.epoch,
+                config: {
+                  slotDuration: context.slotDuration,
+                  slotsPerEpoch: context.slotsPerEpoch,
+                  lookbackSlot: context.lookbackSlot,
+                },
+                services: {
+                  beaconTime: context.beaconTime,
+                  epochController: context.epochController,
+                  validatorsController: context.validatorsController,
+                  slotController: context.slotController,
+                },
+              },
+            });
+
+            logActor(actor, epochId);
+
+            return actor;
+          },
+        }),
+        pinoLog(({ context }) => `Processing epoch ${context.epoch}`, 'EpochWorker'),
+      ],
+    },
+    completed: {
+      type: 'final',
+    },
+    failed: {
+      type: 'final',
+      entry: pinoLog(
+        ({ context }) => `Worker for epoch ${context.epoch} failed and will be retried later`,
+        'EpochWorker',
+        'error',
+      ),
+    },
+  },
+  on: {
+    // Listen for completion from epochProcessorMachine and forward to parent manager
+    EPOCH_COMPLETED: {
+      target: '.completed',
+      actions: [
+        assign({
+          epochActor: null,
+        }),
+        pinoLog(({ context }) => `Epoch ${context.epoch} processing completed`, 'EpochWorker'),
+        sendParent(({ context, event }) => ({
+          type: 'EPOCH_COMPLETED',
+          epoch: context.epoch,
+          machineId: event.machineId,
+        })),
+      ],
+    },
+  },
+});

--- a/packages/indexer/src/xstate/epoch/index.ts
+++ b/packages/indexer/src/xstate/epoch/index.ts
@@ -54,19 +54,16 @@ export const getEpochOrchestratorActor = (
   actor.subscribe((snapshot) => {
     const { context } = snapshot;
 
-    // Get information about the current epoch actor if it exists
-    const epochActorInfo = context.epochActor
-      ? {
-          state: context.epochActor.getSnapshot().value,
-          epochData: context.epochData,
-        }
-      : null;
+    // Get information about active epochs
+    const activeEpochs = Object.keys(context.epochs)
+      .map((e) => parseInt(e))
+      .sort((a, b) => a - b);
 
     logMachine('epochOrchestrator', `State: ${JSON.stringify(snapshot.value)}`, {
-      // Current epoch being processed
-      currentEpoch: context.epochData?.epoch || null,
-      // Active epoch processor if any
-      spawnedEpochProcessor: epochActorInfo,
+      // Active epochs being processed
+      activeEpochs,
+      // Epochs status map
+      epochsStatus: context.epochs,
     });
   });
 

--- a/packages/indexer/src/xstate/pinoLog.ts
+++ b/packages/indexer/src/xstate/pinoLog.ts
@@ -3,7 +3,7 @@ import type { ActionArgs, EventObject, MachineContext, ParameterizedObject } fro
 import createLogger from '@/src/lib/pino.js';
 import { cleanContextForLogging } from '@/src/xstate/multiMachineLogger.js';
 
-// Define the log expression type that returns either string or log data object
+// Define the log expression type that returns either string, log data object, or undefined (skip logging)
 type PinoLogExpr<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
@@ -12,7 +12,7 @@ type PinoLogExpr<
 > = (
   args: ActionArgs<TContext, TExpressionEvent, TEvent>,
   params: TParams,
-) => string | { message: string; data?: unknown };
+) => string | { message: string; data?: unknown } | undefined;
 
 // Define the action interface matching XState's LogAction
 export interface PinoLogAction<
@@ -70,9 +70,12 @@ export const pinoLog = <
       message = value;
       data = undefined;
     } else if (typeof value === 'function') {
-      // Function that returns either string or log data object
+      // Function that returns either string, log data object, or undefined (skip logging)
       const result = value(args, params);
-      if (typeof result === 'string') {
+      if (result === undefined) {
+        // Skip logging if function returns undefined
+        return;
+      } else if (typeof result === 'string') {
         message = result;
         // Don't include context/event by default for function-based logs
         data = undefined;


### PR DESCRIPTION
…active epochs

- Added `getMinEpochToProcessExcluding` method in EpochController and EpochStorage to retrieve the next unprocessed epoch while excluding currently active epochs, facilitating parallel processing.
- Introduced `epochWorkerMachine` to handle individual epoch processing, including partition creation and spawning the epoch processor.
- Updated `epochOrchestratorMachine` to manage multiple epochs in parallel, ensuring capacity limits and ordered release of completed epochs.
- Enhanced logging for better observability during epoch processing and state transitions.
- Updated tests to cover new functionality and ensure correct behavior of the epoch orchestration and processing logic.