### PR TITLE
guard e2e database credentials

### DIFF
--- a/.github/workflows/e2e-api.yml
+++ b/.github/workflows/e2e-api.yml
@@ -52,17 +52,17 @@ jobs:
       - name: Start PostgreSQL container
         run: |
           docker run --name e2e-postgres \
-            -e POSTGRES_DB=beacon_test \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=password \
-            -p 5433:5432 \
+            -e POSTGRES_DB=e2e_beacon \
+            -e POSTGRES_USER=e2e_user \
+            -e POSTGRES_PASSWORD=e2e_password \
+            -p 5499:5432 \
             --tmpfs /var/lib/postgresql/data \
             -d postgres:16
 
       - name: Wait for PostgreSQL
         run: |
           for i in {1..60}; do
-            if docker exec e2e-postgres pg_isready -U postgres -d beacon_test >/dev/null 2>&1; then
+            if docker exec e2e-postgres pg_isready -U e2e_user -d e2e_beacon >/dev/null 2>&1; then
               echo "PostgreSQL is ready!"
               sleep 2
               break
@@ -76,13 +76,13 @@ jobs:
 
       - name: Setup database
         run: |
-          DATABASE_URL="postgresql://postgres:password@localhost:5433/beacon_test?schema=public" \
+          DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
           pnpm --filter @beacon-indexer/db exec prisma migrate deploy --schema=prisma/schema.prisma
 
       - name: Run e2e tests
         run: |
           cd packages/api
-          DATABASE_URL="postgresql://postgres:password@localhost:5433/beacon_test?schema=public" \
+          DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
           API_TOKEN_SECRET="test-secret-must-be-at-least-32-characters-long" \
           CHAIN="gnosis" \
           COINGECKO_TOKEN_PRICE_API_URL="https://api.coingecko.com/api/v3/simple/price" \

--- a/.github/workflows/e2e-indexer.yml
+++ b/.github/workflows/e2e-indexer.yml
@@ -52,17 +52,17 @@ jobs:
       - name: Start PostgreSQL container
         run: |
           docker run --name e2e-postgres \
-            -e POSTGRES_DB=beacon_test \
-            -e POSTGRES_USER=postgres \
-            -e POSTGRES_PASSWORD=password \
-            -p 5433:5432 \
+            -e POSTGRES_DB=e2e_beacon \
+            -e POSTGRES_USER=e2e_user \
+            -e POSTGRES_PASSWORD=e2e_password \
+            -p 5499:5432 \
             --tmpfs /var/lib/postgresql/data \
             -d postgres:16
 
       - name: Wait for PostgreSQL
         run: |
           for i in {1..60}; do
-            if docker exec e2e-postgres pg_isready -U postgres -d beacon_test >/dev/null 2>&1; then
+            if docker exec e2e-postgres pg_isready -U e2e_user -d e2e_beacon >/dev/null 2>&1; then
               echo "PostgreSQL is ready!"
               sleep 2
               break
@@ -76,13 +76,13 @@ jobs:
 
       - name: Setup database
         run: |
-          DATABASE_URL="postgresql://postgres:password@localhost:5433/beacon_test?schema=public" \
+          DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
           pnpm --filter @beacon-indexer/db exec prisma migrate deploy --schema=prisma/schema.prisma
 
       - name: Run e2e tests
         run: |
           cd packages/indexer
-          DATABASE_URL="postgresql://postgres:password@localhost:5433/beacon_test?schema=public" \
+          DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
           pnpm vitest run --config vitest.e2e.config.ts --no-coverage
 
       - name: Cleanup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@
 
 - **`docs`**: project docs. See `docs/`.
 
+### E2E Tests
+
+Run e2e tests only from the repo root with `pnpm test:e2e:local`.
+Never run e2e tests directly with package scripts, Vitest, `.env`, or custom DB credentials. If the root command cannot be used, stop and ask.
+
 ### E2E Test Documentation
 
 Every end-to-end test must include clear comments explaining what the test does.

--- a/packages/api/e2e/setup.ts
+++ b/packages/api/e2e/setup.ts
@@ -1,0 +1,11 @@
+const E2E_DATABASE_URL =
+  'postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public';
+
+/**
+ * Forces API e2e tests to use the local Docker test database.
+ */
+function forceE2eDatabaseUrl() {
+  process.env.DATABASE_URL = E2E_DATABASE_URL;
+}
+
+forceE2eDatabaseUrl();

