### PR TITLE
feat: add admin bot communications flow

### DIFF
--- a/packages/api/src/auth/middleware.ts
+++ b/packages/api/src/auth/middleware.ts
@@ -110,3 +110,22 @@ export const telegramAuthProcedure = baseProcedure.use(async ({ context, next })
 
   return next({ context: { ...context, user, authStrategy: AuthStrategy.TELEGRAM } });
 });
+
+/**
+ * API key authenticated procedure.
+ * Requires a valid Authorization header and rejects other auth strategies.
+ */
+export const apiKeyProcedure = baseProcedure.use(async ({ context, next }) => {
+  const { headers } = context;
+  const authHeader = getHeader(headers, 'authorization');
+
+  if (!authHeader) {
+    throw new ORPCError('UNAUTHORIZED', {
+      message: 'API key authentication required',
+    });
+  }
+
+  authenticateApiKey(authHeader);
+
+  return next({ context: { ...context, authStrategy: AuthStrategy.API_KEY } });
+});

--- a/packages/api/src/lib/procedures.ts
+++ b/packages/api/src/lib/procedures.ts
@@ -3,4 +3,4 @@
  * Import procedures from here in router files.
  */
 export { publicProcedure } from './orpc.js';
-export { securedProcedure, telegramAuthProcedure } from '@/auth/middleware.js';
+export { apiKeyProcedure, securedProcedure, telegramAuthProcedure } from '@/auth/middleware.js';

--- a/packages/api/src/routers/bot/communications.ts
+++ b/packages/api/src/routers/bot/communications.ts
@@ -10,6 +10,7 @@ import {
   CommunicationIdParamSchema,
   CreateBotCommunicationSchema,
 } from '@/routers/bot/schemas.js';
+import { resolveCommunicationRecipients } from '@/storage/bot-communication-recipients.js';
 import { BotCommunicationsStorage } from '@/storage/bot-communications.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
@@ -32,7 +33,6 @@ function mapCommunication(communication: {
   exclude: string[];
   onlyTo: string[];
   sent: boolean;
-  sending: boolean;
   sentAt: Date | null;
   createdAt: Date;
 }) {
@@ -43,19 +43,9 @@ function mapCommunication(communication: {
     exclude: communication.exclude,
     onlyTo: communication.onlyTo,
     sent: communication.sent,
-    sending: communication.sending,
     sentAt: communication.sentAt?.toISOString() ?? null,
     createdAt: communication.createdAt.toISOString(),
   };
-}
-
-/**
- * Re-throws oRPC framework errors so status codes survive the handler boundary.
- */
-function rethrowOrpcError(error: unknown): never | void {
-  if (error instanceof ORPCError) {
-    throw error;
-  }
 }
 
 /**
@@ -99,79 +89,19 @@ export const getBotCommunication = botProcedure
         });
       }
 
-      const recipients = await storage.listRecipients(communication);
+      // Load broadcast recipients only when the communication does not target explicit telegram ids.
+      const broadcastTelegramIds =
+        communication.onlyTo.length > 0 ? [] : await storage.listBroadcastTelegramIds();
+      const recipients = resolveCommunicationRecipients(broadcastTelegramIds, communication);
 
       return successResponse({
         ...mapCommunication(communication),
-        recipients: recipients.map((recipient) => ({
-          id: recipient.id,
-          telegramId: recipient.telegramId.toString(),
-          username: recipient.username,
-        })),
+        recipients,
       }) as BotCommunicationDetailsResponse;
     } catch (error) {
-      rethrowOrpcError(error);
       return errorResponse(
         'GET_COMMUNICATION_ERROR',
         error instanceof Error ? error.message : 'Failed to get communication',
-      ) as BotCommunicationDetailsResponse;
-    }
-  });
-
-/**
- * Claims a pending communication for sending and returns its resolved recipients.
- * POST /bot/communications/{id}/start-send
- */
-export const startBotCommunicationSend = botProcedure
-  .route({ method: 'POST', path: '/bot/communications/{id}/start-send' })
-  .input(CommunicationIdParamSchema)
-  .output(BotCommunicationDetailsResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotCommunicationsStorage();
-      const communication = await storage.findById(input.id);
-
-      if (!communication) {
-        throw new ORPCError('NOT_FOUND', {
-          message: `Communication ${input.id} was not found`,
-        });
-      }
-
-      if (communication.sent) {
-        throw new ORPCError('CONFLICT', {
-          message: `Communication ${input.id} was already sent`,
-        });
-      }
-
-      if (communication.sending) {
-        throw new ORPCError('CONFLICT', {
-          message: `Communication ${input.id} is already being sent`,
-        });
-      }
-
-      const claimed = await storage.startSending(input.id);
-
-      if (!claimed) {
-        throw new ORPCError('CONFLICT', {
-          message: `Communication ${input.id} is already being sent`,
-        });
-      }
-
-      const recipients = await storage.listRecipients(communication);
-
-      return successResponse({
-        ...mapCommunication({ ...communication, sending: true }),
-        recipients: recipients.map((recipient) => ({
-          id: recipient.id,
-          telegramId: recipient.telegramId.toString(),
-          username: recipient.username,
-        })),
-      }) as BotCommunicationDetailsResponse;
-    } catch (error) {
-      rethrowOrpcError(error);
-      return errorResponse(
-        'START_COMMUNICATION_SEND_ERROR',
-        error instanceof Error ? error.message : 'Failed to start communication send',
       ) as BotCommunicationDetailsResponse;
     }
   });
