### PR TITLE
fix(ci): build API package before type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Build db package
         run: pnpm --filter @beacon-indexer/db run build
 
+      - name: Build api package
+        run: pnpm --filter @beacon-indexer/api run build
+
       - name: Type check
         run: pnpm run type-check
 


### PR DESCRIPTION
## Summary

- Add API package build step before type-check in CI workflow
- The app package imports types from `@beacon-indexer/api/routers` which requires the API `dist` folder to exist

## Root Cause

The CI workflow was running type-check before building the API package. The app depends on types exported from `@beacon-indexer/api/routers`, which are only available after the API is built (`dist/routers/index.d.ts`).

## Test plan

- [ ] CI type-check should pass after this fix

Closes #93

🤖 Generated with [Claude Code](https://claude.ai/code)