### PR TITLE
Add AGENTS response-style guidance and sync lockfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,11 @@ A developer should be able to fully understand the intent and flow of the test b
 - Do not move chat context, refactor history, or temporary reasoning into durable code comments.
 - Avoid vague phrasing like "after this", "at this point", or "now" when a literal comment would be clearer.
 - Prefer comments like "gets current cursor", "opens missing rows", or "updates the slot cursor".
+
+## Response Style
+
+- Respond in concise English.
+- Optimize for brevity and information density.
+- Do not add introductions, summaries, or extra context unless requested.
+- Do not provide long plans for small tasks.
+- Use bullets only when they improve clarity.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2649,7 +2649,7 @@ packages:
   '@vercel/analytics@1.3.1':
     resolution: {integrity: sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==}
     peerDependencies:
-      next: '>=14.2.26'
+      next: '>=14.2.32'
       react: ^18 || ^19
     peerDependenciesMeta:
       next:


### PR DESCRIPTION
## What changed
- adds a `Response Style` section to `AGENTS.md`
- keeps the remaining `pnpm-lock.yaml` metadata update on this rebased branch
- rebases `codex/speed-up-deploy` onto the latest `origin/main`

## Why
- preserves the branch-specific repository instructions that are not yet on `main`
- publishes the branch in its current rebased state without reintroducing changes already merged upstream

## Impact
- contributors get explicit response-style guidance in the repo instructions
- the PR scope reflects only the changes still missing from `main`

## Validation
- `git fetch origin main`
- `git rebase origin/main`
- resolved rebase conflicts and pushed with `git push --force-with-lease -u origin codex/speed-up-deploy`
- tests not run; this request was limited to rebasing and opening the PR