### PR TITLE
Fix cluster validator count after create

### DIFF
--- a/packages/api/e2e/cluster.test.ts
+++ b/packages/api/e2e/cluster.test.ts
@@ -16,6 +16,7 @@ import type { ApiResponse } from '@/utils/response.js';
 
 // Response types using ApiResponse wrapper with schema types
 type ClusterResponse = ApiResponse<Cluster>;
+type ClusterWithCountResponse = ApiResponse<ClusterWithCount>;
 type ClusterDetailResponse = ApiResponse<ClusterDetail>;
 type ClusterListResponse = ApiResponse<ClusterWithCount[]>;
 type AddValidatorsResponse = ApiResponse<AddValidatorsData>;
@@ -117,7 +118,7 @@ describe('Cluster API E2E Tests', () => {
       });
 
       expect(response.ok).toBe(true);
-      const body = (await response.json()) as ClusterResponse;
+      const body = (await response.json()) as ClusterWithCountResponse;
 
       expect(body.success).toBe(true);
       expect(body.data).toBeDefined();
@@ -125,6 +126,7 @@ describe('Cluster API E2E Tests', () => {
       expect(body.data!.visibility).toBe('private');
       expect(body.data!.ownerId).toBe(testOwnerId);
       expect(body.data!.id).toBeDefined();
+      expect(body.data!.validatorCount).toBe(1);
 
       createdClusterIds.push(body.data!.id);
     });
@@ -150,11 +152,12 @@ describe('Cluster API E2E Tests', () => {
       });
 
       expect(response.ok).toBe(true);
-      const body = (await response.json()) as ClusterResponse;
+      const body = (await response.json()) as ClusterWithCountResponse;
 
       expect(body.success).toBe(true);
       expect(body.data!.feeRecipientAddress).toBe(feeRecipient);
       expect(body.data!.visibility).toBe('shared');
+      expect(body.data!.validatorCount).toBe(1);
 
       createdClusterIds.push(body.data!.id);
     });
@@ -302,6 +305,149 @@ describe('Cluster API E2E Tests', () => {
 
       expect(body.success).toBe(false);
       expect(body.error!.code).toBe('CLUSTER_NOT_FOUND');
+    });
+
+    it('should replace cluster validators in the same update request', async () => {
+      // This scenario verifies the save route can swap cluster membership in one request.
+      const cluster = await prisma.cluster.create({
+        data: { name: 'Replace Validators Test', ownerId: testOwnerId, visibility: 'private' },
+      });
+      createdClusterIds.push(cluster.id);
+
+      // Seed the existing validator rows used by the cluster before the update.
+      await prisma.validator.upsert({
+        where: { id: 601 },
+        update: {},
+        create: { id: 601, balance: BigInt(32000000000) },
+      });
+      await prisma.validator.upsert({
+        where: { id: 602 },
+        update: {},
+        create: { id: 602, balance: BigInt(32000000000) },
+      });
+      await prisma.validator.upsert({
+        where: { id: 603 },
+        update: {},
+        create: { id: 603, balance: BigInt(32000000000) },
+      });
+
+      // Attach two validators so the update has an existing membership set to replace.
+      await prisma.clusterValidator.createMany({
+        data: [
+          { clusterId: cluster.id, validatorIndex: 601 },
+          { clusterId: cluster.id, validatorIndex: 602 },
+        ],
+      });
+
+      // Save the edited cluster with one kept validator and one newly added validator.
+      const response = await fetch(`${baseUrl}/clusters/${cluster.id}`, {
+        method: 'PUT',
+        headers: userAuthHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          name: 'Replace Validators Test Updated',
+          validatorIndexes: [602, 603],
+        }),
+      });
+
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ClusterResponse;
+
+      // The cluster metadata update should succeed together with the membership sync.
+      expect(body.success).toBe(true);
+      expect(body.data!.name).toBe('Replace Validators Test Updated');
+
+      // Read the join table back to confirm the final membership matches the request exactly.
+      const validators = await prisma.clusterValidator.findMany({
+        where: { clusterId: cluster.id },
+        orderBy: { validatorIndex: 'asc' },
+      });
+      expect(validators.map((row) => row.validatorIndex)).toEqual([602, 603]);
+    });
+
+    it('should allow updating a cluster to an empty validator set', async () => {
+      // This scenario proves an edit can intentionally leave the cluster empty.
+      const cluster = await prisma.cluster.create({
+        data: { name: 'Empty Validators Test', ownerId: testOwnerId, visibility: 'private' },
+      });
+      createdClusterIds.push(cluster.id);
+
+      // Seed one validator so the update removes a real existing membership.
+      await prisma.validator.upsert({
+        where: { id: 604 },
+        update: {},
+        create: { id: 604, balance: BigInt(32000000000) },
+      });
+      await prisma.clusterValidator.create({
+        data: { clusterId: cluster.id, validatorIndex: 604 },
+      });
+
+      // Save the cluster with an explicit empty validator list.
+      const response = await fetch(`${baseUrl}/clusters/${cluster.id}`, {
+        method: 'PUT',
+        headers: userAuthHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          visibility: 'shared',
+          validatorIndexes: [],
+        }),
+      });
+
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ClusterResponse;
+
+      // The route should accept the edit and preserve the other metadata changes.
+      expect(body.success).toBe(true);
+      expect(body.data!.visibility).toBe('shared');
+
+      // The cluster should end with no validator memberships after the sync.
+      const validators = await prisma.clusterValidator.findMany({
+        where: { clusterId: cluster.id },
+      });
+      expect(validators).toEqual([]);
+    });
+
+    it('should reject validator sync when the edited cluster belongs to another user', async () => {
+      // This scenario ensures the ownership guard still protects the transactional save route.
+      const cluster = await prisma.cluster.create({
+        data: { name: 'Unauthorized Update Test', ownerId: testOwnerId, visibility: 'private' },
+      });
+      createdClusterIds.push(cluster.id);
+
+      // Seed one existing membership so the unauthorized edit would be destructive if allowed.
+      await prisma.validator.upsert({
+        where: { id: 605 },
+        update: {},
+        create: { id: 605, balance: BigInt(32000000000) },
+      });
+      await prisma.clusterValidator.create({
+        data: { clusterId: cluster.id, validatorIndex: 605 },
+      });
+
+      // Submit the full edit as a different authenticated user.
+      const response = await fetch(`${baseUrl}/clusters/${cluster.id}`, {
+        method: 'PUT',
+        headers: otherUserAuthHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          name: 'Should Not Apply',
+          validatorIndexes: [],
+        }),
+      });
+
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ClusterResponse;
+
+      // The API must not reveal or mutate clusters owned by another user.
+      expect(body.success).toBe(false);
+      expect(body.error!.code).toBe('CLUSTER_NOT_FOUND');
+
+      // Verify both the name and membership remained unchanged after the rejected request.
+      const unchangedCluster = await prisma.cluster.findUniqueOrThrow({
+        where: { id: cluster.id },
+      });
+      expect(unchangedCluster.name).toBe('Unauthorized Update Test');
+      const validators = await prisma.clusterValidator.findMany({
+        where: { clusterId: cluster.id },
+      });
+      expect(validators.map((row) => row.validatorIndex)).toEqual([605]);
     });
   });
 

