### PR TITLE
refactor(indexer): remove dead code updateValidatorStatuses

### DIFF
--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -389,28 +389,6 @@ export class SlotController extends SlotControllerHelpers {
   }
 
   /**
-   * Update validator statuses
-   */
-  async updateValidatorStatuses(input: {
-    slot: number;
-    epoch: number;
-    beaconBlockData?: Block; // TODO: fix this
-  }) {
-    // Simulate some processing time
-    await new Promise((resolve) => setTimeout(resolve, 90));
-
-    return {
-      slot: input.slot,
-      validatorUpdates: [
-        {
-          validatorIndex: Math.floor(Math.random() * 1000),
-          status: 'active',
-        },
-      ],
-    };
-  }
-
-  /**
    * Cleanup old committee data
    */
   async cleanupOldCommittees(slot: number, slotsPerEpoch: number, maxAttestationDelay: number) {


### PR DESCRIPTION
## Summary

- Remove the dead `updateValidatorStatuses` method from `SlotController` (closes #116)
- This method was a stub returning mock data with `Math.random()` and `setTimeout`, and was never called anywhere in the codebase
- Its functionality has been replaced by `ValidatorsController.trackTransitioningValidators()` which is properly wired into the state machine

## Why this is safe

- Grep across the entire codebase confirms `updateValidatorStatuses` is not referenced anywhere outside its own definition
- TypeScript type-check passes for the `packages/indexer` package after removal
- The `Block` import is retained as it is used by other methods in the same file (`processEpWithdrawals`, `processDeposits`, `processVoluntaryExits`, etc.)

## Test plan

- [x] Verified no references to `updateValidatorStatuses` exist in the codebase via grep
- [x] Verified `pnpm type-check` passes for `packages/indexer`
- [x] Verified ESLint passes on the modified file

🤖 Generated with [Claude Code](https://claude.com/claude-code)