### PR TITLE
Add telegram bot rate limit

### DIFF
--- a/packages/telegram-bot/.env.example
+++ b/packages/telegram-bot/.env.example
@@ -3,6 +3,7 @@ BOT_TOKEN=
 
 # Bot runtime mode.
 BOT_MODE=polling # | webhook
+BOT_RATE_LIMIT_PER_SECOND=30
 # These values only matter when BOT_MODE=webhook.
 SERVER_HOST=0.0.0.0
 SERVER_PORT=3001

--- a/packages/telegram-bot/package.json
+++ b/packages/telegram-bot/package.json
@@ -42,6 +42,7 @@
     "iso-639-1": "3.1.5",
     "pino": "9.9.0",
     "pino-pretty": "13.0.0",
+    "rate-limiter-flexible": "^11.0.1",
     "toad-scheduler": "^3.0.1",
     "tsx": "4.20.4",
     "valibot": "0.42.1",

--- a/packages/telegram-bot/src/bot/handlers/communications/send.ts
+++ b/packages/telegram-bot/src/bot/handlers/communications/send.ts
@@ -5,7 +5,7 @@ import { countBatchDeliveryResults, splitRecipientsIntoBatches } from './send-ba
 
 import { COMMON_REQUESTS_TELEGRAM_ID, getRpcClientForUser } from '@/src/api/client.js';
 import type { Context } from '@/src/bot/context.js';
