### PR TITLE
[codex] add cluster incident bot notifications

### DIFF
--- a/packages/db/prisma/migrations/20251210144216_initial/migration.sql
+++ b/packages/db/prisma/migrations/20251210144216_initial/migration.sql
@@ -4,6 +4,9 @@ CREATE TYPE "public"."ValidatorExitEvent" AS ENUM ('voluntary', 'slashed');
 -- CreateEnum
 CREATE TYPE "public"."ClusterVisibility" AS ENUM ('private', 'shared');
 
+-- CreateEnum
+CREATE TYPE "public"."ClusterIncidentStatus" AS ENUM ('open', 'closed');
+
 -- CreateTable
 CREATE TABLE "public"."validator" (
     "id" INTEGER NOT NULL,
@@ -350,6 +353,30 @@ CREATE TABLE "public"."notification_queue" (
 );
 
 -- CreateTable
+CREATE TABLE "public"."cluster_incident" (
+    "id" TEXT NOT NULL,
+    "status" "public"."ClusterIncidentStatus" NOT NULL DEFAULT 'open',
+    "cluster_id" TEXT NOT NULL,
+    "opened_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "opened_slot" INTEGER NOT NULL,
+    "opened_validator_indexes" INTEGER[] NOT NULL DEFAULT '{}',
+    "current_validator_indexes" INTEGER[] NOT NULL DEFAULT '{}',
+    "affected_validator_indexes" INTEGER[] NOT NULL DEFAULT '{}',
+    "closed_at" TIMESTAMP,
+    "closed_slot" INTEGER,
+    "duration_slots" INTEGER,
+    "duration_seconds" INTEGER,
+    "missed_attestations" INTEGER,
+    "missed_consensus_rewards" BIGINT,
+    "opened_notification_queued_at" TIMESTAMP,
+    "closed_notification_queued_at" TIMESTAMP,
+    "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cluster_incident_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "public"."fee_reward_address" (
     "address" TEXT NOT NULL,
     "user_id" TEXT,
@@ -427,6 +454,12 @@ CREATE INDEX "cluster_validator_validator_index_idx" ON "public"."cluster_valida
 CREATE INDEX "notification_queue_user_id_delivered_idx" ON "public"."notification_queue"("user_id", "delivered");
 
 -- CreateIndex
+CREATE INDEX "cluster_incident_cluster_id_status_idx" ON "public"."cluster_incident"("cluster_id", "status");
+
+-- CreateIndex
+CREATE INDEX "cluster_incident_status_opened_at_idx" ON "public"."cluster_incident"("status", "opened_at" DESC);
+
+-- CreateIndex
 CREATE INDEX "_user_to_fee_reward_address_user_id_idx" ON "public"."_user_to_fee_reward_address"("user_id");
 
 -- AddForeignKey
@@ -440,6 +473,9 @@ ALTER TABLE "public"."cluster_validator" ADD CONSTRAINT "cluster_validator_valid
 
 -- AddForeignKey
 ALTER TABLE "public"."notification_queue" ADD CONSTRAINT "notification_queue_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."cluster_incident" ADD CONSTRAINT "cluster_incident_cluster_id_fkey" FOREIGN KEY ("cluster_id") REFERENCES "public"."cluster"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."_user_to_fee_reward_address" ADD CONSTRAINT "_user_to_fee_reward_address_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -175,6 +175,11 @@ enum ClusterVisibility {
   shared
 }
 
+enum ClusterIncidentStatus {
+  open
+  closed
+}
+
 model validatorExits {
   index Int                @id @map("index")
   epoch Int                @map("epoch")
@@ -502,6 +507,40 @@ model NotificationQueue {
   @@map("notification_queue")
 }
 
+model ClusterIncident {
+  id     String                @id @default(cuid()) @map("id")
+  status ClusterIncidentStatus @default(open) @map("status")
+
+  clusterId String @map("cluster_id")
+
+  openedAt   DateTime @default(now()) @map("opened_at") @db.Timestamp
+  openedSlot Int      @map("opened_slot")
+
+  openedValidatorIndexes   Int[] @default([]) @map("opened_validator_indexes")
+  currentValidatorIndexes  Int[] @default([]) @map("current_validator_indexes")
+  affectedValidatorIndexes Int[] @default([]) @map("affected_validator_indexes")
+
+  closedAt        DateTime? @map("closed_at") @db.Timestamp
+  closedSlot      Int?      @map("closed_slot")
+  durationSlots   Int?      @map("duration_slots")
+  durationSeconds Int?      @map("duration_seconds")
+
+  missedAttestations     Int?    @map("missed_attestations")
+  missedConsensusRewards BigInt? @map("missed_consensus_rewards")
+
+  openedNotificationQueuedAt DateTime? @map("opened_notification_queued_at") @db.Timestamp
+  closedNotificationQueuedAt DateTime? @map("closed_notification_queued_at") @db.Timestamp
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamp
+  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamp
+
+  cluster Cluster @relation(fields: [clusterId], references: [id], onDelete: Cascade)
+
+  @@index([clusterId, status])
+  @@index([status, openedAt(sort: Desc)])
+  @@map("cluster_incident")
+}
+
 model FeeRewardAddress {
   address String                   @id @map("address")
   users   UserToFeeRewardAddress[] @relation("user_to_fee_reward_address")
@@ -519,6 +558,7 @@ model Cluster {
   createdAt           DateTime          @default(now()) @map("created_at")
 
   owner      User               @relation(fields: [ownerId], references: [id], onDelete: Restrict)
+  incidents  ClusterIncident[]
   validators ClusterValidator[]
 
   @@map("cluster")

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -9,6 +9,7 @@ import { ChainStatsController } from '@/src/services/consensus/controllers/chain
 import { DailyArchiveController } from '@/src/services/consensus/controllers/dailyArchive.js';
 import { EpochController } from '@/src/services/consensus/controllers/epoch.js';
 import { HourlyArchiveController } from '@/src/services/consensus/controllers/hourlyArchive.js';
+import { IncidentController } from '@/src/services/consensus/controllers/incident.js';
 import { IndexerConfigController } from '@/src/services/consensus/controllers/indexerConfig.js';
 import { MonthlyArchiveController } from '@/src/services/consensus/controllers/monthlyArchive.js';
 import { PartitionController } from '@/src/services/consensus/controllers/partition.js';
@@ -19,6 +20,7 @@ import { ChainStatsStorage } from '@/src/services/consensus/storage/chainStats.j
 import { DailyArchiveStorage } from '@/src/services/consensus/storage/dailyArchive.js';
 import { EpochStorage } from '@/src/services/consensus/storage/epoch.js';
 import { HourlyArchiveStorage } from '@/src/services/consensus/storage/hourlyArchive.js';
+import { IncidentStorage } from '@/src/services/consensus/storage/incident.js';
 import { IndexerConfigStorage } from '@/src/services/consensus/storage/indexerConfig.js';
 import { MonthlyArchiveStorage } from '@/src/services/consensus/storage/monthlyArchive.js';
 import { PartitionStorage } from '@/src/services/consensus/storage/partition.js';
@@ -186,6 +188,10 @@ async function main() {
   const snapshotStorage = new SnapshotStorage(prisma);
   const snapshotController = new SnapshotController(snapshotStorage, beaconTime);
 
+  // Create incident storage and controller
+  const incidentStorage = new IncidentStorage(prisma);
+  const incidentController = new IncidentController(incidentStorage, beaconTime);
+
   // Start indexing the beacon chain
   await validatorsController.initValidatorsWithWait(env.CONSENSUS_LOOKBACK_SLOT);
 
@@ -203,6 +209,7 @@ async function main() {
     monthlyArchiveController,
     chainStatsController,
     snapshotController,
+    incidentController,
     env.CHAIN,
     chainConfig.beacon.maxAttestationDelay,
     chainConfig.beacon.delaySlotsToHead,

--- a/packages/indexer/src/services/consensus/controllers/incident.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/incident.test.ts
@@ -1,0 +1,173 @@
+import { BeaconTime } from '@beacon-indexer/beacon-utils/beaconTime';
+import { gnosisConfig } from '@beacon-indexer/beacon-utils/config/chain';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { IncidentStorage } from '../storage/incident.js';
+
+import { IncidentController } from './incident.js';
+
+describe('IncidentController', () => {
+  const beaconTime = new BeaconTime({
+    genesisTimestamp: gnosisConfig.beacon.genesisTimestamp,
+    slotDurationMs: gnosisConfig.beacon.slotDuration,
+    slotsPerEpoch: gnosisConfig.beacon.slotsPerEpoch,
+    epochsPerSyncCommitteePeriod: gnosisConfig.beacon.epochsPerSyncCommitteePeriod,
+    lookbackSlot: 0,
+    delaySlotsToHead: gnosisConfig.beacon.delaySlotsToHead,
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens a new incident when a cluster becomes inactive', async () => {
+    const storage = {
+      listCurrentClusterStates: vi.fn().mockResolvedValue([
+        {
+          cluster_id: 'cluster-1',
+          cluster_name: 'Main cluster',
+          owner_id: 'user-1',
+          inactive_validator_indexes: [11],
+        },
+      ]),
+      listOpenIncidents: vi.fn().mockResolvedValue([]),
+      createIncident: vi.fn().mockResolvedValue({ id: 'incident-1' }),
+    } as unknown as IncidentStorage;
+
+    const controller = new IncidentController(storage, beaconTime);
+    const observedSlot = 200;
+    const nowSlot =
+      observedSlot + gnosisConfig.beacon.delaySlotsToHead + gnosisConfig.beacon.maxAttestationDelay;
+
+    vi.spyOn(Date, 'now').mockReturnValue(beaconTime.getTimestampFromSlotNumber(nowSlot));
+
+    const result = await controller.syncOpenIncidents(gnosisConfig.beacon.maxAttestationDelay);
+
+    expect(result).toEqual({ opened: 1, updated: 0, closed: 0 });
+    expect((storage as any).createIncident).toHaveBeenCalledWith({
+      clusterId: 'cluster-1',
+      ownerId: 'user-1',
+      clusterName: 'Main cluster',
+      openedAt: new Date(beaconTime.getTimestampFromSlotNumber(observedSlot)),
+      openedSlot: observedSlot,
+      validatorIndexes: [11],
+    });
+  });
+
+  it('updates and closes an existing incident from snapshot state transitions', async () => {
+    const updateIncidentValidators = vi.fn().mockResolvedValue(undefined);
+    const computeIncidentSummary = vi.fn().mockResolvedValue({
+      missedAttestations: 4,
+      missedConsensusRewards: BigInt(1234),
+    });
+    const closeIncident = vi.fn().mockResolvedValue(undefined);
+
+    const storage = {
+      listCurrentClusterStates: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            cluster_id: 'cluster-1',
+            cluster_name: 'Main cluster',
+            owner_id: 'user-1',
+            inactive_validator_indexes: [11, 22],
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            cluster_id: 'cluster-1',
+            cluster_name: 'Main cluster',
+            owner_id: 'user-1',
+            inactive_validator_indexes: [],
+          },
+        ]),
+      listOpenIncidents: vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            id: 'incident-1',
+            cluster_id: 'cluster-1',
+            opened_at: new Date(beaconTime.getTimestampFromSlotNumber(200)),
+            opened_slot: 200,
+            opened_validator_indexes: [11],
+            current_validator_indexes: [11],
+            affected_validator_indexes: [11],
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: 'incident-1',
+            cluster_id: 'cluster-1',
+            opened_at: new Date(beaconTime.getTimestampFromSlotNumber(200)),
+            opened_slot: 200,
+            opened_validator_indexes: [11],
+            current_validator_indexes: [11, 22],
+            affected_validator_indexes: [11, 22],
+          },
+        ]),
+      updateIncidentValidators,
+      computeIncidentSummary,
+      closeIncident,
+    } as unknown as IncidentStorage;
+
+    const controller = new IncidentController(storage, beaconTime);
+
+    const updateObservedSlot = 210;
+    vi.spyOn(Date, 'now').mockReturnValue(
+      beaconTime.getTimestampFromSlotNumber(
+        updateObservedSlot +
+          gnosisConfig.beacon.delaySlotsToHead +
+          gnosisConfig.beacon.maxAttestationDelay,
+      ),
+    );
+
+    const updateResult = await controller.syncOpenIncidents(
+      gnosisConfig.beacon.maxAttestationDelay,
+    );
+
+    expect(updateResult).toEqual({ opened: 0, updated: 1, closed: 0 });
+    expect(updateIncidentValidators).toHaveBeenCalledWith({
+      incidentId: 'incident-1',
+      currentValidatorIndexes: [11, 22],
+      affectedValidatorIndexes: [11, 22],
+    });
+
+    const closeObservedSlot = 220;
+    vi.spyOn(Date, 'now').mockReturnValue(
+      beaconTime.getTimestampFromSlotNumber(
+        closeObservedSlot +
+          gnosisConfig.beacon.delaySlotsToHead +
+          gnosisConfig.beacon.maxAttestationDelay,
+      ),
+    );
+
+    const closeResult = await controller.syncOpenIncidents(gnosisConfig.beacon.maxAttestationDelay);
+
+    expect(closeResult).toEqual({ opened: 0, updated: 0, closed: 1 });
+    expect(computeIncidentSummary).toHaveBeenCalledWith({
+      fromSlot: 200,
+      toSlot: 220,
+      fromEpoch: beaconTime.getEpochFromSlot(200),
+      toEpoch: beaconTime.getEpochFromSlot(220),
+      validatorIndexes: [11, 22],
+      maxAttestationDelay: gnosisConfig.beacon.maxAttestationDelay,
+    });
+    expect(closeIncident).toHaveBeenCalledWith({
+      incidentId: 'incident-1',
+      ownerId: 'user-1',
+      clusterId: 'cluster-1',
+      clusterName: 'Main cluster',
+      closedAt: new Date(beaconTime.getTimestampFromSlotNumber(closeObservedSlot)),
+      closedSlot: closeObservedSlot,
+      durationSlots: 20,
+      durationSeconds: Math.floor(
+        (beaconTime.getTimestampFromSlotNumber(closeObservedSlot) -
+          beaconTime.getTimestampFromSlotNumber(200)) /
+          1000,
+      ),
+      missedAttestations: 4,
+      missedConsensusRewards: BigInt(1234),
+      affectedValidatorIndexes: [11, 22],
+    });
+  });
+});

--- a/packages/indexer/src/services/consensus/controllers/incident.ts
+++ b/packages/indexer/src/services/consensus/controllers/incident.ts
@@ -1,0 +1,156 @@
+import { BeaconTime } from '@beacon-indexer/beacon-utils/beaconTime';
+
+import { IncidentStorage } from '../storage/incident.js';
+
+import createLogger from '@/src/lib/pino.js';
+
+type OpenIncident = {
+  id: string;
+  cluster_id: string;
+  opened_at: Date;
+  opened_slot: number;
+  opened_validator_indexes: number[];
+  current_validator_indexes: number[];
+  affected_validator_indexes: number[];
+};
+
+function arraysEqual(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+function mergeUniqueSorted(a: number[], b: number[]): number[] {
+  return Array.from(new Set([...a, ...b])).sort((x, y) => x - y);
+}
+
+export class IncidentController {
+  private readonly logger = createLogger('IncidentController');
+
+  constructor(
+    private readonly incidentStorage: IncidentStorage,
+    private readonly beaconTime: BeaconTime,
+  ) {}
+
+  async syncOpenIncidents(maxAttestationDelay: number): Promise<{
+    opened: number;
+    updated: number;
+    closed: number;
+  }> {
+    const [clusterStates, openIncidents] = await Promise.all([
+      this.incidentStorage.listCurrentClusterStates(),
+      this.incidentStorage.listOpenIncidents(),
+    ]);
+
+    const openByCluster = new Map(openIncidents.map((incident) => [incident.cluster_id, incident]));
+    const observedSlot = Math.max(0, this.beaconTime.getChainCurrentSlot() - maxAttestationDelay);
+
+    let opened = 0;
+    let updated = 0;
+    let closed = 0;
+
+    for (const clusterState of clusterStates) {
+      const incident = openByCluster.get(clusterState.cluster_id);
+      const currentInactive = [...clusterState.inactive_validator_indexes].sort((a, b) => a - b);
+
+      if (!incident && currentInactive.length > 0) {
+        const openedAt = new Date(this.beaconTime.getTimestampFromSlotNumber(observedSlot));
+
+        await this.incidentStorage.createIncident({
+          clusterId: clusterState.cluster_id,
+          ownerId: clusterState.owner_id,
+          clusterName: clusterState.cluster_name,
+          openedAt,
+          openedSlot: observedSlot,
+          validatorIndexes: currentInactive,
+        });
+
+        opened += 1;
+        continue;
+      }
+
+      if (!incident) {
+        continue;
+      }
+
+      if (currentInactive.length > 0) {
+        const affectedValidatorIndexes = mergeUniqueSorted(
+          incident.affected_validator_indexes,
+          currentInactive,
+        );
+
+        if (
+          !arraysEqual(currentInactive, incident.current_validator_indexes) ||
+          !arraysEqual(affectedValidatorIndexes, incident.affected_validator_indexes)
+        ) {
+          await this.incidentStorage.updateIncidentValidators({
+            incidentId: incident.id,
+            currentValidatorIndexes: currentInactive,
+            affectedValidatorIndexes,
+          });
+          updated += 1;
+        }
+
+        continue;
+      }
+
+      await this.closeIncident({
+        clusterId: clusterState.cluster_id,
+        clusterName: clusterState.cluster_name,
+        incident,
+        maxAttestationDelay,
+        ownerId: clusterState.owner_id,
+        observedSlot,
+      });
+      closed += 1;
+    }
+
+    if (opened || updated || closed) {
+      this.logger.info('Synchronized cluster incidents', { opened, updated, closed });
+    }
+
+    return { opened, updated, closed };
+  }
+
+  private async closeIncident(params: {
+    incident: OpenIncident;
+    clusterId: string;
+    clusterName: string;
+    ownerId: string;
+    observedSlot: number;
+    maxAttestationDelay: number;
+  }) {
+    const { incident, clusterId, clusterName, ownerId, observedSlot, maxAttestationDelay } = params;
+    const closedAt = new Date(this.beaconTime.getTimestampFromSlotNumber(observedSlot));
+    const closedSlot = Math.max(observedSlot, incident.opened_slot);
+    const durationSlots = Math.max(0, closedSlot - incident.opened_slot);
+    const durationSeconds = Math.max(
+      0,
+      Math.floor((closedAt.getTime() - incident.opened_at.getTime()) / 1000),
+    );
+    const fromEpoch = this.beaconTime.getEpochFromSlot(incident.opened_slot);
+    const toEpoch = this.beaconTime.getEpochFromSlot(closedSlot);
+
+    const summary = await this.incidentStorage.computeIncidentSummary({
+      fromSlot: incident.opened_slot,
+      toSlot: closedSlot,
+      fromEpoch,
+      toEpoch,
+      validatorIndexes: incident.affected_validator_indexes,
+      maxAttestationDelay,
+    });
+
+    await this.incidentStorage.closeIncident({
+      incidentId: incident.id,
+      ownerId,
+      clusterId,
+      clusterName,
+      closedAt,
+      closedSlot,
+      durationSlots,
+      durationSeconds,
+      missedAttestations: summary.missedAttestations,
+      missedConsensusRewards: summary.missedConsensusRewards,
+      affectedValidatorIndexes: incident.affected_validator_indexes,
+    });
+  }
+}

--- a/packages/indexer/src/services/consensus/storage/incident.ts
+++ b/packages/indexer/src/services/consensus/storage/incident.ts
@@ -1,0 +1,319 @@
+import { PrismaClient } from '@beacon-indexer/db';
+
+type ClusterIncidentStateRow = {
+  cluster_id: string;
+  cluster_name: string;
+  owner_id: string;
+  inactive_validator_indexes: number[];
+};
+
+type OpenIncidentRow = {
+  id: string;
+  cluster_id: string;
+  opened_at: Date;
+  opened_slot: number;
+  opened_validator_indexes: number[];
+  current_validator_indexes: number[];
+  affected_validator_indexes: number[];
+};
+
+type IncidentSummaryRow = {
+  missed_attestations: bigint | null;
+  missed_consensus_rewards: bigint | null;
+};
+
+export class IncidentStorage {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async listCurrentClusterStates(): Promise<ClusterIncidentStateRow[]> {
+    return this.prisma.$queryRaw<ClusterIncidentStateRow[]>`
+      SELECT
+        c.id AS cluster_id,
+        c.name AS cluster_name,
+        c.owner_id,
+        COALESCE(
+          ARRAY_AGG(vss.validator_index ORDER BY vss.validator_index)
+            FILTER (
+              WHERE vss.is_inactive = true
+                AND COALESCE(vss.beacon_status, 0) IN (0, 1, 2, 3, 4)
+            ),
+          ARRAY[]::int[]
+        ) AS inactive_validator_indexes
+      FROM cluster c
+      LEFT JOIN cluster_validator cv ON cv.cluster_id = c.id
+      LEFT JOIN validators_snapshot_stats vss ON vss.validator_index = cv.validator_index
+      GROUP BY c.id, c.name, c.owner_id
+    `;
+  }
+
+  async listOpenIncidents(): Promise<OpenIncidentRow[]> {
+    return this.prisma.$queryRaw<OpenIncidentRow[]>`
+      SELECT
+        ci.id,
+        ci.cluster_id,
+        ci.opened_at,
+        ci.opened_slot,
+        ci.opened_validator_indexes,
+        ci.current_validator_indexes,
+        ci.affected_validator_indexes
+      FROM cluster_incident ci
+      WHERE ci.status = 'open'::"public"."ClusterIncidentStatus"
+    `;
+  }
+
+  async createIncident(params: {
+    clusterId: string;
+    ownerId: string;
+    clusterName: string;
+    openedAt: Date;
+    openedSlot: number;
+    validatorIndexes: number[];
+  }) {
+    const { clusterId, ownerId, clusterName, openedAt, openedSlot, validatorIndexes } = params;
+
+    return this.prisma.$transaction(async (tx) => {
+      const incident = await tx.clusterIncident.create({
+        data: {
+          clusterId,
+          openedAt,
+          openedSlot,
+          openedValidatorIndexes: validatorIndexes,
+          currentValidatorIndexes: validatorIndexes,
+          affectedValidatorIndexes: validatorIndexes,
+        },
+      });
+
+      const owner = await tx.user.findUnique({
+        where: { id: ownerId },
+        select: { hasBlockedBot: true, telegramId: true },
+      });
+
+      if (owner?.telegramId && !owner.hasBlockedBot) {
+        await tx.notificationQueue.create({
+          data: {
+            userId: ownerId,
+            type: 'incident_opened',
+            payload: {
+              clusterId,
+              clusterName,
+              incidentId: incident.id,
+              openedAt: openedAt.toISOString(),
+              openedSlot,
+              validatorIndexes,
+            },
+          },
+        });
+
+        await tx.clusterIncident.update({
+          where: { id: incident.id },
+          data: { openedNotificationQueuedAt: new Date(), updatedAt: new Date() },
+        });
+      }
+
+      return incident;
+    });
+  }
+
+  async updateIncidentValidators(params: {
+    incidentId: string;
+    currentValidatorIndexes: number[];
+    affectedValidatorIndexes: number[];
+  }): Promise<void> {
+    await this.prisma.clusterIncident.update({
+      where: { id: params.incidentId },
+      data: {
+        currentValidatorIndexes: params.currentValidatorIndexes,
+        affectedValidatorIndexes: params.affectedValidatorIndexes,
+        updatedAt: new Date(),
+      },
+    });
+  }
+
+  async closeIncident(params: {
+    incidentId: string;
+    ownerId: string;
+    clusterId: string;
+    clusterName: string;
+    closedAt: Date;
+    closedSlot: number;
+    durationSlots: number;
+    durationSeconds: number;
+    missedAttestations: number;
+    missedConsensusRewards: bigint;
+    affectedValidatorIndexes: number[];
+  }): Promise<void> {
+    const {
+      incidentId,
+      ownerId,
+      clusterId,
+      clusterName,
+      closedAt,
+      closedSlot,
+      durationSlots,
+      durationSeconds,
+      missedAttestations,
+      missedConsensusRewards,
+      affectedValidatorIndexes,
+    } = params;
+
+    await this.prisma.$transaction(async (tx) => {
+      await tx.clusterIncident.update({
+        where: { id: incidentId },
+        data: {
+          status: 'closed',
+          closedAt,
+          closedSlot,
+          currentValidatorIndexes: [],
+          durationSlots,
+          durationSeconds,
+          missedAttestations,
+          missedConsensusRewards,
+          updatedAt: new Date(),
+        },
+      });
+
+      const owner = await tx.user.findUnique({
+        where: { id: ownerId },
+        select: { hasBlockedBot: true, telegramId: true },
+      });
+
+      if (owner?.telegramId && !owner.hasBlockedBot) {
+        await tx.notificationQueue.create({
+          data: {
+            userId: ownerId,
+            type: 'incident_closed',
+            payload: {
+              clusterId,
+              clusterName,
+              incidentId,
+              closedAt: closedAt.toISOString(),
+              closedSlot,
+              durationSeconds,
+              durationSlots,
+              missedAttestations,
+              missedConsensusRewards: missedConsensusRewards.toString(),
+              validatorIndexes: affectedValidatorIndexes,
+            },
+          },
+        });
+
+        await tx.clusterIncident.update({
+          where: { id: incidentId },
+          data: { closedNotificationQueuedAt: new Date(), updatedAt: new Date() },
+        });
+      }
+    });
+  }
+
+  async computeIncidentSummary(params: {
+    fromSlot: number;
+    toSlot: number;
+    fromEpoch: number;
+    toEpoch: number;
+    validatorIndexes: number[];
+    maxAttestationDelay: number;
+  }): Promise<{ missedAttestations: number; missedConsensusRewards: bigint }> {
+    const { fromSlot, toSlot, fromEpoch, toEpoch, validatorIndexes, maxAttestationDelay } = params;
+
+    const rows = await this.prisma.$queryRaw<IncidentSummaryRow[]>`
+      WITH
+        daily_slot_misses AS (
+          SELECT COUNT(*)::bigint AS missed_attestations
+          FROM validator_daily_archive vda,
+          LATERAL jsonb_array_elements(COALESCE(vda.data_by_slot, '[]'::jsonb)) AS slot_row
+          WHERE vda.validator_index = ANY(${validatorIndexes}::int[])
+            AND (slot_row->>0)::int BETWEEN ${fromSlot}::int AND ${toSlot}::int
+            AND (
+              (slot_row->>1)::int = -1
+              OR (slot_row->>1)::int > ${maxAttestationDelay}::int
+            )
+        ),
+        hourly_slot_misses AS (
+          SELECT COUNT(*)::bigint AS missed_attestations
+          FROM validator_hourly_archive vha,
+          LATERAL jsonb_array_elements(vha.data_by_slot) AS slot_row
+          WHERE vha.validator_index = ANY(${validatorIndexes}::int[])
+            AND (slot_row->>0)::int BETWEEN ${fromSlot}::int AND ${toSlot}::int
+            AND (
+              (slot_row->>1)::int = -1
+              OR (slot_row->>1)::int > ${maxAttestationDelay}::int
+            )
+        ),
+        raw_slot_misses AS (
+          SELECT COUNT(*)::bigint AS missed_attestations
+          FROM committee c
+          WHERE c.validator_index = ANY(${validatorIndexes}::int[])
+            AND c.slot BETWEEN ${fromSlot}::int AND ${toSlot}::int
+            AND (
+              c.attestation_delay IS NULL
+              OR c.attestation_delay > ${maxAttestationDelay}::int
+            )
+        ),
+        daily_epoch_misses AS (
+          SELECT
+            COALESCE(
+              SUM(
+                COALESCE((epoch_row->>5)::bigint, 0)
+                + COALESCE((epoch_row->>6)::bigint, 0)
+                + COALESCE((epoch_row->>7)::bigint, 0)
+                + COALESCE((epoch_row->>8)::bigint, 0)
+              ),
+              0
+            ) AS missed_consensus_rewards
+          FROM validator_daily_archive vda,
+          LATERAL jsonb_array_elements(COALESCE(vda.data_by_epoch, '[]'::jsonb)) AS epoch_row
+          WHERE vda.validator_index = ANY(${validatorIndexes}::int[])
+            AND (epoch_row->>0)::int BETWEEN ${fromEpoch}::int AND ${toEpoch}::int
+        ),
+        hourly_epoch_misses AS (
+          SELECT
+            COALESCE(
+              SUM(
+                COALESCE((epoch_row->>5)::bigint, 0)
+                + COALESCE((epoch_row->>6)::bigint, 0)
+                + COALESCE((epoch_row->>7)::bigint, 0)
+                + COALESCE((epoch_row->>8)::bigint, 0)
+              ),
+              0
+            ) AS missed_consensus_rewards
+          FROM validator_hourly_archive vha,
+          LATERAL jsonb_array_elements(vha.data_by_epoch) AS epoch_row
+          WHERE vha.validator_index = ANY(${validatorIndexes}::int[])
+            AND (epoch_row->>0)::int BETWEEN ${fromEpoch}::int AND ${toEpoch}::int
+        ),
+        raw_epoch_misses AS (
+          SELECT
+            COALESCE(
+              SUM(
+                er.missed_head
+                + er.missed_target
+                + er.missed_source
+                + er.missed_inactivity
+              ),
+              0
+            ) AS missed_consensus_rewards
+          FROM epoch_rewards er
+          WHERE er.validator_index = ANY(${validatorIndexes}::int[])
+            AND er.epoch BETWEEN ${fromEpoch}::int AND ${toEpoch}::int
+        )
+      SELECT
+        (
+          COALESCE((SELECT missed_attestations FROM daily_slot_misses), 0)
+          + COALESCE((SELECT missed_attestations FROM hourly_slot_misses), 0)
+          + COALESCE((SELECT missed_attestations FROM raw_slot_misses), 0)
+        )::bigint AS missed_attestations,
+        (
+          COALESCE((SELECT missed_consensus_rewards FROM daily_epoch_misses), 0)
+          + COALESCE((SELECT missed_consensus_rewards FROM hourly_epoch_misses), 0)
+          + COALESCE((SELECT missed_consensus_rewards FROM raw_epoch_misses), 0)
+        )::bigint AS missed_consensus_rewards
+    `;
+
+    const row = rows[0];
+
+    return {
+      missedAttestations: Number(row?.missed_attestations ?? BigInt(0)),
+      missedConsensusRewards: row?.missed_consensus_rewards ?? BigInt(0),
+    };
+  }
+}

--- a/packages/indexer/src/xstate/incidents/incidents.machine.ts
+++ b/packages/indexer/src/xstate/incidents/incidents.machine.ts
@@ -1,0 +1,82 @@
+import { setup, fromPromise } from 'xstate';
+
+import { IncidentController } from '@/src/services/consensus/controllers/incident.js';
+import { pinoLog } from '@/src/xstate/pinoLog.js';
+
+const runSync = fromPromise(
+  async ({
+    input,
+  }: {
+    input: { incidentController: IncidentController; maxAttestationDelay: number };
+  }) => {
+    return input.incidentController.syncOpenIncidents(input.maxAttestationDelay);
+  },
+);
+
+export const incidentsMachine = setup({
+  types: {} as {
+    context: {
+      incidentController: IncidentController;
+      maxAttestationDelay: number;
+    };
+    events: { type: 'SNAPSHOT_UPDATED' };
+    input: {
+      incidentController: IncidentController;
+      maxAttestationDelay: number;
+    };
+  },
+  actors: {
+    runSync,
+  },
+}).createMachine({
+  id: 'Incidents',
+  initial: 'idle',
+  context: ({ input }) => ({
+    incidentController: input.incidentController,
+    maxAttestationDelay: input.maxAttestationDelay,
+  }),
+  states: {
+    idle: {
+      on: {
+        SNAPSHOT_UPDATED: {
+          target: 'syncing',
+        },
+      },
+    },
+    syncing: {
+      invoke: {
+        src: 'runSync',
+        input: ({ context }) => ({
+          incidentController: context.incidentController,
+          maxAttestationDelay: context.maxAttestationDelay,
+        }),
+        onDone: {
+          target: 'idle',
+          actions: [
+            pinoLog(
+              ({ event }) =>
+                `Incidents sync: opened=${event.output.opened}, updated=${event.output.updated}, closed=${event.output.closed}`,
+              'Incidents',
+            ),
+          ],
+        },
+        onError: {
+          target: 'idle',
+          actions: [
+            pinoLog(({ event }) => `Incidents sync error: ${event.error}`, 'Incidents', 'error'),
+          ],
+        },
+      },
+      on: {
+        SNAPSHOT_UPDATED: {
+          actions: [
+            pinoLog(
+              () => 'Ignoring SNAPSHOT_UPDATED - incident sync already in progress',
+              'Incidents',
+            ),
+          ],
+        },
+      },
+    },
+  },
+});

--- a/packages/indexer/src/xstate/incidents/index.ts
+++ b/packages/indexer/src/xstate/incidents/index.ts
@@ -1,0 +1,26 @@
+import { createActor } from 'xstate';
+
+import { incidentsMachine } from './incidents.machine.js';
+
+import { IncidentController } from '@/src/services/consensus/controllers/incident.js';
+import { logMachine } from '@/src/xstate/multiMachineLogger.js';
+
+export { incidentsMachine } from './incidents.machine.js';
+
+export const getIncidentsActor = (
+  incidentController: IncidentController,
+  maxAttestationDelay: number,
+) => {
+  const actor = createActor(incidentsMachine, {
+    input: {
+      incidentController,
+      maxAttestationDelay,
+    },
+  });
+
+  actor.subscribe((snapshot) => {
+    logMachine('incidents', `State: ${JSON.stringify(snapshot.value)}`);
+  });
+
+  return actor;
+};

--- a/packages/indexer/src/xstate/index.ts
+++ b/packages/indexer/src/xstate/index.ts
@@ -8,6 +8,7 @@ import {
 } from './archive/index.js';
 import { getChainStatsActor } from './chainStats/index.js';
 import { getCreateEpochActor, getEpochOrchestratorActor } from './epoch/index.js';
+import { getIncidentsActor } from './incidents/index.js';
 import { getLagAlertingActor } from './lagAlerting/index.js';
 import { getSnapshotActor } from './snapshot/index.js';
 
@@ -15,6 +16,7 @@ import { ChainStatsController } from '@/src/services/consensus/controllers/chain
 import { DailyArchiveController } from '@/src/services/consensus/controllers/dailyArchive.js';
 import { EpochController } from '@/src/services/consensus/controllers/epoch.js';
 import { HourlyArchiveController } from '@/src/services/consensus/controllers/hourlyArchive.js';
+import { IncidentController } from '@/src/services/consensus/controllers/incident.js';
 import { MonthlyArchiveController } from '@/src/services/consensus/controllers/monthlyArchive.js';
 import { PartitionController } from '@/src/services/consensus/controllers/partition.js';
 import { SlotController } from '@/src/services/consensus/controllers/slot.js';
@@ -33,6 +35,7 @@ export default function initXstateMachines(
   monthlyArchiveController: MonthlyArchiveController,
   chainStatsController: ChainStatsController,
   snapshotController: SnapshotController,
+  incidentController: IncidentController,
   chain: Chain,
   maxAttestationDelay: number,
   delaySlotsToHead: number,
@@ -72,8 +75,12 @@ export default function initXstateMachines(
   ).start();
 
   // Create and start snapshot actor (runs independently with its own timer)
+  const incidentsActor = getIncidentsActor(incidentController, maxAttestationDelay);
+  incidentsActor.start();
+
   const snapshotActor = getSnapshotActor(
     snapshotController,
+    incidentsActor,
     slotDuration,
     slotsPerEpoch,
     chain,

--- a/packages/indexer/src/xstate/snapshot/index.ts
+++ b/packages/indexer/src/xstate/snapshot/index.ts
@@ -1,15 +1,17 @@
 import type { Chain } from '@beacon-indexer/beacon-utils';
-import { createActor } from 'xstate';
+import { createActor, ActorRefFrom } from 'xstate';
 
 import { snapshotMachine } from './snapshot.machine.js';
 
 import { SnapshotController } from '@/src/services/consensus/controllers/snapshot.js';
+import { incidentsMachine } from '@/src/xstate/incidents/incidents.machine.js';
 import { logMachine } from '@/src/xstate/multiMachineLogger.js';
 
 export { snapshotMachine } from './snapshot.machine.js';
 
 export const getSnapshotActor = (
   snapshotController: SnapshotController,
+  incidentsActor: ActorRefFrom<typeof incidentsMachine>,
   slotDuration: number,
   slotsPerEpoch: number,
   chain: Chain,
@@ -20,6 +22,7 @@ export const getSnapshotActor = (
   const actor = createActor(snapshotMachine, {
     input: {
       snapshotController,
+      incidentsActor,
       slotDuration,
       slotsPerEpoch,
       chain,

--- a/packages/indexer/src/xstate/snapshot/snapshot.machine.ts
+++ b/packages/indexer/src/xstate/snapshot/snapshot.machine.ts
@@ -1,11 +1,13 @@
 import type { Chain } from '@beacon-indexer/beacon-utils';
-import { setup, fromPromise, assign } from 'xstate';
+import { setup, fromPromise, assign, sendTo, ActorRefFrom } from 'xstate';
 
 import { SnapshotController } from '@/src/services/consensus/controllers/snapshot.js';
+import { incidentsMachine } from '@/src/xstate/incidents/incidents.machine.js';
 import { pinoLog } from '@/src/xstate/pinoLog.js';
 
 type SnapshotContext = {
   snapshotController: SnapshotController;
+  incidentsActor: ActorRefFrom<typeof incidentsMachine>;
   slotDuration: number;
   slotsPerEpoch: number;
   chain: Chain;
@@ -118,6 +120,7 @@ export const snapshotMachine = setup({
     context: SnapshotContext;
     input: {
       snapshotController: SnapshotController;
+      incidentsActor: ActorRefFrom<typeof incidentsMachine>;
       slotDuration: number;
       slotsPerEpoch: number;
       chain: Chain;
@@ -137,6 +140,7 @@ export const snapshotMachine = setup({
   initial: 'waiting',
   context: ({ input }) => ({
     snapshotController: input.snapshotController,
+    incidentsActor: input.incidentsActor,
     slotDuration: input.slotDuration,
     slotsPerEpoch: input.slotsPerEpoch,
     chain: input.chain,
@@ -173,6 +177,7 @@ export const snapshotMachine = setup({
               lastMUpdate: ({ event }) => event.output.lastMUpdate,
               lastNewValidatorCheck: ({ event }) => event.output.lastNewValidatorCheck,
             }),
+            sendTo(({ context }) => context.incidentsActor, { type: 'SNAPSHOT_UPDATED' as const }),
             pinoLog(({ event }) => {
               const levels = event.output.updatedLevels;
               return `Snapshot tick: updated [${levels.join(', ')}]`;

--- a/packages/telegram-bot/src/telegram/format-notification.ts
+++ b/packages/telegram-bot/src/telegram/format-notification.ts
@@ -1,6 +1,22 @@
 type NotificationFormatter = (payload: unknown) => string;
 
-const notificationFormatters: Record<string, NotificationFormatter> = {};
+type IncidentPayload = {
+  clusterName?: string;
+  closedAt?: string;
+  closedSlot?: number;
+  durationSeconds?: number;
+  durationSlots?: number;
+  missedAttestations?: number;
+  missedConsensusRewards?: string;
+  openedAt?: string;
+  openedSlot?: number;
+  validatorIndexes?: number[];
+};
+
+const notificationFormatters: Record<string, NotificationFormatter> = {
+  incident_opened: (payload) => formatIncidentOpened(payload),
+  incident_closed: (payload) => formatIncidentClosed(payload),
+};
 
 export function formatNotificationMessage(type: string, payload: unknown): string {
   const formatter = notificationFormatters[type];
@@ -24,4 +40,62 @@ function formatNotificationPayload(payload: unknown): string {
   if (payload === null || payload === undefined) return '';
 
   return JSON.stringify(payload, null, 2);
+}
+
+function formatIncidentOpened(payload: unknown): string {
+  const data = asIncidentPayload(payload);
+  const validators = formatValidatorIndexes(data.validatorIndexes);
+
+  return [
+    'Cluster incident opened',
+    `Cluster: ${data.clusterName ?? 'Unknown cluster'}`,
+    `Started slot: ${data.openedSlot ?? '-'}`,
+    `Started at: ${data.openedAt ?? '-'}`,
+    `Affected validators: ${validators}`,
+  ].join('\n');
+}
+
+function formatIncidentClosed(payload: unknown): string {
+  const data = asIncidentPayload(payload);
+  const validators = formatValidatorIndexes(data.validatorIndexes);
+
+  return [
+    'Cluster incident resolved',
+    `Cluster: ${data.clusterName ?? 'Unknown cluster'}`,
+    `Closed slot: ${data.closedSlot ?? '-'}`,
+    `Closed at: ${data.closedAt ?? '-'}`,
+    `Duration: ${formatDuration(data.durationSeconds)} (${data.durationSlots ?? 0} slots)`,
+    `Missed attestations: ${data.missedAttestations ?? 0}`,
+    `Missed rewards: ${data.missedConsensusRewards ?? '0'}`,
+    `Affected validators: ${validators}`,
+  ].join('\n');
+}
+
+function asIncidentPayload(payload: unknown): IncidentPayload {
+  if (typeof payload === 'object' && payload !== null) {
+    return payload as IncidentPayload;
+  }
+
+  return {};
+}
+
+function formatValidatorIndexes(indexes: number[] | undefined): string {
+  if (!indexes?.length) return '-';
+  return indexes.join(', ');
+}
+
+function formatDuration(durationSeconds: number | undefined): string {
+  if (!durationSeconds || durationSeconds <= 0) return '0s';
+
+  const hours = Math.floor(durationSeconds / 3600);
+  const minutes = Math.floor((durationSeconds % 3600) / 60);
+  const seconds = durationSeconds % 60;
+
+  const parts = [
+    hours > 0 ? `${hours}h` : null,
+    minutes > 0 ? `${minutes}m` : null,
+    seconds > 0 ? `${seconds}s` : null,
+  ].filter(Boolean);
+
+  return parts.join(' ');
 }


### PR DESCRIPTION
## What changed
This PR adds Telegram bot formatting for cluster incident notifications.

It teaches the bot how to render `incident_opened` and `incident_closed` notification payloads produced by the core incidents pipeline.

## Why
The core incidents flow already enqueues notifications. This PR keeps the user-facing message formatting review separate from persistence and API review.

## Impact
- Formats incident-opened alerts
- Formats incident-closed alerts with duration, missed attestations, rewards, and affected validators

## Validation
- `pnpm --filter telegram-bot exec tsc --noEmit`

## Stack
Depends on #161.