--- a/packages/api/e2e/setup.ts
+++ b/packages/api/e2e/setup.ts
@@ -9,3 +9,5 @@ function forceE2eDatabaseUrl() {
 }
 
 forceE2eDatabaseUrl();
+
+export {};

--- a/packages/api/vitest.e2e.config.ts
+++ b/packages/api/vitest.e2e.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     disableConsoleIntercept: true,
     include: ['e2e/**/*.test.ts'],
     exclude: ['e2e/**/mocks/**'],
+    setupFiles: [resolve(__dirname, 'e2e/setup.ts')],
     // Run e2e tests in a single worker to avoid cross-file DB interference
     pool: 'threads',
     poolOptions: {

--- a/packages/indexer/e2e/setup.ts
+++ b/packages/indexer/e2e/setup.ts
@@ -1,0 +1,11 @@
+const E2E_DATABASE_URL =
+  'postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public';
+
+/**
+ * Forces indexer e2e tests to use the local Docker test database.
+ */
+function forceE2eDatabaseUrl() {
+  process.env.DATABASE_URL = E2E_DATABASE_URL;
+}
+
+forceE2eDatabaseUrl();

--- a/packages/indexer/e2e/setup.ts
+++ b/packages/indexer/e2e/setup.ts
@@ -9,3 +9,5 @@ function forceE2eDatabaseUrl() {
 }
 
 forceE2eDatabaseUrl();
+
+export {};

--- a/packages/indexer/vitest.e2e.config.ts
+++ b/packages/indexer/vitest.e2e.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    // No setupFiles for e2e tests - they should use real environment variables
+    // Forces e2e tests to use the hardcoded local Docker test database.
     testTimeout: 300000, // 5 minutes timeout for E2E tests
     hookTimeout: 300000,
     teardownTimeout: 300000,

--- a/packages/indexer/vitest.e2e.config.ts
+++ b/packages/indexer/vitest.e2e.config.ts
@@ -1,6 +1,9 @@
-import { resolve } from 'path';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 import { defineConfig } from 'vitest/config';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   test: {
@@ -13,6 +16,7 @@ export default defineConfig({
     retry: 1,
     bail: 5,
     disableConsoleIntercept: true,
+    setupFiles: [resolve(__dirname, 'e2e/setup.ts')],
     include: ['e2e/**/*.test.ts'], // Include all e2e test files
     exclude: ['e2e/**/mocks/**'], // Exclude mocks
     // Run e2e tests in a single worker to avoid cross-file DB interference

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -15,6 +15,13 @@ NC='\033[0m' # No Color
 # Get package argument (optional)
 PACKAGE="${1:-all}"
 
+# Hardcoded e2e database settings; do not read these values from .env.
+E2E_DB_NAME="e2e_beacon"
+E2E_DB_USER="e2e_user"
+E2E_DB_PASS="e2e_password"
+E2E_DB_PORT="5499"
+E2E_DB_URL="postgresql://$E2E_DB_USER:$E2E_DB_PASS@localhost:$E2E_DB_PORT/$E2E_DB_NAME?schema=public"
+
 echo "🚀 Starting E2E tests locally (package: $PACKAGE)..."
 
 # Check if PostgreSQL container is already running
@@ -27,17 +34,17 @@ fi
 # Start PostgreSQL container with tmpfs for clean data
 echo -e "${GREEN}🐳 Starting PostgreSQL container...${NC}"
 docker run --name e2e-postgres \
-    -e POSTGRES_DB=e2e_beacon \
-    -e POSTGRES_USER=e2e_user \
-    -e POSTGRES_PASSWORD=e2e_password \
-    -p 5499:5432 \
+    -e POSTGRES_DB="$E2E_DB_NAME" \
+    -e POSTGRES_USER="$E2E_DB_USER" \
+    -e POSTGRES_PASSWORD="$E2E_DB_PASS" \
+    -p "$E2E_DB_PORT":5432 \
     --tmpfs /var/lib/postgresql/data \
     -d postgres:16
 
 # Wait for PostgreSQL to be ready
 echo -e "${GREEN}⏳ Waiting for PostgreSQL to be ready...${NC}"
 for i in {1..60}; do
-    if docker exec e2e-postgres pg_isready -U e2e_user -d e2e_beacon >/dev/null 2>&1; then
+    if docker exec e2e-postgres pg_isready -U "$E2E_DB_USER" -d "$E2E_DB_NAME" >/dev/null 2>&1; then
         echo -e "${GREEN}✅ PostgreSQL is ready!${NC}"
         sleep 2  # Give it a moment to fully initialize
         break
@@ -51,7 +58,7 @@ done
 
 # Setup database
 echo -e "${GREEN}🗄️  Setting up database...${NC}"
-DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
+DATABASE_URL="$E2E_DB_URL" \
 pnpm --filter @beacon-indexer/db exec prisma migrate deploy --schema=prisma/schema.prisma
 
 # Store the root directory
@@ -61,7 +68,7 @@ ROOT_DIR=$(pwd)
 run_indexer_e2e() {
     echo -e "${GREEN}🧪 Running indexer E2E tests...${NC}"
     cd "$ROOT_DIR/packages/indexer"
-    DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
+    DATABASE_URL="$E2E_DB_URL" \
     pnpm test:e2e
 }
 
@@ -69,7 +76,7 @@ run_indexer_e2e() {
 run_api_e2e() {
     echo -e "${GREEN}🧪 Running API E2E tests...${NC}"
     cd "$ROOT_DIR/packages/api"
-    DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
+    DATABASE_URL="$E2E_DB_URL" \
     API_TOKEN_SECRET="test-secret-must-be-at-least-32-characters-long" \
     CHAIN="gnosis" \
     TELEGRAM_BOT_TOKEN="fake-token-for-e2e" \

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -27,9 +27,9 @@ fi
 # Start PostgreSQL container with tmpfs for clean data
 echo -e "${GREEN}🐳 Starting PostgreSQL container...${NC}"
 docker run --name e2e-postgres \
-    -e POSTGRES_DB=beacon_test \
-    -e POSTGRES_USER=postgres \
-    -e POSTGRES_PASSWORD=password \
+    -e POSTGRES_DB=e2e_beacon \
+    -e POSTGRES_USER=e2e_user \
+    -e POSTGRES_PASSWORD=e2e_password \
     -p 5499:5432 \
     --tmpfs /var/lib/postgresql/data \
     -d postgres:16
@@ -37,7 +37,7 @@ docker run --name e2e-postgres \
 # Wait for PostgreSQL to be ready
 echo -e "${GREEN}⏳ Waiting for PostgreSQL to be ready...${NC}"
 for i in {1..60}; do
-    if docker exec e2e-postgres pg_isready -U postgres -d beacon_test >/dev/null 2>&1; then
+    if docker exec e2e-postgres pg_isready -U e2e_user -d e2e_beacon >/dev/null 2>&1; then
         echo -e "${GREEN}✅ PostgreSQL is ready!${NC}"
         sleep 2  # Give it a moment to fully initialize
         break
@@ -51,7 +51,7 @@ done
 
 # Setup database
 echo -e "${GREEN}🗄️  Setting up database...${NC}"
-DATABASE_URL="postgresql://postgres:password@localhost:5499/beacon_test?schema=public" \
+DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
 pnpm --filter @beacon-indexer/db exec prisma migrate deploy --schema=prisma/schema.prisma
 
 # Store the root directory
@@ -61,7 +61,7 @@ ROOT_DIR=$(pwd)
 run_indexer_e2e() {
     echo -e "${GREEN}🧪 Running indexer E2E tests...${NC}"
     cd "$ROOT_DIR/packages/indexer"
-    DATABASE_URL="postgresql://postgres:password@localhost:5499/beacon_test?schema=public" \
+    DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
     pnpm test:e2e
 }
 
@@ -69,7 +69,7 @@ run_indexer_e2e() {
 run_api_e2e() {
     echo -e "${GREEN}🧪 Running API E2E tests...${NC}"
     cd "$ROOT_DIR/packages/api"
-    DATABASE_URL="postgresql://postgres:password@localhost:5499/beacon_test?schema=public" \
+    DATABASE_URL="postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public" \
     API_TOKEN_SECRET="test-secret-must-be-at-least-32-characters-long" \
     CHAIN="gnosis" \
     TELEGRAM_BOT_TOKEN="fake-token-for-e2e" \


### PR DESCRIPTION
## Summary
- force API and indexer e2e tests to use the hardcoded local Docker e2e database
- update local and CI e2e runners to create `e2e_beacon` with `e2e_user` / `e2e_password` on localhost port `5499`
- document that e2e tests must be run only through the root `pnpm test:e2e:local` command

## Test Plan
- [x] `pnpm --filter @beacon-indexer/api typecheck`
- [x] `pnpm --filter @beacon-indexer/api exec eslint vitest.e2e.config.ts e2e/setup.ts`
- [x] `pnpm --filter indexer exec eslint vitest.e2e.config.ts e2e/setup.ts`
- [ ] e2e tests intentionally not run
