### PR TITLE
add cluster incident api endpoints

### DIFF
--- a/packages/api/AGENTS.md
+++ b/packages/api/AGENTS.md
@@ -61,7 +61,8 @@ Only use pagination for UI listings (validators, events, history). Stats aggrega
 ## Backend conventions
 
 - Validate all inputs with Zod.
-- **Use raw SQL** for performance-critical queries, not Prisma models.
+- Use Prisma models when the operation can be resolved with one Prisma query.
+- Use raw SQL for performance-critical operations that would require more than one Prisma query.
 
 ## Storage
 

--- a/packages/api/AGENTS.md
+++ b/packages/api/AGENTS.md
@@ -61,6 +61,10 @@ Only use pagination for UI listings (validators, events, history). Stats aggrega
 ## Backend conventions
 
 - Validate all inputs with Zod.
+- Authentication is implemented in the API.
+- Use `securedProcedure` for API endpoints by default.
+- Use `publicProcedure` only for explicitly public endpoints, such as health checks.
+- Use narrower auth wrappers like `botProcedure` or `apiKeyProcedure` when an endpoint must require a specific auth strategy.
 - Use Prisma models when the operation can be resolved with one Prisma query.
 - Use raw SQL for performance-critical operations that would require more than one Prisma query.
 

--- a/packages/api/e2e/helpers.ts
+++ b/packages/api/e2e/helpers.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 /**
  * E2E test API token — must match API_TOKEN_SECRET env var.
  * Used to authenticate test requests that don't need a user in context.
@@ -28,6 +30,34 @@ export function userAuthHeaders(extra?: Record<string, string>): Record<string, 
   return {
     'ns-anonymous-id': E2E_SESSION_ID,
     Origin: process.env.ALLOWED_ORIGINS?.split(',')[0]?.trim() || 'http://localhost:3000',
+    ...extra,
+  };
+}
+
+/**
+ * Returns headers with bot-signature auth for endpoints called by the telegram bot.
+ * Uses the same HMAC format as the production bot client.
+ */
+export function botAuthHeaders(
+  telegramId: string,
+  extra?: Record<string, string>,
+): Record<string, string> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+
+  if (!token) {
+    throw new Error('TELEGRAM_BOT_TOKEN is not set');
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = crypto
+    .createHmac('sha256', token)
+    .update(`${telegramId}:${timestamp}`)
+    .digest('hex');
+
+  return {
+    'bot-signature': signature,
+    'bot-user-id': telegramId,
+    'bot-timestamp': timestamp,
     ...extra,
   };
 }

