### PR TITLE
Add lazy-loaded cluster incidents

### DIFF
--- a/packages/webapp/components/validators/events-feed-content.tsx
+++ b/packages/webapp/components/validators/events-feed-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import ArrowRight from '@/components/icons/arrow-right';
 import { Button } from '@/components/ui/button';
@@ -12,6 +12,10 @@ import {
   UnderlineTabsTrigger,
 } from '@/components/underline-tabs';
 import { useBlockProposals } from '@/hooks/use-block-proposals';
+import type { ClusterIncident } from '@/hooks/use-cluster-incidents';
+import { useClusterIncidents } from '@/hooks/use-cluster-incidents';
+import type { IncidentAffectedValidator } from '@/hooks/use-incident-affected-validators';
+import { useIncidentAffectedValidators } from '@/hooks/use-incident-affected-validators';
 import { cn } from '@/lib/utils';
 
 interface EventsFeedContentProps {
@@ -19,6 +23,8 @@ interface EventsFeedContentProps {
 }
 
 export default function EventsFeedContent({ clusterId }: EventsFeedContentProps) {
+  const [activeTab, setActiveTab] = useState('blocks');
+
   return (
     <div>
       <div className="flex items-center gap-2 mb-3">
@@ -27,7 +33,7 @@ export default function EventsFeedContent({ clusterId }: EventsFeedContentProps)
         </span>
         <div className="flex-1 h-px bg-primary/20" />
       </div>
-      <UnderlineTabs defaultValue="blocks">
+      <UnderlineTabs defaultValue="blocks" value={activeTab} onValueChange={setActiveTab}>
         <UnderlineTabsList>
           <UnderlineTabsTrigger value="blocks">Blocks</UnderlineTabsTrigger>
           <UnderlineTabsTrigger value="incidents">Incidents</UnderlineTabsTrigger>
@@ -41,7 +47,7 @@ export default function EventsFeedContent({ clusterId }: EventsFeedContentProps)
         </UnderlineTabsContent>
 
         <UnderlineTabsContent value="incidents" className="space-y-2 mt-4 min-h-[400px]">
-          <p className="text-sm text-muted-foreground text-center py-8">No incidents</p>
+          <IncidentsTab clusterId={clusterId} isActive={activeTab === 'incidents'} />
         </UnderlineTabsContent>
 
         <UnderlineTabsContent value="consolidations" className="space-y-2 mt-4 min-h-[400px]">
@@ -113,6 +119,270 @@ function BlocksTab({ clusterId }: { clusterId: string | null }) {
           </Button>
         </div>
       )}
+    </div>
+  );
+}
+
+// --- Incidents Tab ---
+
+/** Renders lazy-loaded cluster incidents with pagination. */
+function IncidentsTab({ clusterId, isActive }: { clusterId: string | null; isActive: boolean }) {
+  const [incidentsPage, setIncidentsPage] = useState(1);
+  const {
+    data: incidentsData,
+    isLoading,
+    error,
+  } = useClusterIncidents(clusterId, incidentsPage, isActive);
+
+  const totalIncidentPages = incidentsData
+    ? Math.ceil(incidentsData.totalCount / incidentsData.pageSize)
+    : 0;
+
+  useEffect(() => {
+    // Resets incident pagination when the selected cluster changes.
+    setIncidentsPage(1);
+  }, [clusterId]);
+
+  if (!clusterId) {
+    return <p className="text-sm text-muted-foreground text-center py-8">Select a cluster</p>;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-16 bg-foreground/5 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-destructive text-center py-8">{error.message}</p>;
+  }
+
+  if (!incidentsData || incidentsData.incidents.length === 0) {
+    return <p className="text-sm text-muted-foreground text-center py-8">No incidents</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {incidentsData.incidents.map((incident) => (
+        <IncidentItem key={incident.id} incident={incident} />
+      ))}
+      {totalIncidentPages > 1 && (
+        <div className="flex items-center justify-between pt-3 border-t border-border/50">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setIncidentsPage((p) => Math.max(1, p - 1))}
+            disabled={incidentsPage <= 1}
+          >
+            Prev
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            Page {incidentsPage} of {totalIncidentPages}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setIncidentsPage((p) => Math.min(totalIncidentPages, p + 1))}
+            disabled={incidentsPage >= totalIncidentPages}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Incident Item ---
+
+/** Renders one incident row and lazy-loads affected validators when opened. */
+function IncidentItem({ incident }: { incident: ClusterIncident }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [validatorsPage, setValidatorsPage] = useState(1);
+  const {
+    data: validatorsData,
+    isLoading,
+    error,
+  } = useIncidentAffectedValidators(incident.id, validatorsPage, isOpen);
+
+  const totalValidatorPages = validatorsData
+    ? Math.ceil(validatorsData.totalCount / validatorsData.pageSize)
+    : 0;
+
+  const durationLabel =
+    incident.durationSlots !== null ? `${incident.durationSlots.toLocaleString()} slots` : 'Open';
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger className="w-full">
+        <div className="flex items-center gap-2 md:gap-3 p-2 md:p-3 rounded-lg bg-accent hover:bg-accent/80 transition-colors group cursor-pointer border border-border/50 hover:border-border">
+          <div className="flex-1 flex items-center gap-2 text-left min-w-0">
+            <span className="text-xs md:text-sm font-mono text-muted-foreground whitespace-nowrap capitalize">
+              {incident.status}
+            </span>
+            <span className="text-xs md:text-sm font-mono whitespace-nowrap">
+              Slot #{incident.openedSlot.toLocaleString()}
+            </span>
+            <span className="text-xs md:text-sm text-muted-foreground truncate">
+              {durationLabel}
+            </span>
+          </div>
+
+          <ArrowRight
+            className={cn(
+              'size-4 text-foreground/60 transition-transform flex-shrink-0',
+              isOpen && 'rotate-90',
+              'group-hover:text-foreground',
+            )}
+          />
+        </div>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <div className="px-3 py-3 ml-6 md:ml-11 space-y-3 text-sm border-l-2 border-border">
+          <IncidentDetails incident={incident} />
+          <AffectedValidatorsSection
+            validators={validatorsData?.validators ?? []}
+            isLoading={isLoading}
+            errorMessage={error?.message}
+            totalPages={totalValidatorPages}
+            currentPage={validatorsPage}
+            onPreviousPage={() => setValidatorsPage((p) => Math.max(1, p - 1))}
+            onNextPage={() => setValidatorsPage((p) => Math.min(totalValidatorPages, p + 1))}
+          />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+/** Renders static incident metadata. */
+function IncidentDetails({ incident }: { incident: ClusterIncident }) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Opened</span>
+        <span className="font-mono text-xs break-all">{incident.openedAt}</span>
+      </div>
+      {incident.closedAt && (
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground text-xs md:text-sm">Closed</span>
+          <span className="font-mono text-xs break-all">{incident.closedAt}</span>
+        </div>
+      )}
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Opened Slot</span>
+        <span className="font-mono text-xs md:text-sm">{incident.openedSlot.toLocaleString()}</span>
+      </div>
+      {incident.closedSlot !== null && (
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground text-xs md:text-sm">Closed Slot</span>
+          <span className="font-mono text-xs md:text-sm">
+            {incident.closedSlot.toLocaleString()}
+          </span>
+        </div>
+      )}
+      {incident.missedConsensusRewards !== null && (
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground text-xs md:text-sm">Missed Consensus Rewards</span>
+          <span className="font-normal text-destructive text-xs md:text-sm">
+            {incident.missedConsensusRewards}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AffectedValidatorsSectionProps {
+  validators: IncidentAffectedValidator[];
+  isLoading: boolean;
+  errorMessage?: string;
+  totalPages: number;
+  currentPage: number;
+  onPreviousPage: () => void;
+  onNextPage: () => void;
+}
+
+/** Renders the lazy-loaded affected validators list. */
+function AffectedValidatorsSection({
+  validators,
+  isLoading,
+  errorMessage,
+  totalPages,
+  currentPage,
+  onPreviousPage,
+  onNextPage,
+}: AffectedValidatorsSectionProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <p className="text-xs uppercase tracking-wider text-muted-foreground">
+          Affected Validators
+        </p>
+        <div className="h-12 bg-foreground/5 rounded-lg animate-pulse" />
+      </div>
+    );
+  }
+
+  if (errorMessage) {
+    return <p className="text-sm text-destructive py-2">{errorMessage}</p>;
+  }
+
+  if (validators.length === 0) {
+    return <p className="text-sm text-muted-foreground py-2">No affected validators</p>;
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs uppercase tracking-wider text-muted-foreground">Affected Validators</p>
+      <div className="space-y-1">
+        {validators.map((validator) => (
+          <AffectedValidatorItem key={validator.validatorIndex} validator={validator} />
+        ))}
+      </div>
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-2">
+          <Button variant="ghost" size="sm" onClick={onPreviousPage} disabled={currentPage <= 1}>
+            Prev
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            Page {currentPage} of {totalPages}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onNextPage}
+            disabled={currentPage >= totalPages}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Renders one affected validator row. */
+function AffectedValidatorItem({ validator }: { validator: IncidentAffectedValidator }) {
+  const slotRange =
+    validator.inactiveToSlot !== null
+      ? `${validator.inactiveFromSlot.toLocaleString()}-${validator.inactiveToSlot.toLocaleString()}`
+      : `${validator.inactiveFromSlot.toLocaleString()}-open`;
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md bg-background/60 border border-border/50 px-2 py-1.5">
+      <span className="font-mono text-xs md:text-sm whitespace-nowrap">
+        Val #{validator.validatorIndex}
+      </span>
+      <span className="font-mono text-xs text-muted-foreground truncate">Slots {slotRange}</span>
+      <span className="font-normal text-destructive text-xs md:text-sm whitespace-nowrap">
+        {validator.missedConsensusRewards}
+      </span>
     </div>
   );
 }

--- a/packages/webapp/hooks/use-cluster-incidents.ts
+++ b/packages/webapp/hooks/use-cluster-incidents.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { orpcClient } from '@/lib/orpc';
+
+export interface ClusterIncident {
+  id: string;
+  status: 'open' | 'closed';
+  openedAt: string;
+  openedSlot: number;
+  closedAt: string | null;
+  closedSlot: number | null;
+  durationSlots: number | null;
+  durationSeconds: number | null;
+  missedAttestationRewards: string | null;
+  missedSyncRewards: string | null;
+  missedConsensusRewards: string | null;
+  rewardsFinalized: boolean;
+  rewardsFinalizedAt: string | null;
+  openedNotificationQueuedAt: string | null;
+  closedNotificationQueuedAt: string | null;
+}
+
+export interface ClusterIncidentsResult {
+  incidents: ClusterIncident[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+const INCIDENTS_PAGE_SIZE = 10;
+
+/** Fetches paginated cluster incidents when the incidents tab is active. */
+export function useClusterIncidents(clusterId: string | null, page: number, enabled: boolean) {
+  return useQuery({
+    queryKey: ['clusterIncidents', clusterId, page],
+    queryFn: async () => {
+      if (!clusterId) throw new Error('No cluster provided');
+
+      const response = await orpcClient.cluster.incidents({
+        id: clusterId,
+        page,
+        pageSize: INCIDENTS_PAGE_SIZE,
+      });
+
+      if (!response.success) {
+        throw new Error(response.error?.message || 'Failed to fetch cluster incidents');
+      }
+
+      return response.data as ClusterIncidentsResult;
+    },
+    enabled: Boolean(clusterId && enabled),
+  });
+}

--- a/packages/webapp/hooks/use-incident-affected-validators.ts
+++ b/packages/webapp/hooks/use-incident-affected-validators.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { orpcClient } from '@/lib/orpc';
+
+export interface IncidentAffectedValidator {
+  validatorIndex: number;
+  inactiveFromSlot: number;
+  inactiveToSlot: number | null;
+  rewardsProcessedThroughSlot: number | null;
+  missedAttestationRewards: string;
+  missedSyncRewards: string;
+  missedConsensusRewards: string;
+}
+
+export interface IncidentAffectedValidatorsResult {
+  validators: IncidentAffectedValidator[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+const AFFECTED_VALIDATORS_PAGE_SIZE = 100;
+
+/** Fetches affected validators only after an incident row is expanded. */
+export function useIncidentAffectedValidators(incidentId: string, page: number, enabled: boolean) {
+  return useQuery({
+    queryKey: ['incidentAffectedValidators', incidentId, page],
+    queryFn: async () => {
+      const response = await orpcClient.cluster.incidentAffectedValidators({
+        incidentId,
+        page,
+        pageSize: AFFECTED_VALIDATORS_PAGE_SIZE,
+      });
+
+      if (!response.success) {
+        throw new Error(response.error?.message || 'Failed to fetch affected validators');
+      }
+
+      return response.data as IncidentAffectedValidatorsResult;
+    },
+    enabled,
+  });
+}


### PR DESCRIPTION
## Summary

- Load cluster incidents only when the Incidents events tab is active.
- Fetch incidents 10 per page and add tab-level pagination.
- Lazy-load affected validators only when an incident is expanded, with 100 validators per page.

## Validation

- `pnpm --filter @beacon-indexer/webapp type-check`
- `pnpm --filter @beacon-indexer/webapp lint` (passes with pre-existing warnings outside this change)
- Pre-commit hook: `pnpm --filter @beacon-indexer/api build && pnpm --filter @beacon-indexer/webapp exec tsc --noEmit`