-import { sendNotificationMessage } from '@/src/telegram/messaging.js';
+import { sendMessage } from '@/src/telegram/messaging.js';
 
 /**
  * Parses the communication id from the /send_communication command text.
@@ -59,18 +59,21 @@ export async function sendCommunicationHandler(ctx: CommandContext<Context>) {
   // Send each batch concurrently while keeping the overall broadcast flow easy to follow.
   for (const recipientBatch of splitRecipientsIntoBatches(communication.recipients, 10)) {
     const deliveryResults = await Promise.allSettled(
-      recipientBatch.map((telegramId) =>
-        sendNotificationMessage(
-          ctx.api,
-          Number(telegramId),
+      recipientBatch.map(async (telegramId) => {
+        const messageId = await sendMessage({
+          api: ctx.api,
+          chatId: Number(telegramId),
           telegramId,
-          communication.message,
-          ctx.logger,
-          {
+          text: communication.message,
+          logger: ctx.logger,
+          options: {
+            link_preview_options: { is_disabled: true },
             reply_markup: dismissKeyboard,
           },
-        ),
-      ),
+        });
+
+        return messageId !== null;
+      }),
     );
 
     // Count each settled result so rejected sends still produce a partial batch outcome.

--- a/packages/telegram-bot/src/bot/middlewares/user.ts
+++ b/packages/telegram-bot/src/bot/middlewares/user.ts
@@ -1,27 +1,18 @@
 import { Composer } from 'grammy';
 
-import { getRpcClientForUser } from '@/src/api/client.js';
 import type { Context } from '@/src/bot/context.js';
-import { blockedUserIds } from '@/src/telegram/messaging.js';
+import { handleUnblockedUser } from '@/src/telegram/blocked-users.js';
 
 /**
- * Middleware that detects previously-blocked users who re-engage with the bot.
- * When a user whose telegramId is in the blockedUserIds set sends any message,
- * this middleware calls the API to mark them as unblocked and removes them from the set.
+ * Any incoming update from a user means Telegram allows bot delivery again.
  */
 export const userMiddleware = new Composer<Context>();
 
 userMiddleware.use(async (ctx, next) => {
   const telegramId = ctx.from?.id?.toString();
-  if (telegramId && blockedUserIds.has(telegramId)) {
-    ctx.logger.info({ telegramId }, 'Previously blocked user re-engaged, unblocking');
-    blockedUserIds.delete(telegramId);
-    try {
-      const rpcClient = getRpcClientForUser(telegramId);
-      await rpcClient.bot.setUnblocked({ telegramId });
-    } catch (err) {
-      ctx.logger.error({ err, telegramId }, 'Failed to unblock user via API');
-    }
+  if (telegramId) {
+    await handleUnblockedUser(telegramId, ctx.logger);
   }
+
   await next();
 });

--- a/packages/telegram-bot/src/config.ts
+++ b/packages/telegram-bot/src/config.ts
@@ -6,6 +6,7 @@ interface BaseConfig {
   botToken: string;
   botAllowedUpdates: readonly AllowedUpdateType[];
   botAdmins: number[];
+  botRateLimitPerSecond: number;
   isDebug: boolean;
   logLevel: string;
 }
@@ -34,6 +35,7 @@ function createConfigFromEnv(): Config {
     botToken: env.BOT_TOKEN as string,
     botAllowedUpdates: env.BOT_ALLOWED_UPDATES,
     botAdmins: env.BOT_ADMINS as number[],
+    botRateLimitPerSecond: env.BOT_RATE_LIMIT_PER_SECOND as number,
     isDebug: env.DEBUG as boolean,
     logLevel: env.LOG_LEVEL as string,
   };

--- a/packages/telegram-bot/src/env.ts
+++ b/packages/telegram-bot/src/env.ts
@@ -67,6 +67,7 @@ export const env = createEnv({
       .string()
       .default('[]')
       .transform((val) => JSON.parse(val) as number[]),
+    BOT_RATE_LIMIT_PER_SECOND: z.coerce.number().int().positive().default(30),
 
     // Webhook Configuration (only used when BOT_MODE=webhook)
     BOT_WEBHOOK: z.string().url().optional(),

--- a/packages/telegram-bot/src/scheduler/notify-user-stats.ts
+++ b/packages/telegram-bot/src/scheduler/notify-user-stats.ts
@@ -3,7 +3,7 @@ import type { Api, RawApi } from 'grammy';
 import { getRpcClientForUser } from '@/src/api/client.js';
 import type { Logger } from '@/src/logger.js';
 import { formatStatsMessage } from '@/src/telegram/format-stats.js';
-import { editDashboardMessage, sendDashboardMessage } from '@/src/telegram/messaging.js';
+import { editMessage, sendMessage } from '@/src/telegram/messaging.js';
 
 interface BotUser {
   id: string;
@@ -66,14 +66,18 @@ export async function notifyUserStats(
 
   // Try to edit existing message first
   if (existingMessageId) {
-    const edited = await editDashboardMessage(
+    const edited = await editMessage({
       api,
       chatId,
-      existingMessageId,
-      user.telegramId,
-      message,
-      userLogger,
-    );
+      messageId: existingMessageId,
+      telegramId: user.telegramId,
+      text: message,
+      logger: userLogger,
+      options: {
+        parse_mode: 'MarkdownV2',
+        link_preview_options: { is_disabled: true },
+      },
+    });
     if (edited) {
       userLogger.debug('Message edited successfully');
       return; // Message updated in place, messageId unchanged
@@ -83,13 +87,18 @@ export async function notifyUserStats(
   }
 
   // Send new message
-  const newMessageId = await sendDashboardMessage(
+  const newMessageId = await sendMessage({
     api,
     chatId,
-    user.telegramId,
-    message,
-    userLogger,
-  );
+    telegramId: user.telegramId,
+    text: message,
+    logger: userLogger,
+    options: {
+      parse_mode: 'MarkdownV2',
+      link_preview_options: { is_disabled: true },
+      disable_notification: true,
+    },
+  });
   userLogger.debug({ newMessageId }, 'New message sent');
 
   // Update messageId if we got a new one

--- a/packages/telegram-bot/src/scheduler/process-notifications.ts
+++ b/packages/telegram-bot/src/scheduler/process-notifications.ts
@@ -3,7 +3,7 @@ import type { Api, RawApi } from 'grammy';
 import { COMMON_REQUESTS_TELEGRAM_ID, getRpcClientForUser } from '@/src/api/client.js';
 import type { Logger } from '@/src/logger.js';
 import { formatNotificationMessage } from '@/src/telegram/format-notification.js';
-import { sendNotificationMessage } from '@/src/telegram/messaging.js';
+import { sendMessage } from '@/src/telegram/messaging.js';
 
 interface BotNotification {
   id: string;
@@ -34,15 +34,18 @@ export async function processNotifications(
     if (!notification.telegramId) continue;
 
     const message = formatNotificationMessage(notification.type, notification.payload);
-    const delivered = await sendNotificationMessage(
+    const messageId = await sendMessage({
       api,
-      Number(notification.telegramId),
-      notification.telegramId,
-      message,
-      log.child({ notificationId: notification.id, type: notification.type }),
-    );
+      chatId: Number(notification.telegramId),
+      telegramId: notification.telegramId,
+      text: message,
+      logger: log.child({ notificationId: notification.id, type: notification.type }),
+      options: {
+        link_preview_options: { is_disabled: true },
+      },
+    });
 
-    if (!delivered) continue;
+    if (messageId === null) continue;
 
     await rpcClient.bot.setNotificationDelivered({ id: notification.id });
   }

--- a/packages/telegram-bot/src/telegram/blocked-users.ts
+++ b/packages/telegram-bot/src/telegram/blocked-users.ts
@@ -1,0 +1,21 @@
+import { getRpcClientForUser } from '@/src/api/client.js';
+import type { Logger } from '@/src/logger.js';
+
+export async function handleBlockedUser(telegramId: string, logger: Logger): Promise<void> {
+  logger.info({ telegramId }, 'User has blocked the bot, marking as blocked');
+  try {
+    const rpcClient = getRpcClientForUser(telegramId);
+    await rpcClient.bot.setBlocked({ telegramId });
+  } catch (err) {
+    logger.error({ err, telegramId }, 'Failed to mark user as blocked via API');
+  }
+}
+
+export async function handleUnblockedUser(telegramId: string, logger: Logger): Promise<void> {
+  try {
+    const rpcClient = getRpcClientForUser(telegramId);
+    await rpcClient.bot.setUnblocked({ telegramId });
+  } catch (err) {
+    logger.error({ err, telegramId }, 'Failed to mark user as unblocked via API');
+  }
+}

--- a/packages/telegram-bot/src/telegram/messaging.ts
+++ b/packages/telegram-bot/src/telegram/messaging.ts
@@ -1,138 +1,67 @@
 import type { Api, RawApi } from 'grammy';
 
-import { getRpcClientForUser } from '@/src/api/client.js';
 import type { Logger } from '@/src/logger.js';
-
-/** Telegram API error code for "bot was blocked by the user" */
-const BLOCKED_ERROR_CODE = 403;
-
-/** Telegram API error description for "message is not modified" (not a real error) */
-const SAME_MESSAGE_DESCRIPTION = 'Bad Request: message is not modified';
-
-/** In-memory set of blocked telegramIds (populated on 403, cleared on unblock) */
-export const blockedUserIds = new Set<string>();
+import { handleTelegramRequest } from '@/src/telegram/request.js';
 
 type SendMessageOptions = Parameters<Api<RawApi>['sendMessage']>[2];
+type EditMessageTextOptions = Parameters<Api<RawApi>['editMessageText']>[3];
 
-async function sendTelegramMessage(
-  api: Api<RawApi>,
-  chatId: number,
-  telegramId: string,
-  text: string,
-  logger: Logger,
-  options?: SendMessageOptions,
-): Promise<number | null> {
-  try {
-    const result = await api.sendMessage(chatId, text, options);
-    return result.message_id;
-  } catch (error) {
-    if (isBlockedError(error)) {
-      await handleBlockedUser(telegramId, logger);
-      return null;
-    }
-
-    logger.warn({ err: error, chatId }, 'Failed to send Telegram message');
-    return null;
-  }
+interface SendMessageBaseParams {
+  api: Api<RawApi>;
+  chatId: number;
+  telegramId: string;
+  text: string;
+  logger: Logger;
+  options?: SendMessageOptions;
 }
 
-/**
- * Send a message to a Telegram chat. Detects 403 (blocked) and marks the user via API.
- * Returns the message_id of the sent message.
- */
-export async function sendDashboardMessage(
-  api: Api<RawApi>,
-  chatId: number,
-  telegramId: string,
-  text: string,
-  logger: Logger,
-): Promise<number | null> {
-  return sendTelegramMessage(api, chatId, telegramId, text, logger, {
-    parse_mode: 'MarkdownV2',
-    link_preview_options: { is_disabled: true },
-    disable_notification: true,
-  });
+interface EditMessageParams {
+  api: Api<RawApi>;
+  chatId: number;
+  messageId: number;
+  telegramId: string;
+  text: string;
+  logger: Logger;
+  options?: EditMessageTextOptions;
 }
 
-/**
- * Send a notification message to a Telegram chat.
- * Returns true when delivery succeeded.
- */
-export async function sendNotificationMessage(
-  api: Api<RawApi>,
-  chatId: number,
-  telegramId: string,
-  text: string,
-  logger: Logger,
-  options?: SendMessageOptions,
-): Promise<boolean> {
-  const messageId = await sendTelegramMessage(api, chatId, telegramId, text, logger, {
-    link_preview_options: { is_disabled: true },
-    ...options,
+export async function sendMessage({
+  api,
+  chatId,
+  telegramId,
+  text,
+  logger,
+  options,
+}: SendMessageBaseParams): Promise<number | null> {
+  const result = await handleTelegramRequest({
+    logger,
+    method: 'sendMessage',
+    chatId,
+    telegramId,
+    request: () => api.sendMessage(chatId, text, options),
   });
 
-  return messageId !== null;
+  return result.ok ? result.response.message_id : null;
 }
 
-/**
- * Edit an existing dashboard message. Detects 403 (blocked) and "same message" errors.
- * Returns true if the edit succeeded, false otherwise.
- */
-export async function editDashboardMessage(
-  api: Api<RawApi>,
-  chatId: number,
-  messageId: number,
-  telegramId: string,
-  text: string,
-  logger: Logger,
-): Promise<boolean> {
-  try {
-    await api.editMessageText(chatId, messageId, text, {
-      parse_mode: 'MarkdownV2',
-      link_preview_options: { is_disabled: true },
-    });
-    return true;
-  } catch (error) {
-    if (isBlockedError(error)) {
-      await handleBlockedUser(telegramId, logger);
-      return false;
-    }
+export async function editMessage({
+  api,
+  chatId,
+  messageId,
+  telegramId,
+  text,
+  logger,
+  options,
+}: EditMessageParams): Promise<boolean> {
+  const result = await handleTelegramRequest({
+    logger,
+    method: 'editMessageText',
+    chatId,
+    telegramId,
+    request: () => api.editMessageText(chatId, messageId, text, options),
+    logContext: { messageId },
+    treatSameMessageAsSuccess: true,
+  });
 
-    if (isSameMessageError(error)) {
-      logger.debug({ chatId, messageId }, 'Message content unchanged, skipping');
-      return true;
-    }
-
-    logger.warn({ err: error, chatId, messageId }, 'Failed to edit dashboard message');
-    return false;
-  }
-}
-
-function isBlockedError(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'error_code' in error &&
-    (error as { error_code: number }).error_code === BLOCKED_ERROR_CODE
-  );
-}
-
-function isSameMessageError(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'description' in error &&
-    (error as { description: string }).description.startsWith(SAME_MESSAGE_DESCRIPTION)
-  );
-}
-
-async function handleBlockedUser(telegramId: string, logger: Logger): Promise<void> {
-  logger.info({ telegramId }, 'User has blocked the bot, marking as blocked');
-  blockedUserIds.add(telegramId);
-  try {
-    const rpcClient = getRpcClientForUser(telegramId);
-    await rpcClient.bot.setBlocked({ telegramId });
-  } catch (err) {
-    logger.error({ err, telegramId }, 'Failed to mark user as blocked via API');
-  }
+  return result.ok || result.sameMessage;
 }

--- a/packages/telegram-bot/src/telegram/rate-limit.ts
+++ b/packages/telegram-bot/src/telegram/rate-limit.ts
@@ -1,0 +1,116 @@
+import { RateLimiterMemory, RateLimiterQueue } from 'rate-limiter-flexible';
+
+import { config } from '@/src/config.js';
+import type { Logger } from '@/src/logger.js';
+
+export type TelegramMethod = 'sendMessage' | 'editMessageText';
+
+const TOO_MANY_REQUESTS_ERROR_CODE = 429;
+const TELEGRAM_MAX_RATE_LIMIT_RETRIES = 3;
+
+const telegramRateLimiter = new RateLimiterMemory({
+  points: config.botRateLimitPerSecond,
+  duration: 1,
+  keyPrefix: 'telegram-bot-api',
+});
+const telegramQueue = new RateLimiterQueue(telegramRateLimiter);
+
+const telegramChatRateLimiter = new RateLimiterMemory({
+  points: 1,
+  duration: 1,
+  keyPrefix: 'telegram-chat-api',
+});
+const telegramChatQueue = new RateLimiterQueue(telegramChatRateLimiter);
+
+async function waitForTelegramRateLimit(
+  logger: Logger,
+  method: TelegramMethod,
+  chatId: number,
+): Promise<void> {
+  const chatKey = chatId.toString();
+  const [globalLimiterRes, chatLimiterRes] = await Promise.all([
+    telegramRateLimiter.get('global'),
+    telegramChatRateLimiter.get(chatKey),
+  ]);
+  const globalTokensRemaining = globalLimiterRes?.remainingPoints ?? config.botRateLimitPerSecond;
+  const chatTokensRemaining = chatLimiterRes?.remainingPoints ?? 1;
+
+  if (globalTokensRemaining <= 0 || chatTokensRemaining <= 0) {
+    logger.debug(
+      {
+        method,
+        chatId,
+        globalTokensRemaining,
+        chatTokensRemaining,
+        limitPerSecond: config.botRateLimitPerSecond,
+      },
+      'Telegram API rate limit reached, queueing request',
+    );
+  }
+
+  await telegramQueue.removeTokens(1, 'global');
+  await telegramChatQueue.removeTokens(1, chatKey);
+}
+
+export async function executeTelegramRequest<T>(
+  logger: Logger,
+  method: TelegramMethod,
+  chatId: number,
+  request: () => Promise<T>,
+): Promise<T> {
+  let rateLimitRetries = 0;
+
+  for (;;) {
+    await waitForTelegramRateLimit(logger, method, chatId);
+
+    try {
+      return await request();
+    } catch (error) {
+      const retryAfterMs = getRetryAfterMs(error);
+      if (retryAfterMs === null) {
+        throw error;
+      }
+
+      if (rateLimitRetries >= TELEGRAM_MAX_RATE_LIMIT_RETRIES) {
+        throw error;
+      }
+
+      rateLimitRetries += 1;
+      logger.warn(
+        {
+          err: error,
+          method,
+          chatId,
+          retryAfterMs,
+          retryAttempt: rateLimitRetries,
+          maxRetries: TELEGRAM_MAX_RATE_LIMIT_RETRIES,
+        },
+        'Telegram API returned rate limit, retrying request',
+      );
+      await delay(retryAfterMs);
+    }
+  }
+}
+
+function getRetryAfterMs(error: unknown): number | null {
+  if (
+    typeof error !== 'object' ||
+    error === null ||
+    !('error_code' in error) ||
+    (error as { error_code: number }).error_code !== TOO_MANY_REQUESTS_ERROR_CODE ||
+    !('parameters' in error)
+  ) {
+    return null;
+  }
+
+  const retryAfter = (error as { parameters?: { retry_after?: unknown } }).parameters?.retry_after;
+  if (typeof retryAfter !== 'number' || !Number.isFinite(retryAfter) || retryAfter <= 0) {
+    return null;
+  }
+
+  return retryAfter * 1000;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/telegram-bot/src/telegram/request.ts
+++ b/packages/telegram-bot/src/telegram/request.ts
@@ -1,0 +1,52 @@
+import type { Logger } from '@/src/logger.js';
+import { handleBlockedUser } from '@/src/telegram/blocked-users.js';
+import { executeTelegramRequest, type TelegramMethod } from '@/src/telegram/rate-limit.js';
+import { isBlockedError, isSameMessageError } from '@/src/telegram/telegram-errors.js';
+
+type LogContext = Record<string, unknown>;
+
+type TelegramRequestResult<TResponse> =
+  | { ok: true; response: TResponse }
+  | { ok: false; sameMessage: boolean };
+
+interface TelegramRequestOptions<TResponse> {
+  logger: Logger;
+  method: TelegramMethod;
+  chatId: number;
+  telegramId: string;
+  request: () => Promise<TResponse>;
+  logContext?: LogContext;
+  treatSameMessageAsSuccess?: boolean;
+}
+
+const FAILURE_MESSAGES: Record<TelegramMethod, string> = {
+  sendMessage: 'Failed to send Telegram message',
+  editMessageText: 'Failed to edit Telegram message',
+};
+
+export async function handleTelegramRequest<TResponse>({
+  logger,
+  method,
+  chatId,
+  telegramId,
+  request,
+  logContext = {},
+  treatSameMessageAsSuccess = false,
+}: TelegramRequestOptions<TResponse>): Promise<TelegramRequestResult<TResponse>> {
+  try {
+    return { ok: true, response: await executeTelegramRequest(logger, method, chatId, request) };
+  } catch (error) {
+    if (isBlockedError(error)) {
+      await handleBlockedUser(telegramId, logger);
+      return { ok: false, sameMessage: false };
+    }
+
+    if (treatSameMessageAsSuccess && isSameMessageError(error)) {
+      logger.debug({ chatId, ...logContext }, 'Message content unchanged, skipping');
+      return { ok: false, sameMessage: true };
+    }
+
+    logger.warn({ err: error, chatId, ...logContext }, FAILURE_MESSAGES[method]);
+    return { ok: false, sameMessage: false };
+  }
+}

--- a/packages/telegram-bot/src/telegram/telegram-errors.ts
+++ b/packages/telegram-bot/src/telegram/telegram-errors.ts
@@ -1,0 +1,20 @@
+const BLOCKED_ERROR_CODE = 403;
+const SAME_MESSAGE_DESCRIPTION = 'Bad Request: message is not modified';
+
+export function isBlockedError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'error_code' in error &&
+    (error as { error_code: number }).error_code === BLOCKED_ERROR_CODE
+  );
+}
+
+export function isSameMessageError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'description' in error &&
+    (error as { description: string }).description.startsWith(SAME_MESSAGE_DESCRIPTION)
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,9 @@ importers:
       pino-pretty:
         specifier: 13.0.0
         version: 13.0.0
+      rate-limiter-flexible:
+        specifier: ^11.0.1
+        version: 11.0.1
       toad-scheduler:
         specifier: ^3.0.1
         version: 3.1.0
@@ -4788,6 +4791,9 @@ packages:
   radash@12.1.1:
     resolution: {integrity: sha512-h36JMxKRqrAxVD8201FrCpyeNuUY9Y5zZwujr20fFO77tpUtGa6EZzfKw/3WaiBX95fq7+MpsuMLNdSnORAwSA==}
     engines: {node: '>=14.18.0'}
+
+  rate-limiter-flexible@11.0.1:
+    resolution: {integrity: sha512-hvyCUefjRund2N6hro2H8Dql7OvB6+B3Qv2FLWWbdsdyQScXf4+N0tM0Bryz11awTtNxx6C1QbHYb1rCiAx7pA==}
 
   rate-limiter-flexible@5.0.5:
     resolution: {integrity: sha512-+/dSQfo+3FYwYygUs/V2BBdwGa9nFtakDwKt4l0bnvNB53TNT++QSFewwHX9qXrZJuMe9j+TUaU21lm5ARgqdQ==}
@@ -10011,6 +10017,8 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   radash@12.1.1: {}
+
+  rate-limiter-flexible@11.0.1: {}
 
   rate-limiter-flexible@5.0.5: {}
 


### PR DESCRIPTION
## Summary

- Add configurable Telegram Bot API rate limiting with `rate-limiter-flexible@^11.0.1`.
- Queue outbound Telegram requests through a global bot limiter and a per-chat limiter to avoid bot-wide bursts and per-chat flood limits.
- Retry Telegram `429` responses using `parameters.retry_after`, capped at 3 retries.
- Centralize Telegram request error handling for sends and edits, including blocked-user detection and `message is not modified` as a successful edit.
- Replace domain-specific message helpers with generic `sendMessage` and `editMessage` helpers.
- Mark users as blocked through the API after Telegram `403` responses, and mark them unblocked through the API whenever they send the bot a new update.
- Split Telegram messaging internals into focused helper modules (`rate-limit`, `request`, `blocked-users`, `telegram-errors`).

## Verification

- `pnpm --filter telegram-bot type-check`
- `pnpm --filter telegram-bot lint` (passes with the existing unrelated `setcommands.ts` unused-var warning)

E2E was intentionally not run.