@@ -200,7 +130,6 @@ export const markBotCommunicationSent = botProcedure
         sent: true,
       }) as BotCommunicationSentResponse;
     } catch (error) {
-      rethrowOrpcError(error);
       return errorResponse(
         'MARK_COMMUNICATION_SENT_ERROR',
         error instanceof Error ? error.message : 'Failed to mark communication as sent',

--- a/packages/api/src/routers/bot/communications.ts
+++ b/packages/api/src/routers/bot/communications.ts
@@ -1,0 +1,138 @@
+import { ORPCError } from '@orpc/server';
+import { z } from 'zod';
+
+import { apiKeyProcedure } from '@/lib/procedures.js';
+import { botProcedure } from '@/routers/bot/procedures.js';
+import {
+  BotCommunicationDetailsSchema,
+  BotCommunicationSchema,
+  BotCommunicationSentSchema,
+  CommunicationIdParamSchema,
+  CreateBotCommunicationSchema,
+} from '@/routers/bot/schemas.js';
+import { BotCommunicationsStorage } from '@/storage/bot-communications.js';
+import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
+
+const BotCommunicationResponseSchema = ApiResponseSchema(BotCommunicationSchema);
+type BotCommunicationResponse = z.infer<typeof BotCommunicationResponseSchema>;
+
+const BotCommunicationDetailsResponseSchema = ApiResponseSchema(BotCommunicationDetailsSchema);
+type BotCommunicationDetailsResponse = z.infer<typeof BotCommunicationDetailsResponseSchema>;
+
+const BotCommunicationSentResponseSchema = ApiResponseSchema(BotCommunicationSentSchema);
+type BotCommunicationSentResponse = z.infer<typeof BotCommunicationSentResponseSchema>;
+
+/**
+ * Maps a communication row into the API response shape.
+ */
+function mapCommunication(communication: {
+  id: number;
+  description: string;
+  message: string;
+  exclude: string[];
+  onlyTo: string[];
+  sent: boolean;
+  sentAt: Date | null;
+  createdAt: Date;
+}) {
+  return {
+    id: communication.id,
+    description: communication.description,
+    message: communication.message,
+    exclude: communication.exclude,
+    onlyTo: communication.onlyTo,
+    sent: communication.sent,
+    sentAt: communication.sentAt?.toISOString() ?? null,
+    createdAt: communication.createdAt.toISOString(),
+  };
+}
+
+/**
+ * Creates a new pending communication through API key authentication.
+ * POST /bot/communications
+ */
+export const createBotCommunication = apiKeyProcedure
+  .route({ method: 'POST', path: '/bot/communications' })
+  .input(CreateBotCommunicationSchema)
+  .output(BotCommunicationResponseSchema)
+  .handler(async ({ input }) => {
+    try {
+      const storage = new BotCommunicationsStorage();
+      const communication = await storage.create(input);
+
+      return successResponse(mapCommunication(communication)) as BotCommunicationResponse;
+    } catch (error) {
+      return errorResponse(
+        'CREATE_COMMUNICATION_ERROR',
+        error instanceof Error ? error.message : 'Failed to create communication',
+      ) as BotCommunicationResponse;
+    }
+  });
+
+/**
+ * Returns one communication plus the users that should receive it.
+ * GET /bot/communications/{id}
+ */
+export const getBotCommunication = botProcedure
+  .route({ method: 'GET', path: '/bot/communications/{id}' })
+  .input(CommunicationIdParamSchema)
+  .output(BotCommunicationDetailsResponseSchema)
+  .handler(async ({ input }) => {
+    try {
+      const storage = new BotCommunicationsStorage();
+      const communication = await storage.findById(input.id);
+
+      if (!communication) {
+        throw new ORPCError('NOT_FOUND', {
+          message: `Communication ${input.id} was not found`,
+        });
+      }
+
+      const recipients = await storage.listRecipients(communication);
+
+      return successResponse({
+        ...mapCommunication(communication),
+        recipients: recipients.map((recipient) => ({
+          id: recipient.id,
+          telegramId: recipient.telegramId.toString(),
+          username: recipient.username,
+        })),
+      }) as BotCommunicationDetailsResponse;
+    } catch (error) {
+      return errorResponse(
+        'GET_COMMUNICATION_ERROR',
+        error instanceof Error ? error.message : 'Failed to get communication',
+      ) as BotCommunicationDetailsResponse;
+    }
+  });
+
+/**
+ * Marks a communication as sent after the bot finishes delivery attempts.
+ * PUT /bot/communications/{id}/sent
+ */
+export const markBotCommunicationSent = botProcedure
+  .route({ method: 'PUT', path: '/bot/communications/{id}/sent' })
+  .input(CommunicationIdParamSchema)
+  .output(BotCommunicationSentResponseSchema)
+  .handler(async ({ input }) => {
+    try {
+      const storage = new BotCommunicationsStorage();
+      const updated = await storage.markSent(input.id);
+
+      if (!updated) {
+        throw new ORPCError('CONFLICT', {
+          message: `Communication ${input.id} was already sent`,
+        });
+      }
+
+      return successResponse({
+        id: input.id,
+        sent: true,
+      }) as BotCommunicationSentResponse;
+    } catch (error) {
+      return errorResponse(
+        'MARK_COMMUNICATION_SENT_ERROR',
+        error instanceof Error ? error.message : 'Failed to mark communication as sent',
+      ) as BotCommunicationSentResponse;
+    }
+  });

--- a/packages/api/src/routers/bot/communications.ts
+++ b/packages/api/src/routers/bot/communications.ts
@@ -32,6 +32,7 @@ function mapCommunication(communication: {
   exclude: string[];
   onlyTo: string[];
   sent: boolean;
+  sending: boolean;
   sentAt: Date | null;
   createdAt: Date;
 }) {
@@ -42,9 +43,19 @@ function mapCommunication(communication: {
     exclude: communication.exclude,
     onlyTo: communication.onlyTo,
     sent: communication.sent,
+    sending: communication.sending,
     sentAt: communication.sentAt?.toISOString() ?? null,
     createdAt: communication.createdAt.toISOString(),
   };
+}
+
+/**
+ * Re-throws oRPC framework errors so status codes survive the handler boundary.
+ */
+function rethrowOrpcError(error: unknown): never | void {
+  if (error instanceof ORPCError) {
+    throw error;
+  }
 }
 
 /**
@@ -99,9 +110,68 @@ export const getBotCommunication = botProcedure
         })),
       }) as BotCommunicationDetailsResponse;
     } catch (error) {
+      rethrowOrpcError(error);
       return errorResponse(
         'GET_COMMUNICATION_ERROR',
         error instanceof Error ? error.message : 'Failed to get communication',
+      ) as BotCommunicationDetailsResponse;
+    }
+  });
+
+/**
+ * Claims a pending communication for sending and returns its resolved recipients.
+ * POST /bot/communications/{id}/start-send
+ */
+export const startBotCommunicationSend = botProcedure
+  .route({ method: 'POST', path: '/bot/communications/{id}/start-send' })
+  .input(CommunicationIdParamSchema)
+  .output(BotCommunicationDetailsResponseSchema)
+  .handler(async ({ input }) => {
+    try {
+      const storage = new BotCommunicationsStorage();
+      const communication = await storage.findById(input.id);
+
+      if (!communication) {
+        throw new ORPCError('NOT_FOUND', {
+          message: `Communication ${input.id} was not found`,
+        });
+      }
+
+      if (communication.sent) {
+        throw new ORPCError('CONFLICT', {
+          message: `Communication ${input.id} was already sent`,
+        });
+      }
+
+      if (communication.sending) {
+        throw new ORPCError('CONFLICT', {
+          message: `Communication ${input.id} is already being sent`,
+        });
+      }
+
+      const claimed = await storage.startSending(input.id);
+
+      if (!claimed) {
+        throw new ORPCError('CONFLICT', {
+          message: `Communication ${input.id} is already being sent`,
+        });
+      }
+
+      const recipients = await storage.listRecipients(communication);
+
+      return successResponse({
+        ...mapCommunication({ ...communication, sending: true }),
+        recipients: recipients.map((recipient) => ({
+          id: recipient.id,
+          telegramId: recipient.telegramId.toString(),
+          username: recipient.username,
+        })),
+      }) as BotCommunicationDetailsResponse;
+    } catch (error) {
+      rethrowOrpcError(error);
+      return errorResponse(
+        'START_COMMUNICATION_SEND_ERROR',
+        error instanceof Error ? error.message : 'Failed to start communication send',
       ) as BotCommunicationDetailsResponse;
     }
   });
@@ -130,6 +200,7 @@ export const markBotCommunicationSent = botProcedure
         sent: true,
       }) as BotCommunicationSentResponse;
     } catch (error) {
+      rethrowOrpcError(error);
       return errorResponse(
         'MARK_COMMUNICATION_SENT_ERROR',
         error instanceof Error ? error.message : 'Failed to mark communication as sent',

--- a/packages/api/src/routers/bot/index.ts
+++ b/packages/api/src/routers/bot/index.ts
@@ -1,4 +1,9 @@
 import {
+  createBotCommunication,
+  getBotCommunication,
+  markBotCommunicationSent,
+} from './communications.js';
+import {
   deleteBotNotification,
   listBotNotifications,
   markBotNotificationDelivered,
@@ -11,8 +16,11 @@ import {
 } from './users.js';
 
 export const botRouter = {
+  createCommunication: createBotCommunication,
   deleteNotification: deleteBotNotification,
+  getCommunication: getBotCommunication,
   notifications: listBotNotifications,
+  markCommunicationSent: markBotCommunicationSent,
   setNotificationDelivered: markBotNotificationDelivered,
   users: listBotUsers,
   updateMessageId: updateBotUserMessageId,

--- a/packages/api/src/routers/bot/index.ts
+++ b/packages/api/src/routers/bot/index.ts
@@ -2,6 +2,7 @@ import {
   createBotCommunication,
   getBotCommunication,
   markBotCommunicationSent,
+  startBotCommunicationSend,
 } from './communications.js';
 import {
   deleteBotNotification,
@@ -21,6 +22,7 @@ export const botRouter = {
   getCommunication: getBotCommunication,
   notifications: listBotNotifications,
   markCommunicationSent: markBotCommunicationSent,
+  startCommunicationSend: startBotCommunicationSend,
   setNotificationDelivered: markBotNotificationDelivered,
   users: listBotUsers,
   updateMessageId: updateBotUserMessageId,

--- a/packages/api/src/routers/bot/index.ts
+++ b/packages/api/src/routers/bot/index.ts
@@ -2,7 +2,6 @@ import {
   createBotCommunication,
   getBotCommunication,
   markBotCommunicationSent,
-  startBotCommunicationSend,
 } from './communications.js';
 import {
   deleteBotNotification,
@@ -22,7 +21,6 @@ export const botRouter = {
   getCommunication: getBotCommunication,
   notifications: listBotNotifications,
   markCommunicationSent: markBotCommunicationSent,
-  startCommunicationSend: startBotCommunicationSend,
   setNotificationDelivered: markBotNotificationDelivered,
   users: listBotUsers,
   updateMessageId: updateBotUserMessageId,

--- a/packages/api/src/routers/bot/schemas.ts
+++ b/packages/api/src/routers/bot/schemas.ts
@@ -65,6 +65,7 @@ export const BotCommunicationSchema = z.object({
   exclude: z.array(z.string()),
   onlyTo: z.array(z.string()),
   sent: z.boolean(),
+  sending: z.boolean(),
   sentAt: z.string().nullable(),
   createdAt: z.string(),
 });

--- a/packages/api/src/routers/bot/schemas.ts
+++ b/packages/api/src/routers/bot/schemas.ts
@@ -65,19 +65,12 @@ export const BotCommunicationSchema = z.object({
   exclude: z.array(z.string()),
   onlyTo: z.array(z.string()),
   sent: z.boolean(),
-  sending: z.boolean(),
   sentAt: z.string().nullable(),
   createdAt: z.string(),
 });
 
-export const BotCommunicationRecipientSchema = z.object({
-  id: z.string(),
-  telegramId: z.string(),
-  username: z.string(),
-});
-
 export const BotCommunicationDetailsSchema = BotCommunicationSchema.extend({
-  recipients: z.array(BotCommunicationRecipientSchema),
+  recipients: z.array(z.string()),
 });
 
 export const BotCommunicationSentSchema = z.object({

--- a/packages/api/src/routers/bot/schemas.ts
+++ b/packages/api/src/routers/bot/schemas.ts
@@ -46,3 +46,40 @@ export const BotNotificationDeletedSchema = z.object({
 export const BotNotificationListInputSchema = z.object({
   limit: z.number().int().min(1).max(100).default(20),
 });
+
+export const CommunicationIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export const CreateBotCommunicationSchema = z.object({
+  description: z.string().min(1),
+  message: z.string().min(1),
+  exclude: z.array(z.string()).default([]),
+  onlyTo: z.array(z.string()).default([]),
+});
+
+export const BotCommunicationSchema = z.object({
+  id: z.number().int().positive(),
+  description: z.string(),
+  message: z.string(),
+  exclude: z.array(z.string()),
+  onlyTo: z.array(z.string()),
+  sent: z.boolean(),
+  sentAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+
+export const BotCommunicationRecipientSchema = z.object({
+  id: z.string(),
+  telegramId: z.string(),
+  username: z.string(),
+});
+
+export const BotCommunicationDetailsSchema = BotCommunicationSchema.extend({
+  recipients: z.array(BotCommunicationRecipientSchema),
+});
+
+export const BotCommunicationSentSchema = z.object({
+  id: z.number().int().positive(),
+  sent: z.literal(true),
+});

--- a/packages/api/src/storage/bot-communication-recipients.ts
+++ b/packages/api/src/storage/bot-communication-recipients.ts
@@ -1,0 +1,27 @@
+export interface CommunicationTargeting {
+  exclude: string[];
+  onlyTo: string[];
+}
+
+/**
+ * Resolves the final audience for a communication.
+ */
+export function resolveCommunicationRecipients<T extends { id: string }>(
+  users: T[],
+  targeting: CommunicationTargeting,
+): T[] {
+  // Use sets so the inclusion and exclusion checks stay simple and predictable.
+  const excludedUserIds = new Set(targeting.exclude);
+  const onlyUserIds = new Set(targeting.onlyTo);
+
+  return users.filter((user) => {
+    // Exclusion always wins, even when the user also appears in onlyTo.
+    if (excludedUserIds.has(user.id)) return false;
+
+    // When onlyTo is empty, every notifiable user is eligible.
+    if (onlyUserIds.size === 0) return true;
+
+    // When onlyTo has values, only the listed users are eligible.
+    return onlyUserIds.has(user.id);
+  });
+}

--- a/packages/api/src/storage/bot-communication-recipients.ts
+++ b/packages/api/src/storage/bot-communication-recipients.ts
@@ -4,24 +4,19 @@ export interface CommunicationTargeting {
 }
 
 /**
- * Resolves the final audience for a communication.
+ * Resolves the final telegram ids for a communication.
  */
-export function resolveCommunicationRecipients<T extends { id: string }>(
-  users: T[],
+export function resolveCommunicationRecipients(
+  broadcastTelegramIds: string[],
   targeting: CommunicationTargeting,
-): T[] {
-  // Use sets so the inclusion and exclusion checks stay simple and predictable.
-  const excludedUserIds = new Set(targeting.exclude);
-  const onlyUserIds = new Set(targeting.onlyTo);
+): string[] {
+  // Use a set so exclusion checks stay simple and predictable.
+  const excludedTelegramIds = new Set(targeting.exclude);
 
-  return users.filter((user) => {
-    // Exclusion always wins, even when the user also appears in onlyTo.
-    if (excludedUserIds.has(user.id)) return false;
+  // Use the targeted telegram ids directly when the communication specifies them.
+  const recipientTelegramIds =
+    targeting.onlyTo.length > 0 ? targeting.onlyTo : broadcastTelegramIds;
 
-    // When onlyTo is empty, every notifiable user is eligible.
-    if (onlyUserIds.size === 0) return true;
-
-    // When onlyTo has values, only the listed users are eligible.
-    return onlyUserIds.has(user.id);
-  });
+  // Exclusion always wins over the initial recipient list.
+  return recipientTelegramIds.filter((telegramId) => !excludedTelegramIds.has(telegramId));
 }

--- a/packages/api/src/storage/bot-communications.test.ts
+++ b/packages/api/src/storage/bot-communications.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveCommunicationRecipients } from './bot-communications.js';
+import { resolveCommunicationRecipients } from './bot-communication-recipients.js';
 
 const users = [
   { id: 'user-1', telegramId: 1n, username: 'alpha' },

--- a/packages/api/src/storage/bot-communications.test.ts
+++ b/packages/api/src/storage/bot-communications.test.ts
@@ -2,40 +2,36 @@ import { describe, expect, it } from 'vitest';
 
 import { resolveCommunicationRecipients } from './bot-communication-recipients.js';
 
-const users = [
-  { id: 'user-1', telegramId: 1n, username: 'alpha' },
-  { id: 'user-2', telegramId: 2n, username: 'beta' },
-  { id: 'user-3', telegramId: 3n, username: 'gamma' },
-];
+const broadcastTelegramIds = ['1001', '1002', '1003'];
 
 describe('resolveCommunicationRecipients', () => {
-  it('returns all users when onlyTo and exclude are empty', () => {
+  it('returns all broadcast telegram ids when onlyTo and exclude are empty', () => {
     // This case verifies the default broadcast behavior.
-    const recipients = resolveCommunicationRecipients(users, {
+    const recipients = resolveCommunicationRecipients(broadcastTelegramIds, {
       exclude: [],
       onlyTo: [],
     });
 
-    expect(recipients.map((user) => user.id)).toEqual(['user-1', 'user-2', 'user-3']);
+    expect(recipients).toEqual(['1001', '1002', '1003']);
   });
 
-  it('returns only the users listed in onlyTo', () => {
-    // This case verifies the targeted-send behavior.
-    const recipients = resolveCommunicationRecipients(users, {
+  it('returns the telegram ids listed in onlyTo even when they are not in the broadcast list', () => {
+    // This case verifies the targeted-send behavior without a database lookup.
+    const recipients = resolveCommunicationRecipients(broadcastTelegramIds, {
       exclude: [],
-      onlyTo: ['user-2', 'user-3'],
+      onlyTo: ['2001', '2002'],
     });
 
-    expect(recipients.map((user) => user.id)).toEqual(['user-2', 'user-3']);
+    expect(recipients).toEqual(['2001', '2002']);
   });
 
-  it('removes excluded users even when they also appear in onlyTo', () => {
+  it('removes excluded telegram ids from the final send list', () => {
     // This case verifies the precedence rule agreed for the feature.
-    const recipients = resolveCommunicationRecipients(users, {
-      exclude: ['user-2'],
-      onlyTo: ['user-1', 'user-2'],
+    const recipients = resolveCommunicationRecipients(broadcastTelegramIds, {
+      exclude: ['2002'],
+      onlyTo: ['2001', '2002'],
     });
 
-    expect(recipients.map((user) => user.id)).toEqual(['user-1']);
+    expect(recipients).toEqual(['2001']);
   });
 });

--- a/packages/api/src/storage/bot-communications.test.ts
+++ b/packages/api/src/storage/bot-communications.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveCommunicationRecipients } from './bot-communications.js';
+
+const users = [
+  { id: 'user-1', telegramId: 1n, username: 'alpha' },
+  { id: 'user-2', telegramId: 2n, username: 'beta' },
+  { id: 'user-3', telegramId: 3n, username: 'gamma' },
+];
+
+describe('resolveCommunicationRecipients', () => {
+  it('returns all users when onlyTo and exclude are empty', () => {
+    // This case verifies the default broadcast behavior.
+    const recipients = resolveCommunicationRecipients(users, {
+      exclude: [],
+      onlyTo: [],
+    });
+
+    expect(recipients.map((user) => user.id)).toEqual(['user-1', 'user-2', 'user-3']);
+  });
+
+  it('returns only the users listed in onlyTo', () => {
+    // This case verifies the targeted-send behavior.
+    const recipients = resolveCommunicationRecipients(users, {
+      exclude: [],
+      onlyTo: ['user-2', 'user-3'],
+    });
+
+    expect(recipients.map((user) => user.id)).toEqual(['user-2', 'user-3']);
+  });
+
+  it('removes excluded users even when they also appear in onlyTo', () => {
+    // This case verifies the precedence rule agreed for the feature.
+    const recipients = resolveCommunicationRecipients(users, {
+      exclude: ['user-2'],
+      onlyTo: ['user-1', 'user-2'],
+    });
+
+    expect(recipients.map((user) => user.id)).toEqual(['user-1']);
+  });
+});

--- a/packages/api/src/storage/bot-communications.ts
+++ b/packages/api/src/storage/bot-communications.ts
@@ -1,39 +1,15 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
 import { getPrisma } from '@/lib/prisma.js';
-
-export interface CommunicationTargeting {
-  exclude: string[];
-  onlyTo: string[];
-}
+import {
+  type CommunicationTargeting,
+  resolveCommunicationRecipients,
+} from '@/storage/bot-communication-recipients.js';
 
 export interface NotifiableCommunicationUser {
   id: string;
   telegramId: bigint;
   username: string;
-}
-
-/**
- * Resolves the final audience for a communication.
- */
-export function resolveCommunicationRecipients<T extends { id: string }>(
-  users: T[],
-  targeting: CommunicationTargeting,
-): T[] {
-  // Use sets so the inclusion and exclusion checks stay simple and predictable.
-  const excludedUserIds = new Set(targeting.exclude);
-  const onlyUserIds = new Set(targeting.onlyTo);
-
-  return users.filter((user) => {
-    // Exclusion always wins, even when the user also appears in onlyTo.
-    if (excludedUserIds.has(user.id)) return false;
-
-    // When onlyTo is empty, every notifiable user is eligible.
-    if (onlyUserIds.size === 0) return true;
-
-    // When onlyTo has values, only the listed users are eligible.
-    return onlyUserIds.has(user.id);
-  });
 }
 
 /**
@@ -74,8 +50,18 @@ export class BotCommunicationsStorage {
    * Lists all notifiable users and applies the communication targeting rules.
    */
   async listRecipients(communication: CommunicationTargeting) {
+    // Push the include and exclude filters into the query so the database trims the result set first.
+    const userIdFilter =
+      communication.onlyTo.length > 0 || communication.exclude.length > 0
+        ? {
+            ...(communication.onlyTo.length > 0 ? { in: communication.onlyTo } : {}),
+            ...(communication.exclude.length > 0 ? { notIn: communication.exclude } : {}),
+          }
+        : undefined;
+
     const users = await this.prisma.user.findMany({
       where: {
+        ...(userIdFilter ? { id: userIdFilter } : {}),
         telegramId: { not: null },
         hasBlockedBot: false,
         clusters: {
@@ -93,20 +79,41 @@ export class BotCommunicationsStorage {
       },
     });
 
+    // Keep the in-memory rule as a last line of defense for the "exclude wins" contract.
     return resolveCommunicationRecipients(users as NotifiableCommunicationUser[], communication);
   }
 
   /**
-   * Marks a communication as sent only once.
+   * Claims one communication for sending so only one bot process can dispatch it.
+   */
+  async startSending(id: number) {
+    const result = await this.prisma.communication.updateMany({
+      where: {
+        id,
+        sent: false,
+        sending: false,
+      },
+      data: {
+        sending: true,
+      },
+    });
+
+    return result.count === 1;
+  }
+
+  /**
+   * Marks a communication as sent after a sending claim was acquired.
    */
   async markSent(id: number) {
     const result = await this.prisma.communication.updateMany({
       where: {
         id,
         sent: false,
+        sending: true,
       },
       data: {
         sent: true,
+        sending: false,
         sentAt: new Date(),
       },
     });

--- a/packages/api/src/storage/bot-communications.ts
+++ b/packages/api/src/storage/bot-communications.ts
@@ -1,0 +1,116 @@
+import { PrismaClient } from '@beacon-indexer/db';
+
+import { getPrisma } from '@/lib/prisma.js';
+
+export interface CommunicationTargeting {
+  exclude: string[];
+  onlyTo: string[];
+}
+
+export interface NotifiableCommunicationUser {
+  id: string;
+  telegramId: bigint;
+  username: string;
+}
+
+/**
+ * Resolves the final audience for a communication.
+ */
+export function resolveCommunicationRecipients<T extends { id: string }>(
+  users: T[],
+  targeting: CommunicationTargeting,
+): T[] {
+  // Use sets so the inclusion and exclusion checks stay simple and predictable.
+  const excludedUserIds = new Set(targeting.exclude);
+  const onlyUserIds = new Set(targeting.onlyTo);
+
+  return users.filter((user) => {
+    // Exclusion always wins, even when the user also appears in onlyTo.
+    if (excludedUserIds.has(user.id)) return false;
+
+    // When onlyTo is empty, every notifiable user is eligible.
+    if (onlyUserIds.size === 0) return true;
+
+    // When onlyTo has values, only the listed users are eligible.
+    return onlyUserIds.has(user.id);
+  });
+}
+
+/**
+ * Stores and resolves broadcast communications used by the Telegram bot.
+ */
+export class BotCommunicationsStorage {
+  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+
+  /**
+   * Creates a new communication in pending state.
+   */
+  async create(input: {
+    description: string;
+    message: string;
+    exclude: string[];
+    onlyTo: string[];
+  }) {
+    return this.prisma.communication.create({
+      data: {
+        description: input.description,
+        message: input.message,
+        exclude: input.exclude,
+        onlyTo: input.onlyTo,
+      },
+    });
+  }
+
+  /**
+   * Gets one communication by numeric id.
+   */
+  async findById(id: number) {
+    return this.prisma.communication.findUnique({
+      where: { id },
+    });
+  }
+
+  /**
+   * Lists all notifiable users and applies the communication targeting rules.
+   */
+  async listRecipients(communication: CommunicationTargeting) {
+    const users = await this.prisma.user.findMany({
+      where: {
+        telegramId: { not: null },
+        hasBlockedBot: false,
+        clusters: {
+          some: {
+            validators: {
+              some: {},
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        telegramId: true,
+        username: true,
+      },
+    });
+
+    return resolveCommunicationRecipients(users as NotifiableCommunicationUser[], communication);
+  }
+
+  /**
+   * Marks a communication as sent only once.
+   */
+  async markSent(id: number) {
+    const result = await this.prisma.communication.updateMany({
+      where: {
+        id,
+        sent: false,
+      },
+      data: {
+        sent: true,
+        sentAt: new Date(),
+      },
+    });
+
+    return result.count === 1;
+  }
+}

--- a/packages/api/src/storage/bot-communications.ts
+++ b/packages/api/src/storage/bot-communications.ts
@@ -1,19 +1,9 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
 import { getPrisma } from '@/lib/prisma.js';
-import {
-  type CommunicationTargeting,
-  resolveCommunicationRecipients,
-} from '@/storage/bot-communication-recipients.js';
-
-export interface NotifiableCommunicationUser {
-  id: string;
-  telegramId: bigint;
-  username: string;
-}
 
 /**
- * Stores and resolves broadcast communications used by the Telegram bot.
+ * Stores broadcast communications used by the Telegram bot.
  */
 export class BotCommunicationsStorage {
   constructor(private readonly prisma: PrismaClient = getPrisma()) {}
@@ -47,21 +37,11 @@ export class BotCommunicationsStorage {
   }
 
   /**
-   * Lists all notifiable users and applies the communication targeting rules.
+   * Lists the telegram ids eligible for a full broadcast send.
    */
-  async listRecipients(communication: CommunicationTargeting) {
-    // Push the include and exclude filters into the query so the database trims the result set first.
-    const userIdFilter =
-      communication.onlyTo.length > 0 || communication.exclude.length > 0
-        ? {
-            ...(communication.onlyTo.length > 0 ? { in: communication.onlyTo } : {}),
-            ...(communication.exclude.length > 0 ? { notIn: communication.exclude } : {}),
-          }
-        : undefined;
-
+  async listBroadcastTelegramIds() {
     const users = await this.prisma.user.findMany({
       where: {
-        ...(userIdFilter ? { id: userIdFilter } : {}),
         telegramId: { not: null },
         hasBlockedBot: false,
         clusters: {
@@ -73,47 +53,25 @@ export class BotCommunicationsStorage {
         },
       },
       select: {
-        id: true,
         telegramId: true,
-        username: true,
       },
     });
 
-    // Keep the in-memory rule as a last line of defense for the "exclude wins" contract.
-    return resolveCommunicationRecipients(users as NotifiableCommunicationUser[], communication);
+    // Convert database bigint values into telegram ids the bot can send to directly.
+    return users.map((user) => user.telegramId!.toString());
   }
 
   /**
-   * Claims one communication for sending so only one bot process can dispatch it.
-   */
-  async startSending(id: number) {
-    const result = await this.prisma.communication.updateMany({
-      where: {
-        id,
-        sent: false,
-        sending: false,
-      },
-      data: {
-        sending: true,
-      },
-    });
-
-    return result.count === 1;
-  }
-
-  /**
-   * Marks a communication as sent after a sending claim was acquired.
+   * Marks a communication as sent only once.
    */
   async markSent(id: number) {
     const result = await this.prisma.communication.updateMany({
       where: {
         id,
         sent: false,
-        sending: true,
       },
       data: {
         sent: true,
-        sending: false,
         sentAt: new Date(),
       },
     });

--- a/packages/db/prisma/migrations/20251210144216_initial/migration.sql
+++ b/packages/db/prisma/migrations/20251210144216_initial/migration.sql
@@ -362,6 +362,7 @@ CREATE TABLE "public"."communication" (
     "exclude" TEXT[] DEFAULT ARRAY[]::TEXT[],
     "only_to" TEXT[] DEFAULT ARRAY[]::TEXT[],
     "sent" BOOLEAN NOT NULL DEFAULT false,
+    "sending" BOOLEAN NOT NULL DEFAULT false,
     "sent_at" TIMESTAMP(3),
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 

--- a/packages/db/prisma/migrations/20251210144216_initial/migration.sql
+++ b/packages/db/prisma/migrations/20251210144216_initial/migration.sql
@@ -355,6 +355,20 @@ CREATE TABLE "public"."notification_queue" (
 );
 
 -- CreateTable
+CREATE TABLE "public"."communication" (
+    "id" SERIAL NOT NULL,
+    "description" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "exclude" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "only_to" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "sent" BOOLEAN NOT NULL DEFAULT false,
+    "sent_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "communication_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "public"."cluster_incident" (
     "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "status" "public"."ClusterIncidentStatus" NOT NULL DEFAULT 'open',

--- a/packages/db/prisma/migrations/20251210144216_initial/migration.sql
+++ b/packages/db/prisma/migrations/20251210144216_initial/migration.sql
@@ -362,7 +362,6 @@ CREATE TABLE "public"."communication" (
     "exclude" TEXT[] DEFAULT ARRAY[]::TEXT[],
     "only_to" TEXT[] DEFAULT ARRAY[]::TEXT[],
     "sent" BOOLEAN NOT NULL DEFAULT false,
-    "sending" BOOLEAN NOT NULL DEFAULT false,
     "sent_at" TIMESTAMP(3),
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -515,6 +515,19 @@ model NotificationQueue {
   @@map("notification_queue")
 }
 
+model Communication {
+  id          Int       @id @default(autoincrement()) @map("id")
+  description String    @map("description")
+  message     String    @map("message")
+  exclude     String[]  @default([]) @map("exclude")
+  onlyTo      String[]  @default([]) @map("only_to")
+  sent        Boolean   @default(false) @map("sent")
+  sentAt      DateTime? @map("sent_at") @db.Timestamp
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamp
+
+  @@map("communication")
+}
+
 model ClusterIncident {
   id     String                @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid @map("id")
   status ClusterIncidentStatus @default(open) @map("status")

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -522,6 +522,7 @@ model Communication {
   exclude     String[]  @default([]) @map("exclude")
   onlyTo      String[]  @default([]) @map("only_to")
   sent        Boolean   @default(false) @map("sent")
+  sending     Boolean   @default(false) @map("sending")
   sentAt      DateTime? @map("sent_at") @db.Timestamp
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamp
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -522,7 +522,6 @@ model Communication {
   exclude     String[]  @default([]) @map("exclude")
   onlyTo      String[]  @default([]) @map("only_to")
   sent        Boolean   @default(false) @map("sent")
-  sending     Boolean   @default(false) @map("sending")
   sentAt      DateTime? @map("sent_at") @db.Timestamp
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamp
 

--- a/packages/telegram-bot/src/bot/features/admin.ts
+++ b/packages/telegram-bot/src/bot/features/admin.ts
@@ -4,6 +4,7 @@ import { Composer } from 'grammy';
 import type { Context } from '@/src/bot/context.js';
 import { isAdmin } from '@/src/bot/filters/is-admin.js';
 import { setCommandsHandler } from '@/src/bot/handlers/commands/setcommands.js';
+import { sendCommunicationHandler } from '@/src/bot/handlers/communications/send.js';
 import { logHandle } from '@/src/bot/helpers/logging.js';
 
 const composer = new Composer<Context>();
@@ -15,6 +16,13 @@ feature.command(
   logHandle('command-setcommands'),
   chatAction('typing'),
   setCommandsHandler,
+);
+
+feature.command(
+  'send_communication',
+  logHandle('command-send-communication'),
+  chatAction('typing'),
+  sendCommunicationHandler,
 );
 
 export { composer as adminFeature };

--- a/packages/telegram-bot/src/bot/features/remove-message.ts
+++ b/packages/telegram-bot/src/bot/features/remove-message.ts
@@ -1,0 +1,16 @@
+import { Composer } from 'grammy';
+
+import type { Context } from '@/src/bot/context.js';
+import { logHandle } from '@/src/bot/helpers/logging.js';
+
+const composer = new Composer<Context>();
+
+/**
+ * Deletes one broadcast message when the user taps the dismiss button.
+ */
+composer.callbackQuery('remove_message', logHandle('callback-remove-message'), async (ctx) => {
+  await ctx.answerCallbackQuery();
+  await ctx.deleteMessage();
+});
+
+export { composer as removeMessageFeature };

--- a/packages/telegram-bot/src/bot/handlers/communications/send-batches.test.ts
+++ b/packages/telegram-bot/src/bot/handlers/communications/send-batches.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { countBatchDeliveryResults, splitRecipientsIntoBatches } from './send-batches.js';
+
+test('splitRecipientsIntoBatches returns batches of ten and preserves recipient order', () => {
+  // This case builds a recipient list large enough to require multiple batches.
+  const recipients = Array.from({ length: 23 }, (_, index) => `${index + 1}`);
+
+  // This call splits the recipients into the batch size used by broadcast sends.
+  const batches = splitRecipientsIntoBatches(recipients, 10);
+
+  // This assertion verifies the expected 10/10/3 batch layout.
+  assert.deepEqual(
+    batches.map((batch) => batch.length),
+    [10, 10, 3],
+  );
+
+  // This assertion verifies the helper keeps the original send order intact.
+  assert.deepEqual(batches.flat(), recipients);
+});
+
+test('countBatchDeliveryResults treats rejected sends as failures instead of aborting the batch', () => {
+  // This case simulates a mixed batch where one send rejects and the others still finish.
+  const results: PromiseSettledResult<boolean>[] = [
+    { status: 'fulfilled', value: true },
+    { status: 'rejected', reason: new Error('telegram failure') },
+    { status: 'fulfilled', value: false },
+    { status: 'fulfilled', value: true },
+  ];
+
+  // This call counts the finished batch without throwing on the rejected send.
+  const counts = countBatchDeliveryResults(results);
+
+  // This assertion verifies successful deliveries are counted separately from all failures.
+  assert.deepEqual(counts, {
+    failedCount: 2,
+    sentCount: 2,
+  });
+});

--- a/packages/telegram-bot/src/bot/handlers/communications/send-batches.ts
+++ b/packages/telegram-bot/src/bot/handlers/communications/send-batches.ts
@@ -1,0 +1,36 @@
+/**
+ * Splits recipients into fixed-size batches for broadcast sends.
+ */
+export function splitRecipientsIntoBatches(recipients: string[], batchSize: number): string[][] {
+  const batches: string[][] = [];
+
+  // Slice the recipient list into contiguous groups that can be sent concurrently.
+  for (let index = 0; index < recipients.length; index += batchSize) {
+    batches.push(recipients.slice(index, index + batchSize));
+  }
+
+  return batches;
+}
+
+/**
+ * Counts successful and failed deliveries from one settled batch.
+ */
+export function countBatchDeliveryResults(results: PromiseSettledResult<boolean>[]) {
+  let sentCount = 0;
+  let failedCount = 0;
+
+  // Treat rejected sends as failed deliveries so one bad recipient does not abort the batch.
+  for (const result of results) {
+    if (result.status === 'fulfilled' && result.value) {
+      sentCount += 1;
+      continue;
+    }
+
+    failedCount += 1;
+  }
+
+  return {
+    failedCount,
+    sentCount,
+  };
+}

--- a/packages/telegram-bot/src/bot/handlers/communications/send.ts
+++ b/packages/telegram-bot/src/bot/handlers/communications/send.ts
@@ -6,6 +6,17 @@ import type { Context } from '@/src/bot/context.js';
 import { sendNotificationMessage } from '@/src/telegram/messaging.js';
 
 /**
+ * Returns a readable message from an oRPC client error.
+ */
+function getRpcErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
+/**
  * Parses the communication id from the /send_communication command text.
  */
 function parseCommunicationId(text: string | undefined): number | null {
@@ -36,18 +47,19 @@ export async function sendCommunicationHandler(ctx: CommandContext<Context>) {
 
   const telegramId = ctx.from.id.toString();
   const rpcClient = getRpcClientForUser(telegramId);
-  const communicationResponse = await rpcClient.bot.getCommunication({
-    id: communicationId,
-  });
+  let communicationResponse;
 
-  if (!communicationResponse.success || !communicationResponse.data) {
-    return ctx.reply(
-      communicationResponse.error?.message ?? `Communication ${communicationId} was not found.`,
-    );
+  try {
+    communicationResponse = await rpcClient.bot.startCommunicationSend({
+      id: communicationId,
+    });
+  } catch (error) {
+    ctx.logger.warn({ err: error, communicationId }, 'Failed to start communication send');
+    return ctx.reply(getRpcErrorMessage(error, `Communication ${communicationId} was not found.`));
   }
 
-  if (communicationResponse.data.sent) {
-    return ctx.reply('already sent');
+  if (!communicationResponse.data) {
+    return ctx.reply(`Communication ${communicationId} could not be loaded.`);
   }
 
   // Reuse the legacy dismiss button so every user can remove the broadcast locally.
@@ -73,12 +85,15 @@ export async function sendCommunicationHandler(ctx: CommandContext<Context>) {
     else failedCount += 1;
   }
 
-  const markSentResponse = await rpcClient.bot.markCommunicationSent({
-    id: communicationId,
-  });
-
-  if (!markSentResponse.success) {
-    return ctx.reply(markSentResponse.error?.message ?? 'already sent');
+  try {
+    await rpcClient.bot.markCommunicationSent({
+      id: communicationId,
+    });
+  } catch (error) {
+    ctx.logger.error({ err: error, communicationId }, 'Failed to mark communication as sent');
+    return ctx.reply(
+      getRpcErrorMessage(error, `Communication ${communicationId} could not be finalized.`),
+    );
   }
 
   return ctx.reply(

--- a/packages/telegram-bot/src/bot/handlers/communications/send.ts
+++ b/packages/telegram-bot/src/bot/handlers/communications/send.ts
@@ -1,0 +1,87 @@
+import { InlineKeyboard } from 'grammy';
+import type { CommandContext } from 'grammy';
+
+import { getRpcClientForUser } from '@/src/api/client.js';
+import type { Context } from '@/src/bot/context.js';
+import { sendNotificationMessage } from '@/src/telegram/messaging.js';
+
+/**
+ * Parses the communication id from the /send_communication command text.
+ */
+function parseCommunicationId(text: string | undefined): number | null {
+  if (!text) return null;
+
+  const [, rawId] = text.trim().split(/\s+/, 2);
+  if (!rawId) return null;
+
+  const communicationId = Number.parseInt(rawId, 10);
+
+  return Number.isSafeInteger(communicationId) && communicationId > 0 ? communicationId : null;
+}
+
+/**
+ * Sends one stored communication to its resolved audience.
+ */
+export async function sendCommunicationHandler(ctx: CommandContext<Context>) {
+  const communicationId = parseCommunicationId(ctx.message?.text);
+
+  if (!communicationId) {
+    return ctx.reply('Usage: /send_communication <id>');
+  }
+
+  // Stop early when Telegram did not attach the sender metadata.
+  if (!ctx.from) {
+    return ctx.reply('Unable to identify the sender of this command.');
+  }
+
+  const telegramId = ctx.from.id.toString();
+  const rpcClient = getRpcClientForUser(telegramId);
+  const communicationResponse = await rpcClient.bot.getCommunication({
+    id: communicationId,
+  });
+
+  if (!communicationResponse.success || !communicationResponse.data) {
+    return ctx.reply(
+      communicationResponse.error?.message ?? `Communication ${communicationId} was not found.`,
+    );
+  }
+
+  if (communicationResponse.data.sent) {
+    return ctx.reply('already sent');
+  }
+
+  // Reuse the legacy dismiss button so every user can remove the broadcast locally.
+  const dismissKeyboard = new InlineKeyboard().text('Dismiss', 'remove_message');
+
+  let sentCount = 0;
+  let failedCount = 0;
+
+  // Send the message sequentially so the bot logs remain easy to trace during manual broadcasts.
+  for (const recipient of communicationResponse.data.recipients) {
+    const delivered = await sendNotificationMessage(
+      ctx.api,
+      Number(recipient.telegramId),
+      recipient.telegramId,
+      communicationResponse.data.message,
+      ctx.logger,
+      {
+        reply_markup: dismissKeyboard,
+      },
+    );
+
+    if (delivered) sentCount += 1;
+    else failedCount += 1;
+  }
+
+  const markSentResponse = await rpcClient.bot.markCommunicationSent({
+    id: communicationId,
+  });
+
+  if (!markSentResponse.success) {
+    return ctx.reply(markSentResponse.error?.message ?? 'already sent');
+  }
+
+  return ctx.reply(
+    `Communication ${communicationId} sent to ${sentCount} users. Failed deliveries: ${failedCount}.`,
+  );
+}

--- a/packages/telegram-bot/src/bot/handlers/communications/send.ts
+++ b/packages/telegram-bot/src/bot/handlers/communications/send.ts
@@ -1,20 +1,11 @@
 import { InlineKeyboard } from 'grammy';
 import type { CommandContext } from 'grammy';
 
-import { getRpcClientForUser } from '@/src/api/client.js';
+import { countBatchDeliveryResults, splitRecipientsIntoBatches } from './send-batches.js';
+
+import { COMMON_REQUESTS_TELEGRAM_ID, getRpcClientForUser } from '@/src/api/client.js';
 import type { Context } from '@/src/bot/context.js';
 import { sendNotificationMessage } from '@/src/telegram/messaging.js';
-
-/**
- * Returns a readable message from an oRPC client error.
- */
-function getRpcErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  return fallback;
-}
 
 /**
  * Parses the communication id from the /send_communication command text.
@@ -40,26 +31,23 @@ export async function sendCommunicationHandler(ctx: CommandContext<Context>) {
     return ctx.reply('Usage: /send_communication <id>');
   }
 
-  // Stop early when Telegram did not attach the sender metadata.
-  if (!ctx.from) {
-    return ctx.reply('Unable to identify the sender of this command.');
+  // Use the generic bot client because this command is not tied to any user context.
+  const rpcClient = getRpcClientForUser(COMMON_REQUESTS_TELEGRAM_ID);
+  const communicationResponse = await rpcClient.bot.getCommunication({
+    id: communicationId,
+  });
+
+  if (!communicationResponse.success || !communicationResponse.data) {
+    return ctx.reply(
+      communicationResponse.error?.message ?? `Communication ${communicationId} was not found.`,
+    );
   }
 
-  const telegramId = ctx.from.id.toString();
-  const rpcClient = getRpcClientForUser(telegramId);
-  let communicationResponse;
+  // Store the loaded communication after the response guard so the rest of the handler stays typed.
+  const communication = communicationResponse.data;
 
-  try {
-    communicationResponse = await rpcClient.bot.startCommunicationSend({
-      id: communicationId,
-    });
-  } catch (error) {
-    ctx.logger.warn({ err: error, communicationId }, 'Failed to start communication send');
-    return ctx.reply(getRpcErrorMessage(error, `Communication ${communicationId} was not found.`));
-  }
-
-  if (!communicationResponse.data) {
-    return ctx.reply(`Communication ${communicationId} could not be loaded.`);
+  if (communication.sent) {
+    return ctx.reply('already sent');
   }
 
   // Reuse the legacy dismiss button so every user can remove the broadcast locally.
@@ -68,32 +56,35 @@ export async function sendCommunicationHandler(ctx: CommandContext<Context>) {
   let sentCount = 0;
   let failedCount = 0;
 
-  // Send the message sequentially so the bot logs remain easy to trace during manual broadcasts.
-  for (const recipient of communicationResponse.data.recipients) {
-    const delivered = await sendNotificationMessage(
-      ctx.api,
-      Number(recipient.telegramId),
-      recipient.telegramId,
-      communicationResponse.data.message,
-      ctx.logger,
-      {
-        reply_markup: dismissKeyboard,
-      },
+  // Send each batch concurrently while keeping the overall broadcast flow easy to follow.
+  for (const recipientBatch of splitRecipientsIntoBatches(communication.recipients, 10)) {
+    const deliveryResults = await Promise.allSettled(
+      recipientBatch.map((telegramId) =>
+        sendNotificationMessage(
+          ctx.api,
+          Number(telegramId),
+          telegramId,
+          communication.message,
+          ctx.logger,
+          {
+            reply_markup: dismissKeyboard,
+          },
+        ),
+      ),
     );
 
-    if (delivered) sentCount += 1;
-    else failedCount += 1;
+    // Count each settled result so rejected sends still produce a partial batch outcome.
+    const batchCounts = countBatchDeliveryResults(deliveryResults);
+    sentCount += batchCounts.sentCount;
+    failedCount += batchCounts.failedCount;
   }
 
-  try {
-    await rpcClient.bot.markCommunicationSent({
-      id: communicationId,
-    });
-  } catch (error) {
-    ctx.logger.error({ err: error, communicationId }, 'Failed to mark communication as sent');
-    return ctx.reply(
-      getRpcErrorMessage(error, `Communication ${communicationId} could not be finalized.`),
-    );
+  const markSentResponse = await rpcClient.bot.markCommunicationSent({
+    id: communicationId,
+  });
+
+  if (!markSentResponse.success) {
+    return ctx.reply(markSentResponse.error?.message ?? 'already sent');
   }
 
   return ctx.reply(

--- a/packages/telegram-bot/src/bot/index.ts
+++ b/packages/telegram-bot/src/bot/index.ts
@@ -8,6 +8,7 @@ import { Bot as TelegramBot } from 'grammy';
 import type { Context } from '@/src/bot/context.js';
 import { adminFeature } from '@/src/bot/features/admin.js';
 import { languageFeature } from '@/src/bot/features/language.js';
+import { removeMessageFeature } from '@/src/bot/features/remove-message.js';
 import { dashboardFeature } from '@/src/bot/features/reset-message.js';
 import { unhandledFeature } from '@/src/bot/features/unhandled.js';
 import { welcomeFeature } from '@/src/bot/features/welcome.js';
@@ -66,6 +67,7 @@ export function createBot(
   protectedBot.use(welcomeFeature);
   protectedBot.use(dashboardFeature);
   protectedBot.use(adminFeature);
+  protectedBot.use(removeMessageFeature);
   if (isMultipleLocales) protectedBot.use(languageFeature);
 
   // must be the last handler

--- a/packages/telegram-bot/src/telegram/messaging.ts
+++ b/packages/telegram-bot/src/telegram/messaging.ts
@@ -64,9 +64,11 @@ export async function sendNotificationMessage(
   telegramId: string,
   text: string,
   logger: Logger,
+  options?: SendMessageOptions,
 ): Promise<boolean> {
   const messageId = await sendTelegramMessage(api, chatId, telegramId, text, logger, {
     link_preview_options: { is_disabled: true },
+    ...options,
   });
 
   return messageId !== null;


### PR DESCRIPTION
## Summary
- add a persisted bot communication flow in the API with create, fetch, recipient resolution, and mark-sent endpoints
- add admin Telegram bot support for `/send_communication <id>` and keep the legacy `Dismiss` button behavior
- add recipient resolution coverage for the `onlyTo` and `exclude` targeting rules, with exclusion taking precedence

## Why
This brings back the old `heads_up` utility in a way that fits the new architecture: communications are created and stored through the API, then explicitly sent by the bot without allowing accidental re-sends.

## Test Plan
- `pnpm --filter @beacon-indexer/api test`
- `pnpm --filter @beacon-indexer/api build`
- `pnpm --filter @beacon-indexer/api typecheck`
- `pnpm --filter telegram-bot type-check`
- commit hooks ran `eslint --fix`, `prettier --write`, and package type-checks during commit

## Notes
- the DB change was added to the Prisma schema and the initial migration, so existing databases still need the schema change applied before using the feature