--- a/packages/api/e2e/incidents.test.ts
+++ b/packages/api/e2e/incidents.test.ts
@@ -1,0 +1,492 @@
+import { createServer } from 'node:http';
+
+import { PrismaClient } from '@beacon-indexer/db';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { botAuthHeaders, E2E_SESSION_ID, userAuthHeaders } from './helpers.js';
+
+import { createHttpServer } from '@/server.js';
+import type { ApiResponse } from '@/utils/response.js';
+
+type IncidentListItem = {
+  id: string;
+  status: 'open' | 'closed';
+  openedAt: string;
+  openedSlot: number;
+  closedAt: string | null;
+  closedSlot: number | null;
+  durationSlots: number | null;
+  durationSeconds: number | null;
+  missedAttestationRewards: string | null;
+  missedSyncRewards: string | null;
+  missedConsensusRewards: string | null;
+  rewardsFinalized: boolean;
+  rewardsFinalizedAt: string | null;
+  openedNotificationQueuedAt: string | null;
+  closedNotificationQueuedAt: string | null;
+};
+
+type IncidentListPayload = {
+  incidents: IncidentListItem[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+};
+
+type IncidentAffectedValidator = {
+  validatorIndex: number;
+  inactiveFromSlot: number;
+  inactiveToSlot: number | null;
+  rewardsProcessedThroughSlot: number | null;
+  missedAttestationRewards: string;
+  missedSyncRewards: string;
+  missedConsensusRewards: string;
+};
+
+type IncidentAffectedValidatorsPayload = {
+  validators: IncidentAffectedValidator[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+};
+
+type IncidentNotificationPayload = {
+  incidentId: string;
+  notifiedAt: string;
+};
+
+describe('Incident API E2E Tests', () => {
+  let prisma: PrismaClient;
+  let server: ReturnType<typeof createServer>;
+  let baseUrl: string;
+
+  // This user matches the anonymous auth helper used in API tests.
+  const anonymousOwnerId = 'e2e-test-owner-id';
+  // This user exercises bot-signature auth through bot-user-id resolution.
+  const botOwnerId = 'e2e-bot-owner-id';
+  const botTelegramId = '123456789';
+  // This second bot user proves ownership checks reject foreign clusters.
+  const foreignBotOwnerId = 'e2e-bot-owner-id-2';
+  const foreignBotTelegramId = '987654321';
+
+  beforeAll(async () => {
+    // This suite requires the configured test database.
+    if (!process.env.DATABASE_URL) {
+      throw new Error('DATABASE_URL is not set');
+    }
+
+    // This Prisma client points at the same database used by the API server.
+    prisma = new PrismaClient({
+      datasources: {
+        db: {
+          url: process.env.DATABASE_URL,
+        },
+      },
+    });
+
+    // This connection lets the suite seed and verify database state directly.
+    await prisma.$connect();
+
+    // This user supports the existing anonymous-session auth flow.
+    await prisma.user.upsert({
+      where: { id: anonymousOwnerId },
+      update: {},
+      create: {
+        id: anonymousOwnerId,
+        username: `anon:${E2E_SESSION_ID}`,
+      },
+    });
+
+    // This user supports bot-signature requests for owned resources.
+    await prisma.user.upsert({
+      where: { id: botOwnerId },
+      update: {
+        telegramId: BigInt(botTelegramId),
+        username: 'incident-bot-owner',
+      },
+      create: {
+        id: botOwnerId,
+        telegramId: BigInt(botTelegramId),
+        username: 'incident-bot-owner',
+      },
+    });
+
+    // This user supports foreign bot-signature requests for auth rejection checks.
+    await prisma.user.upsert({
+      where: { id: foreignBotOwnerId },
+      update: {
+        telegramId: BigInt(foreignBotTelegramId),
+        username: 'incident-bot-foreign-owner',
+      },
+      create: {
+        id: foreignBotOwnerId,
+        telegramId: BigInt(foreignBotTelegramId),
+        username: 'incident-bot-foreign-owner',
+      },
+    });
+
+    // This server instance exposes the same REST handlers used in production.
+    server = createHttpServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+
+        // This local URL is used by every request in the suite.
+        if (address && typeof address === 'object') {
+          baseUrl = `http://127.0.0.1:${address.port}`;
+        }
+
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    // This cleanup resets incident rows between scenarios.
+    await prisma.clusterIncidentValidator.deleteMany({});
+    await prisma.clusterIncident.deleteMany({});
+    await prisma.clusterValidator.deleteMany({});
+    await prisma.cluster.deleteMany({
+      where: {
+        ownerId: {
+          in: [anonymousOwnerId, botOwnerId, foreignBotOwnerId],
+        },
+      },
+    });
+    await prisma.validator.deleteMany({
+      where: {
+        id: {
+          in: [101, 102, 103, 104, 105],
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    // This closes the HTTP server before disconnecting the test database.
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    // This disconnect prevents hanging Vitest workers.
+    await prisma.$disconnect();
+  });
+
+  /**
+   * This helper creates a validator row used by incident interval records.
+   */
+  async function seedValidator(validatorIndex: number) {
+    await prisma.validator.upsert({
+      where: { id: validatorIndex },
+      update: {},
+      create: {
+        id: validatorIndex,
+        balance: BigInt(32_000_000_000),
+      },
+    });
+  }
+
+  describe('GET /clusters/:id/incidents', () => {
+    it('returns paginated incidents ordered by newest first', async () => {
+      // This cluster owns the incident history returned by the endpoint.
+      const cluster = await prisma.cluster.create({
+        data: {
+          id: 'cluster-incidents-list',
+          name: 'Incident History',
+          ownerId: anonymousOwnerId,
+          visibility: 'private',
+        },
+      });
+
+      // This older incident exercises second-page pagination.
+      await prisma.clusterIncident.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000111',
+          clusterId: cluster.id,
+          status: 'closed',
+          openedAt: new Date('2025-01-01T00:00:00.000Z'),
+          openedSlot: 100,
+          closedAt: new Date('2025-01-01T01:00:00.000Z'),
+          closedSlot: 200,
+          durationSlots: 100,
+          durationSeconds: 3600,
+          missedAttestationRewards: BigInt(10),
+          missedSyncRewards: BigInt(5),
+          missedConsensusRewards: BigInt(15),
+          rewardsFinalized: true,
+          rewardsFinalizedAt: new Date('2025-01-01T01:05:00.000Z'),
+        },
+      });
+
+      // This newer incident exercises first-page ordering.
+      await prisma.clusterIncident.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000222',
+          clusterId: cluster.id,
+          status: 'open',
+          openedAt: new Date('2025-01-02T00:00:00.000Z'),
+          openedSlot: 300,
+          missedAttestationRewards: BigInt(20),
+          missedSyncRewards: BigInt(7),
+          missedConsensusRewards: BigInt(27),
+        },
+      });
+
+      // This request reads only one incident to force pagination metadata.
+      const response = await fetch(
+        `${baseUrl}/clusters/${cluster.id}/incidents?page=1&pageSize=1`,
+        {
+          headers: userAuthHeaders(),
+        },
+      );
+
+      // This assertion confirms the route exists and returns a wrapped payload.
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ApiResponse<IncidentListPayload>;
+
+      // This verifies the page shape and first-page ordering.
+      expect(body.success).toBe(true);
+      expect(body.data?.totalCount).toBe(2);
+      expect(body.data?.page).toBe(1);
+      expect(body.data?.pageSize).toBe(1);
+      expect(body.data?.incidents).toHaveLength(1);
+      expect(body.data?.incidents[0]?.id).toBe('00000000-0000-4000-8000-000000000222');
+      expect(body.data?.incidents[0]?.missedConsensusRewards).toBe('0.00000000084375');
+    });
+  });
+
+  describe('POST /clusters/:id/incidents/opened-notified', () => {
+    it('updates the open incident notification timestamp for bot-authenticated calls', async () => {
+      // This cluster belongs to the user resolved from bot-user-id.
+      const cluster = await prisma.cluster.create({
+        data: {
+          id: 'cluster-open-notified',
+          name: 'Open Incident',
+          ownerId: botOwnerId,
+          visibility: 'private',
+        },
+      });
+
+      // This open incident should receive the latest notification timestamp.
+      const incident = await prisma.clusterIncident.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000333',
+          clusterId: cluster.id,
+          status: 'open',
+          openedAt: new Date('2025-01-03T00:00:00.000Z'),
+          openedSlot: 400,
+          openedNotificationQueuedAt: new Date('2025-01-03T01:00:00.000Z'),
+        },
+      });
+
+      // This request simulates the telegram bot resending an open notification.
+      const response = await fetch(`${baseUrl}/clusters/${cluster.id}/incidents/opened-notified`, {
+        method: 'POST',
+        headers: botAuthHeaders(botTelegramId, {
+          'Content-Type': 'application/json',
+        }),
+      });
+
+      // This assertion confirms the endpoint accepts bot-signature auth.
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ApiResponse<IncidentNotificationPayload>;
+
+      // This verifies the response exposes the updated incident id and timestamp.
+      expect(body.success).toBe(true);
+      expect(body.data?.incidentId).toBe(incident.id);
+      expect(body.data?.notifiedAt).toBeTruthy();
+
+      // This query confirms the timestamp was overwritten in the database.
+      const reloaded = await prisma.clusterIncident.findUniqueOrThrow({
+        where: { id: incident.id },
+      });
+      expect(reloaded.openedNotificationQueuedAt?.toISOString()).toBe(body.data?.notifiedAt);
+      expect(reloaded.openedNotificationQueuedAt?.getTime()).toBeGreaterThan(
+        incident.openedNotificationQueuedAt!.getTime(),
+      );
+    });
+
+    it('rejects a cluster owned by another user', async () => {
+      // This cluster belongs to a different bot-authenticated user.
+      const cluster = await prisma.cluster.create({
+        data: {
+          id: 'cluster-open-notified-foreign',
+          name: 'Foreign Open Incident',
+          ownerId: botOwnerId,
+          visibility: 'private',
+        },
+      });
+
+      // This incident exists but should stay inaccessible to the foreign bot user.
+      await prisma.clusterIncident.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000334',
+          clusterId: cluster.id,
+          status: 'open',
+          openedAt: new Date('2025-01-03T00:00:00.000Z'),
+          openedSlot: 401,
+        },
+      });
+
+      // This request uses a different bot-user-id than the cluster owner.
+      const response = await fetch(`${baseUrl}/clusters/${cluster.id}/incidents/opened-notified`, {
+        method: 'POST',
+        headers: botAuthHeaders(foreignBotTelegramId, {
+          'Content-Type': 'application/json',
+        }),
+      });
+
+      // This assertion confirms unauthorized bot access is rejected.
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ApiResponse<IncidentNotificationPayload>;
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe('POST /clusters/incidents/:incidentId/closed-notified', () => {
+    it('updates the closed incident notification timestamp for bot-authenticated calls', async () => {
+      // This cluster belongs to the bot-resolved owner.
+      const cluster = await prisma.cluster.create({
+        data: {
+          id: 'cluster-closed-notified',
+          name: 'Closed Incident',
+          ownerId: botOwnerId,
+          visibility: 'private',
+        },
+      });
+
+      // This closed incident should receive the latest close notification timestamp.
+      const incident = await prisma.clusterIncident.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000444',
+          clusterId: cluster.id,
+          status: 'closed',
+          openedAt: new Date('2025-01-04T00:00:00.000Z'),
+          openedSlot: 500,
+          closedAt: new Date('2025-01-04T02:00:00.000Z'),
+          closedSlot: 520,
+        },
+      });
+
+      // This request records the latest bot send time for the closed incident.
+      const response = await fetch(`${baseUrl}/clusters/incidents/${incident.id}/closed-notified`, {
+        method: 'POST',
+        headers: botAuthHeaders(botTelegramId, {
+          'Content-Type': 'application/json',
+        }),
+      });
+
+      // This assertion confirms the endpoint updates the target incident.
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ApiResponse<IncidentNotificationPayload>;
+      expect(body.success).toBe(true);
+      expect(body.data?.incidentId).toBe(incident.id);
+
+      // This query confirms the closed-notified timestamp persisted.
+      const reloaded = await prisma.clusterIncident.findUniqueOrThrow({
+        where: { id: incident.id },
+      });
+      expect(reloaded.closedNotificationQueuedAt?.toISOString()).toBe(body.data?.notifiedAt);
+    });
+  });
+
+  describe('GET /clusters/incidents/:incidentId/affected-validators', () => {
+    it('returns paginated affected validators ordered by validator index', async () => {
+      // This cluster owns the incident validator rows returned by the endpoint.
+      const cluster = await prisma.cluster.create({
+        data: {
+          id: 'cluster-affected-validators',
+          name: 'Affected Validators',
+          ownerId: botOwnerId,
+          visibility: 'private',
+        },
+      });
+
+      // These validator rows back the incident interval records.
+      await seedValidator(101);
+      await seedValidator(102);
+      await seedValidator(103);
+
+      // This incident groups the validator intervals returned by the endpoint.
+      const incident = await prisma.clusterIncident.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000555',
+          clusterId: cluster.id,
+          status: 'closed',
+          openedAt: new Date('2025-01-05T00:00:00.000Z'),
+          openedSlot: 600,
+          closedAt: new Date('2025-01-05T03:00:00.000Z'),
+          closedSlot: 630,
+        },
+      });
+
+      // This first row should land on page one.
+      await prisma.clusterIncidentValidator.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000561',
+          incidentId: incident.id,
+          validatorIndex: 101,
+          inactiveFromSlot: 600,
+          inactiveToSlot: 610,
+          rewardsProcessedThroughSlot: 610,
+          missedAttestationRewards: BigInt(10),
+          missedSyncRewards: BigInt(0),
+          missedConsensusRewards: BigInt(10),
+        },
+      });
+
+      // This second row should land on page one after sorting.
+      await prisma.clusterIncidentValidator.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000562',
+          incidentId: incident.id,
+          validatorIndex: 102,
+          inactiveFromSlot: 601,
+          inactiveToSlot: 611,
+          rewardsProcessedThroughSlot: 611,
+          missedAttestationRewards: BigInt(11),
+          missedSyncRewards: BigInt(1),
+          missedConsensusRewards: BigInt(12),
+        },
+      });
+
+      // This third row should move to page two.
+      await prisma.clusterIncidentValidator.create({
+        data: {
+          id: '00000000-0000-4000-8000-000000000563',
+          incidentId: incident.id,
+          validatorIndex: 103,
+          inactiveFromSlot: 602,
+          inactiveToSlot: 612,
+          rewardsProcessedThroughSlot: 612,
+          missedAttestationRewards: BigInt(12),
+          missedSyncRewards: BigInt(2),
+          missedConsensusRewards: BigInt(14),
+        },
+      });
+
+      // This request reads only two validators to force pagination.
+      const response = await fetch(
+        `${baseUrl}/clusters/incidents/${incident.id}/affected-validators?page=1&pageSize=2`,
+        {
+          headers: botAuthHeaders(botTelegramId),
+        },
+      );
+
+      // This assertion confirms the route returns a paginated validator list.
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ApiResponse<IncidentAffectedValidatorsPayload>;
+
+      // This verifies pagination metadata and index ordering.
+      expect(body.success).toBe(true);
+      expect(body.data?.totalCount).toBe(3);
+      expect(body.data?.page).toBe(1);
+      expect(body.data?.pageSize).toBe(2);
+      expect(body.data?.validators.map((row) => row.validatorIndex)).toEqual([101, 102]);
+      expect(body.data?.validators[0]?.missedConsensusRewards).toBe('0.0000000003125');
+    });
+  });
+});