--- a/packages/api/e2e/cluster.test.ts
+++ b/packages/api/e2e/cluster.test.ts
@@ -364,6 +364,55 @@ describe('Cluster API E2E Tests', () => {
       expect(validators.map((row) => row.validatorIndex)).toEqual([602, 603]);
     });
 
+    it('should update validator membership without requiring metadata changes', async () => {
+      // This scenario verifies the transactional sync works when the save only changes validators.
+      const cluster = await prisma.cluster.create({
+        data: { name: 'Validator Only Update Test', ownerId: testOwnerId, visibility: 'private' },
+      });
+      createdClusterIds.push(cluster.id);
+
+      // Seed the validator rows used by the membership-only update request.
+      await prisma.validator.upsert({
+        where: { id: 606 },
+        update: {},
+        create: { id: 606, balance: BigInt(32000000000) },
+      });
+      await prisma.validator.upsert({
+        where: { id: 607 },
+        update: {},
+        create: { id: 607, balance: BigInt(32000000000) },
+      });
+
+      // Start with one validator so the request performs a real membership change.
+      await prisma.clusterValidator.create({
+        data: { clusterId: cluster.id, validatorIndex: 606 },
+      });
+
+      // Save only the new validator set and leave cluster metadata untouched.
+      const response = await fetch(`${baseUrl}/clusters/${cluster.id}`, {
+        method: 'PUT',
+        headers: userAuthHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({
+          validatorIndexes: [607],
+        }),
+      });
+
+      expect(response.ok).toBe(true);
+      const body = (await response.json()) as ClusterResponse;
+
+      // The route should keep the original metadata while applying the new membership.
+      expect(body.success).toBe(true);
+      expect(body.data!.name).toBe('Validator Only Update Test');
+      expect(body.data!.visibility).toBe('private');
+
+      // Read the final membership to confirm the validator-only save replaced the join rows.
+      const validators = await prisma.clusterValidator.findMany({
+        where: { clusterId: cluster.id },
+        orderBy: { validatorIndex: 'asc' },
+      });
+      expect(validators.map((row) => row.validatorIndex)).toEqual([607]);
+    });
+
     it('should allow updating a cluster to an empty validator set', async () => {
       // This scenario proves an edit can intentionally leave the cluster empty.
       const cluster = await prisma.cluster.create({

--- a/packages/api/src/routers/cluster/create.ts
+++ b/packages/api/src/routers/cluster/create.ts
@@ -1,4 +1,4 @@
-import { ClusterSchema, CreateClusterInputSchema } from './schemas.js';
+import { ClusterWithCountSchema, CreateClusterInputSchema } from './schemas.js';
 
 import { securedProcedure } from '@/lib/procedures.js';
 import { ClusterStorage } from '@/storage/cluster.js';
@@ -11,7 +11,7 @@ import { ApiResponseSchema } from '@/utils/response.js';
 export const createCluster = securedProcedure
   .route({ method: 'POST', path: '/clusters' })
   .input(CreateClusterInputSchema)
-  .output(ApiResponseSchema(ClusterSchema))
+  .output(ApiResponseSchema(ClusterWithCountSchema))
   .handler(async ({ input, context }) => {
     try {
       const storage = new ClusterStorage();
@@ -20,9 +20,8 @@ export const createCluster = securedProcedure
         ownerId: context.user!.id,
         visibility: input.visibility,
         feeRecipientAddress: input.feeRecipientAddress ?? null,
+        validatorIndexes: input.validatorIndexes,
       });
-
-      await storage.addValidators(cluster.id, input.validatorIndexes);
 
       return {
         success: true,
@@ -33,6 +32,7 @@ export const createCluster = securedProcedure
           feeRecipientAddress: cluster.feeRecipientAddress,
           ownerId: cluster.ownerId,
           createdAt: cluster.createdAt.toISOString(),
+          validatorCount: cluster.validatorCount,
         },
         meta: { timestamp: new Date().toISOString() },
       };

--- a/packages/api/src/routers/cluster/schemas.ts
+++ b/packages/api/src/routers/cluster/schemas.ts
@@ -43,6 +43,7 @@ export const UpdateClusterInputSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   visibility: ClusterVisibilitySchema.optional(),
   feeRecipientAddress: ethereumAddressSchema.nullable().optional(),
+  validatorIndexes: z.array(z.number().int().nonnegative()).optional(),
 });
 
 export type UpdateClusterInput = z.infer<typeof UpdateClusterInputSchema>;

--- a/packages/api/src/routers/cluster/update.ts
+++ b/packages/api/src/routers/cluster/update.ts
@@ -29,8 +29,26 @@ export const updateCluster = securedProcedure
       if (input.visibility !== undefined) updateData.visibility = input.visibility;
       if (input.feeRecipientAddress !== undefined)
         updateData.feeRecipientAddress = input.feeRecipientAddress;
+      if (input.validatorIndexes !== undefined) {
+        // Verifies the full saved validator set before applying the transactional sync.
+        const { notFound } = await storage.verifyValidatorIndexes(input.validatorIndexes);
 
-      const cluster = await storage.update(input.id, updateData);
+        if (notFound.length > 0) {
+          return {
+            success: false,
+            error: {
+              code: 'VALIDATORS_NOT_FOUND',
+              message: `Validators not found: ${notFound.join(', ')}`,
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+      }
+
+      const cluster = await storage.updateWithValidators(input.id, {
+        ...updateData,
+        validatorIndexes: input.validatorIndexes,
+      });
 
       return {
         success: true,

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -229,17 +229,24 @@ export class ClusterStorage {
       data.validatorIndexes !== undefined
         ? this.uniqueValidatorIndexes(data.validatorIndexes)
         : undefined;
+    const metadata = {
+      name: data.name,
+      visibility: data.visibility,
+      feeRecipientAddress: data.feeRecipientAddress,
+    };
+    const hasMetadataUpdates = Object.values(metadata).some((value) => value !== undefined);
 
     // Runs the metadata update and membership sync together so saves are atomic.
     return this.prisma.$transaction(async (tx) => {
-      const cluster = await tx.cluster.update({
-        where: { id },
-        data: {
-          name: data.name,
-          visibility: data.visibility,
-          feeRecipientAddress: data.feeRecipientAddress,
-        },
-      });
+      // Reuses the stored cluster row when the save only changes validator membership.
+      const cluster = hasMetadataUpdates
+        ? await tx.cluster.update({
+            where: { id },
+            data: metadata,
+          })
+        : await tx.cluster.findUniqueOrThrow({
+            where: { id },
+          });
 
       if (validatorIndexes !== undefined) {
         // Reads the current membership first so the sync only writes the real delta.

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -7,12 +7,17 @@ interface CreateClusterData {
   ownerId: string;
   visibility: ClusterVisibility;
   feeRecipientAddress?: string | null;
+  validatorIndexes?: number[];
 }
 
 interface UpdateClusterData {
   name?: string;
   visibility?: ClusterVisibility;
   feeRecipientAddress?: string | null;
+}
+
+interface UpdateClusterWithValidatorsData extends UpdateClusterData {
+  validatorIndexes?: number[];
 }
 
 /**
@@ -23,10 +28,55 @@ export class ClusterStorage {
   constructor(private readonly prisma: PrismaClient = getPrisma()) {}
 
   /**
+   * Removes duplicate validator indexes while preserving the first occurrence.
+   */
+  private uniqueValidatorIndexes(indexes: number[]): number[] {
+    const seen = new Set<number>();
+
+    // Keeps the diff deterministic even when the caller sends repeated indexes.
+    return indexes.filter((index) => {
+      if (seen.has(index)) {
+        return false;
+      }
+
+      seen.add(index);
+      return true;
+    });
+  }
+
+  /**
    * Create a new cluster
    */
   async create(data: CreateClusterData) {
-    return this.prisma.cluster.create({ data });
+    const validatorIndexes = this.uniqueValidatorIndexes(data.validatorIndexes ?? []);
+
+    // Persists the cluster and its initial membership in one transaction so callers never
+    // observe a cluster without the validators that were part of the create request.
+    return this.prisma.$transaction(async (tx) => {
+      const cluster = await tx.cluster.create({
+        data: {
+          name: data.name,
+          ownerId: data.ownerId,
+          visibility: data.visibility,
+          feeRecipientAddress: data.feeRecipientAddress,
+        },
+      });
+
+      if (validatorIndexes.length > 0) {
+        await tx.clusterValidator.createMany({
+          data: validatorIndexes.map((validatorIndex) => ({
+            clusterId: cluster.id,
+            validatorIndex,
+          })),
+          skipDuplicates: true,
+        });
+      }
+
+      return {
+        ...cluster,
+        validatorCount: validatorIndexes.length,
+      };
+    });
   }
 
   /**
@@ -169,6 +219,69 @@ export class ClusterStorage {
    */
   async update(id: string, data: UpdateClusterData) {
     return this.prisma.cluster.update({ where: { id }, data });
+  }
+
+  /**
+   * Update cluster metadata and synchronize validator membership in one transaction.
+   */
+  async updateWithValidators(id: string, data: UpdateClusterWithValidatorsData) {
+    const validatorIndexes =
+      data.validatorIndexes !== undefined
+        ? this.uniqueValidatorIndexes(data.validatorIndexes)
+        : undefined;
+
+    // Runs the metadata update and membership sync together so saves are atomic.
+    return this.prisma.$transaction(async (tx) => {
+      const cluster = await tx.cluster.update({
+        where: { id },
+        data: {
+          name: data.name,
+          visibility: data.visibility,
+          feeRecipientAddress: data.feeRecipientAddress,
+        },
+      });
+
+      if (validatorIndexes !== undefined) {
+        // Reads the current membership first so the sync only writes the real delta.
+        const currentValidators = await tx.clusterValidator.findMany({
+          where: { clusterId: id },
+          select: { validatorIndex: true },
+        });
+
+        const currentValidatorSet = new Set(currentValidators.map((row) => row.validatorIndex));
+        const nextValidatorSet = new Set(validatorIndexes);
+
+        // Adds validators that appear in the new draft but not in the stored cluster.
+        const validatorIndexesToAdd = validatorIndexes.filter(
+          (validatorIndex) => !currentValidatorSet.has(validatorIndex),
+        );
+        // Removes validators that are still stored but no longer appear in the saved draft.
+        const validatorIndexesToRemove = currentValidators
+          .map((row) => row.validatorIndex)
+          .filter((validatorIndex) => !nextValidatorSet.has(validatorIndex));
+
+        if (validatorIndexesToRemove.length > 0) {
+          await tx.clusterValidator.deleteMany({
+            where: {
+              clusterId: id,
+              validatorIndex: { in: validatorIndexesToRemove },
+            },
+          });
+        }
+
+        if (validatorIndexesToAdd.length > 0) {
+          await tx.clusterValidator.createMany({
+            data: validatorIndexesToAdd.map((validatorIndex) => ({
+              clusterId: id,
+              validatorIndex,
+            })),
+            skipDuplicates: true,
+          });
+        }
+      }
+
+      return cluster;
+    });
   }
 
   /**

--- a/packages/webapp/app/page.tsx
+++ b/packages/webapp/app/page.tsx
@@ -46,6 +46,7 @@ export default function DashboardOverview() {
           <SheetTitle className="sr-only">Add Cluster</SheetTitle>
           <div className="mt-6">
             <ClusterForm
+              key="create-cluster-form"
               clusterId={null}
               onClose={() => setClusterFormOpen(false)}
               onSaved={() => refetchClusters()}
@@ -63,6 +64,8 @@ export default function DashboardOverview() {
           <SheetTitle className="sr-only">Manage Cluster</SheetTitle>
           <div className="mt-6">
             <ClusterForm
+              // Remounts the editor when a different cluster opens so local draft state stays isolated.
+              key={managingClusterId ?? 'manage-cluster-form'}
               clusterId={managingClusterId}
               onClose={() => setManagingClusterId(null)}
               onSaved={() => refetchClusters()}

--- a/packages/webapp/components/validators/cluster-card.tsx
+++ b/packages/webapp/components/validators/cluster-card.tsx
@@ -59,7 +59,7 @@ export default function ClusterCard({ cluster, onManage, gnoPrice }: ClusterCard
     return displays;
   };
 
-  const totalValidators = cluster.validators.length;
+  const totalValidators = cluster.validatorCount ?? cluster.validators.length;
 
   const balanceUsd = (cluster.totalBalance * gnoPrice).toFixed(2);
   const effectiveBalanceUsd = (cluster.totalEffectiveBalance * gnoPrice).toFixed(0);

--- a/packages/webapp/components/validators/cluster-form.tsx
+++ b/packages/webapp/components/validators/cluster-form.tsx
@@ -2,7 +2,7 @@
 
 import { Trash2, Loader2 } from 'lucide-react';
 import type React from 'react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { isAddress } from 'viem';
 
 import { Button } from '@/components/ui/button';
@@ -23,8 +23,6 @@ import {
   useCreateCluster,
   useUpdateCluster,
   useDeleteCluster,
-  useAddValidators,
-  useRemoveValidator,
 } from '@/hooks/use-clusters';
 import { useToast } from '@/hooks/use-toast';
 import type { ValidatorItem } from '@/hooks/use-validator-input';
@@ -33,7 +31,7 @@ interface ClusterFormProps {
   /** Cluster ID for edit mode, null for create mode */
   clusterId: string | null;
   onClose: () => void;
-  onSaved?: () => void;
+  onSaved?: () => void | Promise<unknown>;
   onDeleted?: () => void;
 }
 
@@ -52,9 +50,7 @@ export default function ClusterForm({ clusterId, onClose, onSaved, onDeleted }: 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  // Validators state - initialValidators is passed to ValidatorSection,
-  // validators holds the current state received via callback
-  const [initialValidators, setInitialValidators] = useState<ValidatorItem[]>([]);
+  // Validators state lives in the form so the save payload always matches the visible chips.
   const [validators, setValidators] = useState<ValidatorItem[]>([]);
 
   // Get withdrawal addresses from the full cluster details
@@ -64,8 +60,6 @@ export default function ClusterForm({ clusterId, onClose, onSaved, onDeleted }: 
   const createCluster = useCreateCluster();
   const updateCluster = useUpdateCluster();
   const deleteCluster = useDeleteCluster();
-  const addValidatorsMutation = useAddValidators();
-  const removeValidatorMutation = useRemoveValidator();
 
   // Initialize form state from API data when editing an existing cluster.
   // The formInitialized flag ensures this only runs once - subsequent API refetches
@@ -76,28 +70,20 @@ export default function ClusterForm({ clusterId, onClose, onSaved, onDeleted }: 
       setName(clusterDetails.name);
       setVisibility(clusterDetails.visibility);
       setFeeRecipient(clusterDetails.feeRecipientAddress || '');
-
-      if (clusterDetails.validators?.length > 0) {
-        setInitialValidators(
-          clusterDetails.validators.map((v, i) => ({
-            id: `i-${i}`,
-            type: 'index' as const,
-            value: v.validatorIndex.toString(),
-            index: v.validatorIndex,
-            displayName: `Validator #${v.validatorIndex}`,
-            withdrawalAddress: v.withdrawalAddress,
-          })),
-        );
-      }
+      setValidators(
+        clusterDetails.validators.map((v, i) => ({
+          id: `i-${i}`,
+          type: 'index' as const,
+          value: v.validatorIndex.toString(),
+          index: v.validatorIndex,
+          displayName: `Validator #${v.validatorIndex}`,
+          withdrawalAddress: v.withdrawalAddress,
+        })),
+      );
 
       setFormInitialized(true);
     }
   }, [clusterDetails, formInitialized]);
-
-  // Stable callback for validator changes
-  const handleValidatorsChange = useCallback((newValidators: ValidatorItem[]) => {
-    setValidators(newValidators);
-  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -107,30 +93,14 @@ export default function ClusterForm({ clusterId, onClose, onSaved, onDeleted }: 
       const validatorIndexes = validators.map((v) => v.index);
 
       if (clusterId) {
-        // Update existing cluster
+        // Update existing cluster and sync the final validator list in the same save request.
         await updateCluster.mutateAsync({
           id: clusterId,
           name,
           visibility,
           feeRecipientAddress: feeRecipient || null,
+          validatorIndexes,
         });
-
-        // Calculate validators to add/remove using clusterDetails
-        const existingIndexes = new Set(
-          clusterDetails?.validators.map((v) => v.validatorIndex) ?? [],
-        );
-        const newIndexes = new Set(validatorIndexes);
-
-        const toAdd = validatorIndexes.filter((idx) => !existingIndexes.has(idx));
-        const toRemove = [...existingIndexes].filter((idx) => !newIndexes.has(idx));
-
-        if (toAdd.length > 0) {
-          await addValidatorsMutation.mutateAsync({ clusterId, validatorIndexes: toAdd });
-        }
-
-        for (const validatorIndex of toRemove) {
-          await removeValidatorMutation.mutateAsync({ clusterId, validatorIndex });
-        }
 
         toast({ title: 'Cluster updated', description: `${name} has been updated` });
       } else {
@@ -145,7 +115,8 @@ export default function ClusterForm({ clusterId, onClose, onSaved, onDeleted }: 
         toast({ title: 'Cluster created', description: `${name} has been created` });
       }
 
-      onSaved?.();
+      // Waits for the parent refresh flow so the home list is updated before the sheet closes.
+      await onSaved?.();
       onClose();
     } catch (error) {
       toast({
@@ -168,7 +139,7 @@ export default function ClusterForm({ clusterId, onClose, onSaved, onDeleted }: 
         description: `${clusterDetails?.name || 'Cluster'} has been deleted`,
       });
       onDeleted?.();
-      onSaved?.();
+      await onSaved?.();
       onClose();
     } catch (error) {
       toast({
@@ -243,10 +214,10 @@ export default function ClusterForm({ clusterId, onClose, onSaved, onDeleted }: 
 
         {/* Validators */}
         <ValidatorInput
-          initialValidators={initialValidators}
+          validators={validators}
           withdrawalAddresses={withdrawalAddresses}
           isEditMode={!!clusterId}
-          onValidatorsChange={handleValidatorsChange}
+          onValidatorsChange={setValidators}
         />
 
         {/* Actions */}

--- a/packages/webapp/components/validators/cluster-form/validator-input.tsx
+++ b/packages/webapp/components/validators/cluster-form/validator-input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { BulkActionDialog } from './bulk-action-dialog';
 import { ValidatorInputField } from './validator-input-field';
@@ -10,14 +10,14 @@ import { useMediaQuery } from '@/hooks/use-mobile';
 import { useValidatorInput, type ValidatorItem } from '@/hooks/use-validator-input';
 
 interface ValidatorInputProps {
-  initialValidators: ValidatorItem[];
+  validators: ValidatorItem[];
   withdrawalAddresses: string[];
   isEditMode: boolean;
   onValidatorsChange: (validators: ValidatorItem[]) => void;
 }
 
 export function ValidatorInput({
-  initialValidators,
+  validators,
   withdrawalAddresses,
   isEditMode,
   onValidatorsChange,
@@ -26,7 +26,6 @@ export function ValidatorInput({
   const [helpDialogOpen, setHelpDialogOpen] = useState(false);
 
   const {
-    validators,
     inputValue,
     validationState,
     errorMessage,
@@ -45,14 +44,10 @@ export function ValidatorInput({
     handleKeyDown,
     closeBulkAction,
   } = useValidatorInput({
-    initialValidators,
+    validators,
+    onValidatorsChange,
     withdrawalAddresses,
   });
-
-  // Notify parent when validators change
-  useEffect(() => {
-    onValidatorsChange(validators);
-  }, [validators, onValidatorsChange]);
 
   return (
     <div className="space-y-4">

--- a/packages/webapp/components/validators/cluster-overview-content.tsx
+++ b/packages/webapp/components/validators/cluster-overview-content.tsx
@@ -118,7 +118,7 @@ export default function ClusterOverviewContent({
     return displays;
   };
 
-  const totalValidators = cluster.validators.length;
+  const totalValidators = cluster.validatorCount ?? cluster.validators.length;
 
   const balanceUsd = formatNumber(cluster.totalBalance * gnoPrice);
   const effectiveBalanceUsd = formatNumber(cluster.totalEffectiveBalance * gnoPrice, 0);

--- a/packages/webapp/components/validators/cluster-overview.tsx
+++ b/packages/webapp/components/validators/cluster-overview.tsx
@@ -72,7 +72,7 @@ export default function ClusterOverview({
     return displays;
   };
 
-  const totalValidators = cluster.validators.length;
+  const totalValidators = cluster.validatorCount ?? cluster.validators.length;
 
   const balanceUsd = (cluster.totalBalance * gnoPrice).toFixed(2);
   const effectiveBalanceUsd = (cluster.totalEffectiveBalance * gnoPrice).toFixed(0);

--- a/packages/webapp/hooks/use-clusters.ts
+++ b/packages/webapp/hooks/use-clusters.ts
@@ -5,6 +5,51 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { orpcClient } from '@/lib/orpc';
 import { useUserId } from '@/lib/user-id';
 
+interface ClusterListItem {
+  id: string;
+  name: string;
+  visibility: 'private' | 'shared';
+  feeRecipientAddress: string | null;
+  ownerId: string;
+  createdAt: string;
+  validatorCount: number;
+}
+
+/**
+ * Merges a created cluster into the cached list so the home view reflects the save immediately.
+ */
+function mergeCreatedCluster(
+  currentClusters: ClusterListItem[] | undefined,
+  createdCluster: ClusterListItem,
+): ClusterListItem[] {
+  const nextClusters = currentClusters?.filter((cluster) => cluster.id !== createdCluster.id) ?? [];
+
+  // Keeps the newest cluster at the top to match the API ordering by createdAt descending.
+  return [createdCluster, ...nextClusters];
+}
+
+/**
+ * Normalizes the create response into the list shape used by the home cache.
+ */
+function toClusterListItem(
+  cluster: Partial<ClusterListItem> | undefined,
+  fallback: Pick<ClusterListItem, 'name' | 'visibility' | 'feeRecipientAddress' | 'validatorCount'>,
+): ClusterListItem {
+  if (!cluster?.id || !cluster.ownerId || !cluster.createdAt) {
+    throw new Error('Failed to create cluster');
+  }
+
+  return {
+    id: cluster.id,
+    name: cluster.name ?? fallback.name,
+    visibility: cluster.visibility ?? fallback.visibility,
+    feeRecipientAddress: cluster.feeRecipientAddress ?? fallback.feeRecipientAddress,
+    ownerId: cluster.ownerId,
+    createdAt: cluster.createdAt,
+    validatorCount: cluster.validatorCount ?? fallback.validatorCount,
+  };
+}
+
 /**
  * Hook to fetch all clusters for the current user
  */
@@ -56,7 +101,7 @@ export function useCreateCluster() {
       validatorIndexes: number[];
       visibility?: 'private' | 'shared';
       feeRecipientAddress?: string | null;
-    }) => {
+    }): Promise<ClusterListItem> => {
       const response = await orpcClient.cluster.create({
         ...data,
         visibility: data.visibility || 'private',
@@ -64,10 +109,21 @@ export function useCreateCluster() {
       if (!response.success) {
         throw new Error(response.error?.message || 'Failed to create cluster');
       }
-      return response.data;
+
+      return toClusterListItem(response.data, {
+        name: data.name,
+        visibility: data.visibility || 'private',
+        feeRecipientAddress: data.feeRecipientAddress ?? null,
+        validatorCount: data.validatorIndexes.length,
+      });
     },
-    onSuccess: () => {
+    onSuccess: (createdCluster) => {
+      queryClient.setQueryData<ClusterListItem[]>(['clusters'], (currentClusters) =>
+        mergeCreatedCluster(currentClusters, createdCluster),
+      );
       queryClient.invalidateQueries({ queryKey: ['clusters'] });
+      queryClient.invalidateQueries({ queryKey: ['cluster'] });
+      queryClient.invalidateQueries({ queryKey: ['clusterSnapshot'] });
     },
   });
 }
@@ -84,6 +140,7 @@ export function useUpdateCluster() {
       name?: string;
       visibility?: 'private' | 'shared';
       feeRecipientAddress?: string | null;
+      validatorIndexes?: number[];
     }) => {
       const { id, ...updateData } = data;
       const response = await orpcClient.cluster.update({ id, ...updateData });

--- a/packages/webapp/hooks/use-validator-input.ts
+++ b/packages/webapp/hooks/use-validator-input.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { isAddress, isHex, size } from 'viem';
 
 import { useToast } from '@/hooks/use-toast';
@@ -37,7 +37,8 @@ type InputType = 'index' | 'pubkey' | 'withdrawalAddress' | 'unknown';
 const BULK_ADD_THRESHOLD = 10;
 
 interface UseValidatorInputProps {
-  initialValidators?: ValidatorItem[];
+  validators: ValidatorItem[];
+  onValidatorsChange: (validators: ValidatorItem[]) => void;
   withdrawalAddresses?: string[];
 }
 
@@ -119,13 +120,13 @@ function sortValidatorsDescending(validators: ValidatorItem[]): ValidatorItem[] 
  * Groups validators by their actual withdrawal address.
  */
 export function useValidatorInput({
-  initialValidators = [],
+  validators,
+  onValidatorsChange,
   withdrawalAddresses: knownWithdrawalAddresses = [],
-}: UseValidatorInputProps = {}) {
+}: UseValidatorInputProps) {
   const { toast } = useToast();
 
   // Core state
-  const [validators, setValidators] = useState<ValidatorItem[]>(initialValidators);
   const [inputValue, setInputValue] = useState('');
   const [validationState, setValidationState] = useState<ValidationState>('idle');
   const [errorMessage, setErrorMessage] = useState('');
@@ -144,13 +145,6 @@ export function useValidatorInput({
   const searchByIndexes = useSearchByIndexes();
   const searchByPubkeys = useSearchByPubkeys();
   const searchByWithdrawalAddresses = useSearchByWithdrawalAddresses();
-
-  // Update validators when initialValidators change (for edit mode)
-  useEffect(() => {
-    if (initialValidators.length > 0 && validators.length === 0) {
-      setValidators(sortValidatorsDescending(initialValidators));
-    }
-  }, [initialValidators]);
 
   // Combine known and discovered withdrawal addresses for fetching all validators
   const allWithdrawalAddressesToFetch = useMemo(() => {
@@ -371,7 +365,7 @@ export function useValidatorInput({
       }
 
       // Add validators
-      setValidators((prev) => sortValidatorsDescending([...prev, ...newValidators]));
+      onValidatorsChange(sortValidatorsDescending([...validators, ...newValidators]));
       setValidationState('valid');
       setInputValue('');
 
@@ -422,7 +416,7 @@ export function useValidatorInput({
   const handleConfirmBulkAdd = () => {
     if (!bulkAction || bulkAction.action !== 'add') return;
 
-    setValidators((prev) => sortValidatorsDescending([...prev, ...bulkAction.validators]));
+    onValidatorsChange(sortValidatorsDescending([...validators, ...bulkAction.validators]));
 
     // Track discovered withdrawal addresses if not already known
     const newAddresses = bulkAction.validators
@@ -469,9 +463,9 @@ export function useValidatorInput({
 
     if (validatorsToRemove.length === 1) {
       // Just remove directly
-      setValidators((prev) =>
+      onValidatorsChange(
         sortValidatorsDescending(
-          prev.filter((v) => v.withdrawalAddress?.toLowerCase() !== lowerAddr),
+          validators.filter((v) => v.withdrawalAddress?.toLowerCase() !== lowerAddr),
         ),
       );
       toast({
@@ -493,8 +487,8 @@ export function useValidatorInput({
     if (!bulkAction || bulkAction.action !== 'remove') return;
 
     const indexesToRemove = new Set(bulkAction.validators.map((v) => v.index));
-    setValidators((prev) =>
-      sortValidatorsDescending(prev.filter((v) => !indexesToRemove.has(v.index))),
+    onValidatorsChange(
+      sortValidatorsDescending(validators.filter((v) => !indexesToRemove.has(v.index))),
     );
 
     toast({
@@ -506,7 +500,7 @@ export function useValidatorInput({
   };
 
   const removeValidator = (id: string) => {
-    setValidators((prev) => sortValidatorsDescending(prev.filter((v) => v.id !== id)));
+    onValidatorsChange(sortValidatorsDescending(validators.filter((v) => v.id !== id)));
   };
 
   const addMissingValidators = (address: string) => {
@@ -514,7 +508,7 @@ export function useValidatorInput({
     const missing = missingValidatorsByAddress[lowerAddr];
     if (!missing || missing.length === 0) return;
 
-    setValidators((prev) => sortValidatorsDescending([...prev, ...missing]));
+    onValidatorsChange(sortValidatorsDescending([...validators, ...missing]));
     toast({
       title: 'Validators added',
       description: `Added ${missing.length} validators from ${address.slice(0, 10)}...`,


### PR DESCRIPTION
## Summary
- make cluster create atomic so the cluster and its validator membership are persisted together
- return `validatorCount` from `POST /clusters` and update the `['clusters']` cache immediately after create
- render cluster counts from `validatorCount` when the lightweight cluster list has not hydrated full validator details yet

## Root Cause
The home view was showing the validator badge from `cluster.validators.length`. Right after create, the home screen renders the lightweight cluster list entry, which had `validatorCount` but still had `validators: []`, so the UI showed `0` until a full refresh loaded detailed validator data.

## Impact
- newly created clusters show the correct validator count immediately after closing the form
- cluster create is now transactional with its initial validator membership
- cluster edit continues to synchronize validator membership in a single save flow

## Validation
- `pnpm --filter @beacon-indexer/api exec tsc --noEmit`
- `pnpm --filter @beacon-indexer/webapp exec tsc --noEmit`
- `pnpm --filter @beacon-indexer/api build`
- pre-commit hooks ran `eslint --fix`, API type-check, API build, and webapp type-check successfully

## Notes
- API e2e tests were not run in this session because the local PostgreSQL instance expected at `localhost:5433` was not available.
