### PR TITLE
feat(db): add Cluster and ClusterValidator tables

### DIFF
--- a/packages/db/prisma/migrations/20251210144216_initial/migration.sql
+++ b/packages/db/prisma/migrations/20251210144216_initial/migration.sql
@@ -1,6 +1,9 @@
 -- CreateEnum
 CREATE TYPE "public"."ValidatorExitEvent" AS ENUM ('voluntary', 'slashed');
 
+-- CreateEnum
+CREATE TYPE "public"."ClusterVisibility" AS ENUM ('private', 'shared');
+
 -- CreateTable
 CREATE TABLE "public"."validator" (
     "id" INTEGER NOT NULL,
@@ -250,7 +253,7 @@ CREATE TABLE "public"."cluster" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "owner_id" BIGINT NOT NULL,
-    "visibility" TEXT NOT NULL DEFAULT 'private',
+    "visibility" "public"."ClusterVisibility" NOT NULL DEFAULT 'private',
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "cluster_pkey" PRIMARY KEY ("id")

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -168,6 +168,11 @@ enum ValidatorExitEvent {
     slashed
 }
 
+enum ClusterVisibility {
+    private
+    shared
+}
+
 model validatorExits {
     index Int                @id @map("index")
     epoch Int                @map("epoch")
@@ -343,13 +348,13 @@ model FeeRewardAddress {
 }
 
 model Cluster {
-    id         String   @id @default(cuid())
+    id         String            @id @default(cuid())
     name       String
-    ownerId    BigInt   @map("owner_id")
-    visibility String   @default("private") // 'private' | 'shared'
-    createdAt  DateTime @default(now()) @map("created_at")
+    ownerId    BigInt            @map("owner_id")
+    visibility ClusterVisibility @default(private)
+    createdAt  DateTime          @default(now()) @map("created_at")
 
-    owner      User               @relation(fields: [ownerId], references: [id])
+    owner      User               @relation(fields: [ownerId], references: [id], onDelete: Restrict)
     validators ClusterValidator[]
 
     @@map("cluster")

--- a/packages/indexer/src/services/consensus/storage/summary.ts
+++ b/packages/indexer/src/services/consensus/storage/summary.ts
@@ -48,8 +48,7 @@ export class SummaryStorage {
       WITH
         user_validators AS (
           SELECT DISTINCT cv.validator_index
-          FROM cluster c
-          JOIN cluster_validator cv ON cv.cluster_id = c.id
+          FROM cluster_validator cv
           JOIN validator v ON v.id = cv.validator_index
           WHERE v.status IN (2, 3)
         ),


### PR DESCRIPTION
## Summary

- Add `Cluster` model with name, owner, visibility ('private'/'shared'), and timestamps
- Add `ClusterValidator` join table for cluster-validator many-to-many relationship  
- Remove `UserToValidator` model and update User/Validator relations
- Update initial migration SQL with new table definitions and foreign keys
- Update indexer summary query to use new cluster tables

Closes #60

## Test plan

- [x] `pnpm prisma:generate` completes without errors
- [x] `pnpm type-check` passes in all packages
- [ ] `pnpm db:danger:reset` creates tables correctly
- [ ] Verify `cluster` and `cluster_validator` tables exist with correct schema
- [ ] Verify FK constraints work (cluster.owner_id -> user.id, etc.)
- [ ] Verify `_user_to_validator` table no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)