--- a/packages/api/src/routers/cluster/incidents.ts
+++ b/packages/api/src/routers/cluster/incidents.ts
@@ -1,0 +1,349 @@
+import { z } from 'zod';
+
+import {
+  ClusterIncidentAffectedValidatorsInputSchema,
+  ClusterIncidentAffectedValidatorsResponseSchema,
+  ClusterIncidentIdParamSchema,
+  ClusterIncidentNotificationSchema,
+  ClusterIncidentsInputSchema,
+  ClusterIncidentsResponseSchema,
+} from './schemas.js';
+
+import { securedProcedure } from '@/lib/procedures.js';
+import { IncidentStorage } from '@/storage/incident.js';
+import { ApiResponseSchema } from '@/utils/response.js';
+import { formatBalance } from '@/utils/tokenFormat.js';
+
+const incidentStorage = new IncidentStorage();
+const ClusterIncidentsApiResponseSchema = ApiResponseSchema(ClusterIncidentsResponseSchema);
+const ClusterIncidentNotificationApiResponseSchema = ApiResponseSchema(
+  ClusterIncidentNotificationSchema,
+);
+const ClusterIncidentAffectedValidatorsApiResponseSchema = ApiResponseSchema(
+  ClusterIncidentAffectedValidatorsResponseSchema,
+);
+
+type ClusterIncidentsApiResponse = z.infer<typeof ClusterIncidentsApiResponseSchema>;
+type ClusterIncidentNotificationApiResponse = z.infer<
+  typeof ClusterIncidentNotificationApiResponseSchema
+>;
+type ClusterIncidentAffectedValidatorsApiResponse = z.infer<
+  typeof ClusterIncidentAffectedValidatorsApiResponseSchema
+>;
+
+/**
+ * Returns a success response for a missing authenticated user.
+ */
+function missingUserResponse(): ClusterIncidentsApiResponse {
+  return {
+    success: false,
+    error: {
+      code: 'UNAUTHORIZED',
+      message: 'Authenticated user is required for this endpoint',
+    },
+    meta: { timestamp: new Date().toISOString() },
+  };
+}
+
+/**
+ * Returns a success response for a missing authenticated user on notification routes.
+ */
+function missingNotificationUserResponse(): ClusterIncidentNotificationApiResponse {
+  return {
+    success: false,
+    error: {
+      code: 'UNAUTHORIZED',
+      message: 'Authenticated user is required for this endpoint',
+    },
+    meta: { timestamp: new Date().toISOString() },
+  };
+}
+
+/**
+ * Returns a success response for a missing authenticated user on validator routes.
+ */
+function missingValidatorsUserResponse(): ClusterIncidentAffectedValidatorsApiResponse {
+  return {
+    success: false,
+    error: {
+      code: 'UNAUTHORIZED',
+      message: 'Authenticated user is required for this endpoint',
+    },
+    meta: { timestamp: new Date().toISOString() },
+  };
+}
+
+/**
+ * Lists incidents for one owned cluster.
+ */
+export const listClusterIncidents = securedProcedure
+  .route({ method: 'GET', path: '/clusters/{id}/incidents' })
+  .input(ClusterIncidentsInputSchema)
+  .output(ClusterIncidentsApiResponseSchema)
+  .handler(async ({ input, context }) => {
+    if (!context.user) {
+      return missingUserResponse();
+    }
+
+    try {
+      const { rows, totalCount } = await incidentStorage.listClusterIncidents({
+        ownerId: context.user.id,
+        clusterId: input.id,
+        page: input.page,
+        pageSize: input.pageSize,
+      });
+
+      // This fallback distinguishes an empty page from an unknown or foreign cluster.
+      if (rows.length === 0) {
+        const isOwnedCluster = await incidentStorage.isOwnedCluster({
+          ownerId: context.user.id,
+          clusterId: input.id,
+        });
+
+        if (!isOwnedCluster) {
+          return {
+            success: false,
+            error: {
+              code: 'CLUSTER_NOT_FOUND',
+              message: `Cluster with id ${input.id} not found`,
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          incidents: rows.map((row) => ({
+            id: row.id,
+            status: row.status,
+            openedAt: row.opened_at.toISOString(),
+            openedSlot: row.opened_slot,
+            closedAt: row.closed_at?.toISOString() ?? null,
+            closedSlot: row.closed_slot,
+            durationSlots: row.duration_slots,
+            durationSeconds: row.duration_seconds,
+            missedAttestationRewards:
+              row.missed_attestation_rewards !== null
+                ? formatBalance(row.missed_attestation_rewards)
+                : null,
+            missedSyncRewards:
+              row.missed_sync_rewards !== null ? formatBalance(row.missed_sync_rewards) : null,
+            missedConsensusRewards:
+              row.missed_consensus_rewards !== null
+                ? formatBalance(row.missed_consensus_rewards)
+                : null,
+            rewardsFinalized: row.rewards_finalized,
+            rewardsFinalizedAt: row.rewards_finalized_at?.toISOString() ?? null,
+            openedNotificationQueuedAt: row.opened_notification_queued_at?.toISOString() ?? null,
+            closedNotificationQueuedAt: row.closed_notification_queued_at?.toISOString() ?? null,
+          })),
+          totalCount,
+          page: input.page,
+          pageSize: input.pageSize,
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: 'CLUSTER_INCIDENTS_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to fetch cluster incidents',
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    }
+  });
+
+/**
+ * Updates the send timestamp for the current open incident in a cluster.
+ */
+export const markClusterIncidentOpenedNotified = securedProcedure
+  .route({ method: 'POST', path: '/clusters/{id}/incidents/opened-notified' })
+  .input(ClusterIncidentsInputSchema.pick({ id: true }))
+  .output(ClusterIncidentNotificationApiResponseSchema)
+  .handler(async ({ input, context }) => {
+    if (!context.user) {
+      return missingNotificationUserResponse();
+    }
+
+    try {
+      const notifiedAt = new Date();
+      const updatedIncident = await incidentStorage.markOpenIncidentNotified({
+        ownerId: context.user.id,
+        clusterId: input.id,
+        notifiedAt,
+      });
+
+      if (!updatedIncident) {
+        return {
+          success: false,
+          error: {
+            code: 'OPEN_INCIDENT_NOT_FOUND',
+            message: `No open incident found for cluster ${input.id}`,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          incidentId: updatedIncident.incident_id,
+          notifiedAt: updatedIncident.opened_notification_queued_at.toISOString(),
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: 'MARK_OPEN_INCIDENT_NOTIFIED_ERROR',
+          message:
+            error instanceof Error ? error.message : 'Failed to update open incident notification',
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    }
+  });
+
+/**
+ * Updates the send timestamp for a closed incident.
+ */
+export const markClusterIncidentClosedNotified = securedProcedure
+  .route({ method: 'POST', path: '/clusters/incidents/{incidentId}/closed-notified' })
+  .input(ClusterIncidentIdParamSchema)
+  .output(ClusterIncidentNotificationApiResponseSchema)
+  .handler(async ({ input, context }) => {
+    if (!context.user) {
+      return missingNotificationUserResponse();
+    }
+
+    try {
+      const notifiedAt = new Date();
+      const updatedIncident = await incidentStorage.markClosedIncidentNotified({
+        ownerId: context.user.id,
+        incidentId: input.incidentId,
+        notifiedAt,
+      });
+
+      if (!updatedIncident) {
+        const incidentStatus = await incidentStorage.getOwnedIncidentStatus({
+          ownerId: context.user.id,
+          incidentId: input.incidentId,
+        });
+
+        if (!incidentStatus) {
+          return {
+            success: false,
+            error: {
+              code: 'INCIDENT_NOT_FOUND',
+              message: `Incident with id ${input.incidentId} not found`,
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+
+        return {
+          success: false,
+          error: {
+            code: 'INCIDENT_NOT_CLOSED',
+            message: `Incident with id ${input.incidentId} is not closed`,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          incidentId: updatedIncident.incident_id,
+          notifiedAt: updatedIncident.closed_notification_queued_at.toISOString(),
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: 'MARK_CLOSED_INCIDENT_NOTIFIED_ERROR',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Failed to update closed incident notification',
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    }
+  });
+
+/**
+ * Lists affected validators for one owned incident.
+ */
+export const listIncidentAffectedValidators = securedProcedure
+  .route({ method: 'GET', path: '/clusters/incidents/{incidentId}/affected-validators' })
+  .input(ClusterIncidentAffectedValidatorsInputSchema)
+  .output(ClusterIncidentAffectedValidatorsApiResponseSchema)
+  .handler(async ({ input, context }) => {
+    if (!context.user) {
+      return missingValidatorsUserResponse();
+    }
+
+    try {
+      const { rows, totalCount } = await incidentStorage.listIncidentAffectedValidators({
+        ownerId: context.user.id,
+        incidentId: input.incidentId,
+        page: input.page,
+        pageSize: input.pageSize,
+      });
+
+      // This fallback distinguishes an empty page from an unknown or foreign incident.
+      if (rows.length === 0) {
+        const isOwnedIncident = await incidentStorage.isOwnedIncident({
+          ownerId: context.user.id,
+          incidentId: input.incidentId,
+        });
+
+        if (!isOwnedIncident) {
+          return {
+            success: false,
+            error: {
+              code: 'INCIDENT_NOT_FOUND',
+              message: `Incident with id ${input.incidentId} not found`,
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+      }
+
+      return {
+        success: true,
+        data: {
+          validators: rows.map((row) => ({
+            validatorIndex: row.validator_index,
+            inactiveFromSlot: row.inactive_from_slot,
+            inactiveToSlot: row.inactive_to_slot,
+            rewardsProcessedThroughSlot: row.rewards_processed_through_slot,
+            missedAttestationRewards: formatBalance(row.missed_attestation_rewards),
+            missedSyncRewards: formatBalance(row.missed_sync_rewards),
+            missedConsensusRewards: formatBalance(row.missed_consensus_rewards),
+          })),
+          totalCount,
+          page: input.page,
+          pageSize: input.pageSize,
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          code: 'INCIDENT_AFFECTED_VALIDATORS_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to fetch affected validators',
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    }
+  });

--- a/packages/api/src/routers/cluster/index.ts
+++ b/packages/api/src/routers/cluster/index.ts
@@ -2,6 +2,12 @@ import { addValidators } from './addValidators.js';
 import { createCluster } from './create.js';
 import { deleteCluster } from './delete.js';
 import { getCluster } from './get.js';
+import {
+  listIncidentAffectedValidators,
+  listClusterIncidents,
+  markClusterIncidentClosedNotified,
+  markClusterIncidentOpenedNotified,
+} from './incidents.js';
 import { listClusters } from './list.js';
 import {
   getClusterMissedAttestations,
@@ -20,6 +26,10 @@ export const clusterRouter = {
   delete: deleteCluster,
   addValidators,
   removeValidators,
+  incidents: listClusterIncidents,
+  incidentAffectedValidators: listIncidentAffectedValidators,
+  setIncidentClosedNotified: markClusterIncidentClosedNotified,
+  setIncidentOpenedNotified: markClusterIncidentOpenedNotified,
   snapshot: getClusterSnapshot,
   missedAttestations: getClusterMissedAttestations,
   allMissedAttestations: getAllClustersMissedAttestations,

--- a/packages/api/src/routers/cluster/schemas.ts
+++ b/packages/api/src/routers/cluster/schemas.ts
@@ -37,6 +37,121 @@ export const ClusterIdParamSchema = z.object({
 export type ClusterIdParam = z.infer<typeof ClusterIdParamSchema>;
 
 /**
+ * Shared pagination schema for cluster incident listings.
+ */
+export const ClusterIncidentPaginationSchema = z.object({
+  page: z.coerce.number().int().positive().default(1),
+  pageSize: z.coerce.number().int().positive().max(100).default(10),
+});
+
+export type ClusterIncidentPagination = z.infer<typeof ClusterIncidentPaginationSchema>;
+
+/**
+ * Incident ID path parameter schema.
+ */
+export const ClusterIncidentIdParamSchema = z.object({
+  incidentId: z.string().uuid(),
+});
+
+export type ClusterIncidentIdParam = z.infer<typeof ClusterIncidentIdParamSchema>;
+
+/**
+ * List incidents input schema.
+ */
+export const ClusterIncidentsInputSchema = ClusterIdParamSchema.extend(
+  ClusterIncidentPaginationSchema.shape,
+);
+
+export type ClusterIncidentsInput = z.infer<typeof ClusterIncidentsInputSchema>;
+
+/**
+ * Cluster incident response item schema.
+ */
+export const ClusterIncidentSchema = z.object({
+  id: z.string(),
+  status: z.enum(['open', 'closed']),
+  openedAt: z.string(),
+  openedSlot: z.number(),
+  closedAt: z.string().nullable(),
+  closedSlot: z.number().nullable(),
+  durationSlots: z.number().nullable(),
+  durationSeconds: z.number().nullable(),
+  missedAttestationRewards: z.string().nullable(),
+  missedSyncRewards: z.string().nullable(),
+  missedConsensusRewards: z.string().nullable(),
+  rewardsFinalized: z.boolean(),
+  rewardsFinalizedAt: z.string().nullable(),
+  openedNotificationQueuedAt: z.string().nullable(),
+  closedNotificationQueuedAt: z.string().nullable(),
+});
+
+export type ClusterIncident = z.infer<typeof ClusterIncidentSchema>;
+
+/**
+ * Paginated cluster incidents response schema.
+ */
+export const ClusterIncidentsResponseSchema = z.object({
+  incidents: z.array(ClusterIncidentSchema),
+  totalCount: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+
+export type ClusterIncidentsResponse = z.infer<typeof ClusterIncidentsResponseSchema>;
+
+/**
+ * Incident notification update response schema.
+ */
+export const ClusterIncidentNotificationSchema = z.object({
+  incidentId: z.string(),
+  notifiedAt: z.string(),
+});
+
+export type ClusterIncidentNotification = z.infer<typeof ClusterIncidentNotificationSchema>;
+
+/**
+ * Affected validators list input schema.
+ */
+export const ClusterIncidentAffectedValidatorsInputSchema = ClusterIncidentIdParamSchema.extend(
+  ClusterIncidentPaginationSchema.shape,
+);
+
+export type ClusterIncidentAffectedValidatorsInput = z.infer<
+  typeof ClusterIncidentAffectedValidatorsInputSchema
+>;
+
+/**
+ * Affected validator response item schema.
+ */
+export const ClusterIncidentAffectedValidatorSchema = z.object({
+  validatorIndex: z.number(),
+  inactiveFromSlot: z.number(),
+  inactiveToSlot: z.number().nullable(),
+  rewardsProcessedThroughSlot: z.number().nullable(),
+  missedAttestationRewards: z.string(),
+  missedSyncRewards: z.string(),
+  missedConsensusRewards: z.string(),
+});
+
+export type ClusterIncidentAffectedValidator = z.infer<
+  typeof ClusterIncidentAffectedValidatorSchema
+>;
+
+/**
+ * Paginated affected validators response schema.
+ */
+export const ClusterIncidentAffectedValidatorsResponseSchema = z.object({
+  validators: z.array(ClusterIncidentAffectedValidatorSchema),
+  totalCount: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});
+
+export type ClusterIncidentAffectedValidatorsResponse = z.infer<
+  typeof ClusterIncidentAffectedValidatorsResponseSchema
+>;
+
+/**
  * Update cluster input schema
  */
 export const UpdateClusterInputSchema = z.object({

--- a/packages/api/src/storage/incident.ts
+++ b/packages/api/src/storage/incident.ts
@@ -1,0 +1,251 @@
+import { Prisma, PrismaClient } from '@beacon-indexer/db';
+
+import { getPrisma } from '@/lib/prisma.js';
+
+type ListClusterIncidentsParams = {
+  ownerId: string;
+  clusterId: string;
+  page: number;
+  pageSize: number;
+};
+
+type MarkOpenIncidentNotifiedParams = {
+  ownerId: string;
+  clusterId: string;
+  notifiedAt: Date;
+};
+
+type MarkClosedIncidentNotifiedParams = {
+  ownerId: string;
+  incidentId: string;
+  notifiedAt: Date;
+};
+
+type ListIncidentAffectedValidatorsParams = {
+  ownerId: string;
+  incidentId: string;
+  page: number;
+  pageSize: number;
+};
+
+/**
+ * Reads and updates cluster incidents using ownership-scoped queries.
+ */
+export class IncidentStorage {
+  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+
+  /**
+   * Confirms the cluster belongs to the authenticated user.
+   */
+  async isOwnedCluster(params: { ownerId: string; clusterId: string }): Promise<boolean> {
+    const [row] = await this.prisma.$queryRaw<Array<{ exists: boolean }>>`
+      SELECT EXISTS(
+        SELECT 1
+        FROM cluster
+        WHERE id = ${params.clusterId}
+          AND owner_id = ${params.ownerId}
+      ) AS "exists"
+    `;
+
+    return row?.exists ?? false;
+  }
+
+  /**
+   * Confirms the incident belongs to a cluster owned by the authenticated user.
+   */
+  async isOwnedIncident(params: { ownerId: string; incidentId: string }): Promise<boolean> {
+    const [row] = await this.prisma.$queryRaw<Array<{ exists: boolean }>>`
+      SELECT EXISTS(
+        SELECT 1
+        FROM cluster_incident incident
+        JOIN cluster ON cluster.id = incident.cluster_id
+        WHERE incident.id = ${params.incidentId}::uuid
+          AND cluster.owner_id = ${params.ownerId}
+      ) AS "exists"
+    `;
+
+    return row?.exists ?? false;
+  }
+
+  /**
+   * Lists cluster incidents with ownership and pagination applied in SQL.
+   */
+  async listClusterIncidents(params: ListClusterIncidentsParams) {
+    const offset = (params.page - 1) * params.pageSize;
+
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        id: string;
+        status: 'open' | 'closed';
+        opened_at: Date;
+        opened_slot: number;
+        closed_at: Date | null;
+        closed_slot: number | null;
+        duration_slots: number | null;
+        duration_seconds: number | null;
+        missed_attestation_rewards: bigint | null;
+        missed_sync_rewards: bigint | null;
+        missed_consensus_rewards: bigint | null;
+        rewards_finalized: boolean;
+        rewards_finalized_at: Date | null;
+        opened_notification_queued_at: Date | null;
+        closed_notification_queued_at: Date | null;
+        total_count: bigint;
+      }>
+    >(Prisma.sql`
+      SELECT
+        incident.id,
+        incident.status::text AS status,
+        incident.opened_at,
+        incident.opened_slot,
+        incident.closed_at,
+        incident.closed_slot,
+        incident.duration_slots,
+        incident.duration_seconds,
+        incident.missed_attestation_rewards,
+        incident.missed_sync_rewards,
+        incident.missed_consensus_rewards,
+        incident.rewards_finalized,
+        incident.rewards_finalized_at,
+        incident.opened_notification_queued_at,
+        incident.closed_notification_queued_at,
+        COUNT(*) OVER()::bigint AS total_count
+      FROM cluster_incident AS incident
+      JOIN cluster ON cluster.id = incident.cluster_id
+      WHERE incident.cluster_id = ${params.clusterId}
+        AND cluster.owner_id = ${params.ownerId}
+      ORDER BY incident.opened_at DESC, incident.id DESC
+      LIMIT ${params.pageSize} OFFSET ${offset}
+    `);
+
+    if (rows.length === 0) {
+      return {
+        rows,
+        totalCount: 0,
+      };
+    }
+
+    return {
+      rows,
+      totalCount: Number(rows[0].total_count),
+    };
+  }
+
+  /**
+   * Updates the latest open-notified timestamp for the current open incident.
+   */
+  async markOpenIncidentNotified(params: MarkOpenIncidentNotifiedParams) {
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        incident_id: string;
+        opened_notification_queued_at: Date;
+      }>
+    >(Prisma.sql`
+      UPDATE cluster_incident AS incident
+      SET
+        opened_notification_queued_at = ${params.notifiedAt},
+        updated_at = ${params.notifiedAt}
+      FROM cluster
+      WHERE cluster.id = incident.cluster_id
+        AND cluster.id = ${params.clusterId}
+        AND cluster.owner_id = ${params.ownerId}
+        AND incident.status = 'open'::"ClusterIncidentStatus"
+      RETURNING incident.id AS incident_id, incident.opened_notification_queued_at
+    `);
+
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Reads the current status for an owned incident.
+   */
+  async getOwnedIncidentStatus(params: { ownerId: string; incidentId: string }) {
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        status: 'open' | 'closed';
+      }>
+    >(Prisma.sql`
+      SELECT incident.status::text AS status
+      FROM cluster_incident AS incident
+      JOIN cluster ON cluster.id = incident.cluster_id
+      WHERE incident.id = ${params.incidentId}::uuid
+        AND cluster.owner_id = ${params.ownerId}
+    `);
+
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Updates the latest closed-notified timestamp for a closed incident.
+   */
+  async markClosedIncidentNotified(params: MarkClosedIncidentNotifiedParams) {
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        incident_id: string;
+        closed_notification_queued_at: Date;
+      }>
+    >(Prisma.sql`
+      UPDATE cluster_incident AS incident
+      SET
+        closed_notification_queued_at = ${params.notifiedAt},
+        updated_at = ${params.notifiedAt}
+      FROM cluster
+      WHERE cluster.id = incident.cluster_id
+        AND incident.id = ${params.incidentId}::uuid
+        AND cluster.owner_id = ${params.ownerId}
+        AND incident.status = 'closed'::"ClusterIncidentStatus"
+      RETURNING incident.id AS incident_id, incident.closed_notification_queued_at
+    `);
+
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Lists incident validators with ownership and pagination applied in SQL.
+   */
+  async listIncidentAffectedValidators(params: ListIncidentAffectedValidatorsParams) {
+    const offset = (params.page - 1) * params.pageSize;
+
+    const rows = await this.prisma.$queryRaw<
+      Array<{
+        validator_index: number;
+        inactive_from_slot: number;
+        inactive_to_slot: number | null;
+        rewards_processed_through_slot: number | null;
+        missed_attestation_rewards: bigint;
+        missed_sync_rewards: bigint;
+        missed_consensus_rewards: bigint;
+        total_count: bigint;
+      }>
+    >(Prisma.sql`
+      SELECT
+        incident_validator.validator_index,
+        incident_validator.inactive_from_slot,
+        incident_validator.inactive_to_slot,
+        incident_validator.rewards_processed_through_slot,
+        incident_validator.missed_attestation_rewards,
+        incident_validator.missed_sync_rewards,
+        incident_validator.missed_consensus_rewards,
+        COUNT(*) OVER()::bigint AS total_count
+      FROM cluster_incident_validator AS incident_validator
+      JOIN cluster_incident AS incident ON incident.id = incident_validator.incident_id
+      JOIN cluster ON cluster.id = incident.cluster_id
+      WHERE incident.id = ${params.incidentId}::uuid
+        AND cluster.owner_id = ${params.ownerId}
+      ORDER BY incident_validator.validator_index ASC
+      LIMIT ${params.pageSize} OFFSET ${offset}
+    `);
+
+    if (rows.length === 0) {
+      return {
+        rows,
+        totalCount: 0,
+      };
+    }
+
+    return {
+      rows,
+      totalCount: Number(rows[0].total_count),
+    };
+  }
+}

--- a/packages/api/src/storage/incident.ts
+++ b/packages/api/src/storage/incident.ts
@@ -1,4 +1,4 @@
-import { Prisma, PrismaClient } from '@beacon-indexer/db';
+import { ClusterIncidentStatus, Prisma, PrismaClient } from '@beacon-indexer/db';
 
 import { getPrisma } from '@/lib/prisma.js';
 
@@ -38,33 +38,32 @@ export class IncidentStorage {
    * Confirms the cluster belongs to the authenticated user.
    */
   async isOwnedCluster(params: { ownerId: string; clusterId: string }): Promise<boolean> {
-    const [row] = await this.prisma.$queryRaw<Array<{ exists: boolean }>>`
-      SELECT EXISTS(
-        SELECT 1
-        FROM cluster
-        WHERE id = ${params.clusterId}
-          AND owner_id = ${params.ownerId}
-      ) AS "exists"
-    `;
+    const cluster = await this.prisma.cluster.findFirst({
+      where: {
+        id: params.clusterId,
+        ownerId: params.ownerId,
+      },
+      select: { id: true },
+    });
 
-    return row?.exists ?? false;
+    return cluster !== null;
   }
 
   /**
    * Confirms the incident belongs to a cluster owned by the authenticated user.
    */
   async isOwnedIncident(params: { ownerId: string; incidentId: string }): Promise<boolean> {
-    const [row] = await this.prisma.$queryRaw<Array<{ exists: boolean }>>`
-      SELECT EXISTS(
-        SELECT 1
-        FROM cluster_incident incident
-        JOIN cluster ON cluster.id = incident.cluster_id
-        WHERE incident.id = ${params.incidentId}::uuid
-          AND cluster.owner_id = ${params.ownerId}
-      ) AS "exists"
-    `;
+    const incident = await this.prisma.clusterIncident.findFirst({
+      where: {
+        id: params.incidentId,
+        cluster: {
+          ownerId: params.ownerId,
+        },
+      },
+      select: { id: true },
+    });
 
-    return row?.exists ?? false;
+    return incident !== null;
   }
 
   /**
@@ -135,69 +134,87 @@ export class IncidentStorage {
    * Updates the latest open-notified timestamp for the current open incident.
    */
   async markOpenIncidentNotified(params: MarkOpenIncidentNotifiedParams) {
-    const rows = await this.prisma.$queryRaw<
-      Array<{
-        incident_id: string;
-        opened_notification_queued_at: Date;
-      }>
-    >(Prisma.sql`
-      UPDATE cluster_incident AS incident
-      SET
-        opened_notification_queued_at = ${params.notifiedAt},
-        updated_at = ${params.notifiedAt}
-      FROM cluster
-      WHERE cluster.id = incident.cluster_id
-        AND cluster.id = ${params.clusterId}
-        AND cluster.owner_id = ${params.ownerId}
-        AND incident.status = 'open'::"ClusterIncidentStatus"
-      RETURNING incident.id AS incident_id, incident.opened_notification_queued_at
-    `);
+    const rows = await this.prisma.clusterIncident.updateManyAndReturn({
+      where: {
+        clusterId: params.clusterId,
+        status: ClusterIncidentStatus.open,
+        cluster: {
+          ownerId: params.ownerId,
+        },
+      },
+      data: {
+        openedNotificationQueuedAt: params.notifiedAt,
+        updatedAt: params.notifiedAt,
+      },
+      select: {
+        id: true,
+        openedNotificationQueuedAt: true,
+      },
+    });
 
-    return rows[0] ?? null;
+    const incident = rows[0];
+
+    if (!incident?.openedNotificationQueuedAt) {
+      return null;
+    }
+
+    return {
+      incident_id: incident.id,
+      opened_notification_queued_at: incident.openedNotificationQueuedAt,
+    };
   }
 
   /**
    * Reads the current status for an owned incident.
    */
   async getOwnedIncidentStatus(params: { ownerId: string; incidentId: string }) {
-    const rows = await this.prisma.$queryRaw<
-      Array<{
-        status: 'open' | 'closed';
-      }>
-    >(Prisma.sql`
-      SELECT incident.status::text AS status
-      FROM cluster_incident AS incident
-      JOIN cluster ON cluster.id = incident.cluster_id
-      WHERE incident.id = ${params.incidentId}::uuid
-        AND cluster.owner_id = ${params.ownerId}
-    `);
+    const incident = await this.prisma.clusterIncident.findFirst({
+      where: {
+        id: params.incidentId,
+        cluster: {
+          ownerId: params.ownerId,
+        },
+      },
+      select: {
+        status: true,
+      },
+    });
 
-    return rows[0] ?? null;
+    return incident;
   }
 
   /**
    * Updates the latest closed-notified timestamp for a closed incident.
    */
   async markClosedIncidentNotified(params: MarkClosedIncidentNotifiedParams) {
-    const rows = await this.prisma.$queryRaw<
-      Array<{
-        incident_id: string;
-        closed_notification_queued_at: Date;
-      }>
-    >(Prisma.sql`
-      UPDATE cluster_incident AS incident
-      SET
-        closed_notification_queued_at = ${params.notifiedAt},
-        updated_at = ${params.notifiedAt}
-      FROM cluster
-      WHERE cluster.id = incident.cluster_id
-        AND incident.id = ${params.incidentId}::uuid
-        AND cluster.owner_id = ${params.ownerId}
-        AND incident.status = 'closed'::"ClusterIncidentStatus"
-      RETURNING incident.id AS incident_id, incident.closed_notification_queued_at
-    `);
+    const rows = await this.prisma.clusterIncident.updateManyAndReturn({
+      where: {
+        id: params.incidentId,
+        status: ClusterIncidentStatus.closed,
+        cluster: {
+          ownerId: params.ownerId,
+        },
+      },
+      data: {
+        closedNotificationQueuedAt: params.notifiedAt,
+        updatedAt: params.notifiedAt,
+      },
+      select: {
+        id: true,
+        closedNotificationQueuedAt: true,
+      },
+    });
 
-    return rows[0] ?? null;
+    const incident = rows[0];
+
+    if (!incident?.closedNotificationQueuedAt) {
+      return null;
+    }
+
+    return {
+      incident_id: incident.id,
+      closed_notification_queued_at: incident.closedNotificationQueuedAt,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary
- add paginated cluster incident endpoints on the current incident model
- add bot-authenticated notification update endpoints for open and closed incidents
- add paginated affected-validator reads and API e2e coverage

## Test Plan
- [x] `pnpm --filter @beacon-indexer/api exec vitest run --config vitest.e2e.config.ts e2e/incidents.test.ts --no-coverage`
- [x] `pnpm --filter @beacon-indexer/api typecheck`
- [x] `pnpm --filter @beacon-indexer/api build`