### PR TITLE
Update incident notifications and feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,9 @@ A developer should be able to fully understand the intent and flow of the test b
 
 - Every code block must include clear comments explaining its purpose. Comments should be sufficient for a developer to understand the logic without reading the code itself.
 - Every function must have a short comment summarizing what it does.
-- Comments must be simple and direct.
-- Comments must describe the local code only.
+- Comments must be simple, easy to understand, direct and describe the local code only
 - Do not move chat context, refactor history, or temporary reasoning into durable code comments.
-- Avoid vague phrasing like "after this", "at this point", or "now" when a literal comment would be clearer.
-- Prefer comments like "gets current cursor", "opens missing rows", or "updates the slot cursor".
+- Do not mix reusable helpers with feature logic. Move reusable formatting, parsing, calculation, or conversion helpers to a shared `utils` module with generic names and interfaces.
 
 ## Agent
 

--- a/packages/telegram-bot/src/scheduler/process-incident-notifications.test.ts
+++ b/packages/telegram-bot/src/scheduler/process-incident-notifications.test.ts
@@ -3,13 +3,11 @@ import test from 'node:test';
 
 import type { InlineKeyboardMarkup } from 'grammy/types';
 
-import { buildIncidentNotificationSendOptions } from './process-incident-notifications.js';
+import { buildIncidentNotificationSendOptions } from '../telegram/incident-notification-options.js';
 
 /** Gets the inline keyboard from send options for assertions. */
-function getInlineKeyboardMarkup(
-  type: 'incident_opened' | 'incident_closed',
-): InlineKeyboardMarkup {
-  const options = buildIncidentNotificationSendOptions(type);
+function getInlineKeyboardMarkup(): InlineKeyboardMarkup {
+  const options = buildIncidentNotificationSendOptions();
   assert.ok(options);
   assert.ok(options.reply_markup);
   assert.ok('inline_keyboard' in options.reply_markup);
@@ -19,7 +17,7 @@ function getInlineKeyboardMarkup(
 
 test('buildIncidentNotificationSendOptions adds a dismiss button to opened incident notifications', () => {
   // This case builds the Telegram send options for an opened incident alert.
-  const replyMarkup = getInlineKeyboardMarkup('incident_opened');
+  const replyMarkup = getInlineKeyboardMarkup();
 
   // This assertion verifies users can dismiss opened incident alerts from Telegram.
   assert.deepEqual(replyMarkup.inline_keyboard, [
@@ -29,7 +27,7 @@ test('buildIncidentNotificationSendOptions adds a dismiss button to opened incid
 
 test('buildIncidentNotificationSendOptions adds a dismiss button to closed incident notifications', () => {
   // This case builds the Telegram send options for a closed incident alert.
-  const replyMarkup = getInlineKeyboardMarkup('incident_closed');
+  const replyMarkup = getInlineKeyboardMarkup();
 
   // This assertion verifies users can dismiss closed incident alerts from Telegram.
   assert.deepEqual(replyMarkup.inline_keyboard, [

--- a/packages/telegram-bot/src/scheduler/process-incident-notifications.test.ts
+++ b/packages/telegram-bot/src/scheduler/process-incident-notifications.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { InlineKeyboardMarkup } from 'grammy/types';
+
+import { buildIncidentNotificationSendOptions } from './process-incident-notifications.js';
+
+/** Gets the inline keyboard from send options for assertions. */
+function getInlineKeyboardMarkup(
+  type: 'incident_opened' | 'incident_closed',
+): InlineKeyboardMarkup {
+  const options = buildIncidentNotificationSendOptions(type);
+  assert.ok(options);
+  assert.ok(options.reply_markup);
+  assert.ok('inline_keyboard' in options.reply_markup);
+
+  return options.reply_markup;
+}
+
+test('buildIncidentNotificationSendOptions adds a dismiss button to opened incident notifications', () => {
+  // This case builds the Telegram send options for an opened incident alert.
+  const replyMarkup = getInlineKeyboardMarkup('incident_opened');
+
+  // This assertion verifies users can dismiss opened incident alerts from Telegram.
+  assert.deepEqual(replyMarkup.inline_keyboard, [
+    [{ text: 'Dismiss', callback_data: 'remove_message' }],
+  ]);
+});
+
+test('buildIncidentNotificationSendOptions adds a dismiss button to closed incident notifications', () => {
+  // This case builds the Telegram send options for a closed incident alert.
+  const replyMarkup = getInlineKeyboardMarkup('incident_closed');
+
+  // This assertion verifies users can dismiss closed incident alerts from Telegram.
+  assert.deepEqual(replyMarkup.inline_keyboard, [
+    [{ text: 'Dismiss', callback_data: 'remove_message' }],
+  ]);
+});

--- a/packages/telegram-bot/src/scheduler/process-incident-notifications.ts
+++ b/packages/telegram-bot/src/scheduler/process-incident-notifications.ts
@@ -1,9 +1,9 @@
 import type { Api, RawApi } from 'grammy';
-import { InlineKeyboard } from 'grammy';
 
 import { COMMON_REQUESTS_TELEGRAM_ID, getRpcClientForUser } from '@/src/api/client.js';
 import type { Logger } from '@/src/logger.js';
 import { formatNotificationMessage } from '@/src/telegram/format-notification.js';
+import { buildIncidentNotificationSendOptions } from '@/src/telegram/incident-notification-options.js';
 import { sendMessage } from '@/src/telegram/messaging.js';
 
 type IncidentNotificationType = 'incident_opened' | 'incident_closed';
@@ -15,20 +15,6 @@ interface BotIncidentNotification {
   type: IncidentNotificationType;
   payload: unknown;
   createdAt: string;
-}
-
-type IncidentNotificationSendOptions = Parameters<Api<RawApi>['sendMessage']>[2];
-
-/** Builds Telegram send options for incident notifications. */
-export function buildIncidentNotificationSendOptions(
-  _type: IncidentNotificationType,
-): IncidentNotificationSendOptions {
-  const dismissKeyboard = new InlineKeyboard().text('Dismiss', 'remove_message');
-
-  return {
-    link_preview_options: { is_disabled: true },
-    reply_markup: dismissKeyboard,
-  };
 }
 
 /** Processes incident notifications without using the notification queue. */
@@ -59,7 +45,7 @@ export async function processIncidentNotifications(
       telegramId: notification.telegramId,
       text: message,
       logger: log.child({ incidentId: notification.id, type: notification.type }),
-      options: buildIncidentNotificationSendOptions(notification.type),
+      options: buildIncidentNotificationSendOptions(),
     });
 
     if (messageId === null) continue;

--- a/packages/telegram-bot/src/scheduler/process-incident-notifications.ts
+++ b/packages/telegram-bot/src/scheduler/process-incident-notifications.ts
@@ -1,4 +1,5 @@
 import type { Api, RawApi } from 'grammy';
+import { InlineKeyboard } from 'grammy';
 
 import { COMMON_REQUESTS_TELEGRAM_ID, getRpcClientForUser } from '@/src/api/client.js';
 import type { Logger } from '@/src/logger.js';
@@ -14,6 +15,20 @@ interface BotIncidentNotification {
   type: IncidentNotificationType;
   payload: unknown;
   createdAt: string;
+}
+
+type IncidentNotificationSendOptions = Parameters<Api<RawApi>['sendMessage']>[2];
+
+/** Builds Telegram send options for incident notifications. */
+export function buildIncidentNotificationSendOptions(
+  _type: IncidentNotificationType,
+): IncidentNotificationSendOptions {
+  const dismissKeyboard = new InlineKeyboard().text('Dismiss', 'remove_message');
+
+  return {
+    link_preview_options: { is_disabled: true },
+    reply_markup: dismissKeyboard,
+  };
 }
 
 /** Processes incident notifications without using the notification queue. */
@@ -44,9 +59,7 @@ export async function processIncidentNotifications(
       telegramId: notification.telegramId,
       text: message,
       logger: log.child({ incidentId: notification.id, type: notification.type }),
-      options: {
-        link_preview_options: { is_disabled: true },
-      },
+      options: buildIncidentNotificationSendOptions(notification.type),
     });
 
     if (messageId === null) continue;

--- a/packages/telegram-bot/src/telegram/format-date.test.ts
+++ b/packages/telegram-bot/src/telegram/format-date.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { formatUtcDateTime } from './format-date.js';
+
+test('formatUtcDateTime formats ISO timestamps in UTC', () => {
+  // This timestamp includes a non-UTC offset to verify the output is normalized.
+  const timestamp = '2026-04-21T09:00:00.000-03:00';
+
+  // This assertion verifies the visible time is UTC and omits ISO separators.
+  assert.equal(formatUtcDateTime(timestamp), '2026-04-21 12:00:00 UTC');
+});
+
+test('formatUtcDateTime returns a dash for missing timestamps', () => {
+  // This assertion verifies optional incident timestamps render as empty fields.
+  assert.equal(formatUtcDateTime(undefined), '-');
+});

--- a/packages/telegram-bot/src/telegram/format-date.ts
+++ b/packages/telegram-bot/src/telegram/format-date.ts
@@ -1,0 +1,20 @@
+/** Formats an ISO timestamp as a UTC date-time string. */
+export function formatUtcDateTime(timestamp: string | undefined): string {
+  if (!timestamp) return '-';
+
+  const date = new Date(timestamp);
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    day: '2-digit',
+    hour: '2-digit',
+    hour12: false,
+    minute: '2-digit',
+    month: '2-digit',
+    second: '2-digit',
+    timeZone: 'UTC',
+    year: 'numeric',
+  }).formatToParts(date);
+  const partValue = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? '';
+
+  return `${partValue('year')}-${partValue('month')}-${partValue('day')} ${partValue('hour')}:${partValue('minute')}:${partValue('second')} UTC`;
+}

--- a/packages/telegram-bot/src/telegram/format-notification.test.ts
+++ b/packages/telegram-bot/src/telegram/format-notification.test.ts
@@ -18,7 +18,7 @@ test('formatNotificationMessage formats opened incident notifications without va
       'Cluster incident opened',
       'Cluster: Main validators',
       'Started slot: 123',
-      'Started at: 2026-04-21T12:00:00.000Z',
+      'Started at: 2026-04-21 12:00:00 UTC',
     ].join('\n'),
   );
 });
@@ -54,7 +54,7 @@ test('formatNotificationMessage formats closed incident notifications without re
       'Cluster incident resolved',
       'Cluster: Main validators',
       'Closed slot: 153',
-      'Closed at: 2026-04-21T13:00:00.000Z',
+      'Closed at: 2026-04-21 13:00:00 UTC',
     ].join('\n'),
   );
 });

--- a/packages/telegram-bot/src/telegram/format-notification.ts
+++ b/packages/telegram-bot/src/telegram/format-notification.ts
@@ -1,6 +1,8 @@
 import { formatDistanceStrict, parseISO } from 'date-fns';
 import { z } from 'zod';
 
+import { formatUtcDateTime } from './format-date.js';
+
 type NotificationFormatter = (payload: unknown) => string;
 
 const IncidentPayloadSchema = z.object({
@@ -56,7 +58,7 @@ function formatIncidentOpened(payload: unknown): string {
     'Cluster incident opened',
     `Cluster: ${data.clusterName ?? 'Unknown cluster'}`,
     `Started slot: ${data.openedSlot ?? '-'}`,
-    `Started at: ${data.openedAt ?? '-'}`,
+    `Started at: ${formatUtcDateTime(data.openedAt)}`,
   ].join('\n');
 }
 
@@ -68,7 +70,7 @@ function formatIncidentClosed(payload: unknown): string {
     'Cluster incident resolved',
     `Cluster: ${data.clusterName ?? 'Unknown cluster'}`,
     `Closed slot: ${data.closedSlot ?? '-'}`,
-    `Closed at: ${data.closedAt ?? '-'}`,
+    `Closed at: ${formatUtcDateTime(data.closedAt)}`,
   ].join('\n');
 }
 

--- a/packages/telegram-bot/src/telegram/incident-notification-options.ts
+++ b/packages/telegram-bot/src/telegram/incident-notification-options.ts
@@ -1,0 +1,14 @@
+import type { Api, RawApi } from 'grammy';
+import { InlineKeyboard } from 'grammy';
+
+type IncidentNotificationSendOptions = Parameters<Api<RawApi>['sendMessage']>[2];
+
+/** Builds Telegram send options for incident notifications. */
+export function buildIncidentNotificationSendOptions(): IncidentNotificationSendOptions {
+  const dismissKeyboard = new InlineKeyboard().text('Dismiss', 'remove_message');
+
+  return {
+    link_preview_options: { is_disabled: true },
+    reply_markup: dismissKeyboard,
+  };
+}

--- a/packages/webapp/components/validators/events-feed-content.tsx
+++ b/packages/webapp/components/validators/events-feed-content.tsx
@@ -11,12 +11,19 @@ import {
   UnderlineTabsList,
   UnderlineTabsTrigger,
 } from '@/components/underline-tabs';
+import { env } from '@/env';
 import { useBlockProposals } from '@/hooks/use-block-proposals';
+import { useChainStats } from '@/hooks/use-chain-stats';
 import type { ClusterIncident } from '@/hooks/use-cluster-incidents';
 import { useClusterIncidents } from '@/hooks/use-cluster-incidents';
-import type { IncidentAffectedValidator } from '@/hooks/use-incident-affected-validators';
 import { useIncidentAffectedValidators } from '@/hooks/use-incident-affected-validators';
-import { cn } from '@/lib/utils';
+import {
+  cn,
+  formatIncidentDateTime,
+  formatIncidentDuration,
+  formatNumber,
+  getTokenSymbol,
+} from '@/lib/utils';
 
 interface EventsFeedContentProps {
   clusterId: string | null;
@@ -128,6 +135,7 @@ function BlocksTab({ clusterId }: { clusterId: string | null }) {
 /** Renders lazy-loaded cluster incidents with pagination. */
 function IncidentsTab({ clusterId, isActive }: { clusterId: string | null; isActive: boolean }) {
   const [incidentsPage, setIncidentsPage] = useState(1);
+  const { data: chainStats } = useChainStats();
   const {
     data: incidentsData,
     isLoading,
@@ -137,6 +145,8 @@ function IncidentsTab({ clusterId, isActive }: { clusterId: string | null; isAct
   const totalIncidentPages = incidentsData
     ? Math.ceil(incidentsData.totalCount / incidentsData.pageSize)
     : 0;
+  const tokenPrice = chainStats?.tokenPrice ?? 0;
+  const tokenSymbol = getTokenSymbol(env.NEXT_PUBLIC_CHAIN);
 
   useEffect(() => {
     // Resets incident pagination when the selected cluster changes.
@@ -168,7 +178,12 @@ function IncidentsTab({ clusterId, isActive }: { clusterId: string | null; isAct
   return (
     <div className="space-y-2">
       {incidentsData.incidents.map((incident) => (
-        <IncidentItem key={incident.id} incident={incident} />
+        <IncidentItem
+          key={incident.id}
+          incident={incident}
+          tokenPrice={tokenPrice}
+          tokenSymbol={tokenSymbol}
+        />
       ))}
       {totalIncidentPages > 1 && (
         <div className="flex items-center justify-between pt-3 border-t border-border/50">
@@ -200,35 +215,35 @@ function IncidentsTab({ clusterId, isActive }: { clusterId: string | null; isAct
 // --- Incident Item ---
 
 /** Renders one incident row and lazy-loads affected validators when opened. */
-function IncidentItem({ incident }: { incident: ClusterIncident }) {
+function IncidentItem({
+  incident,
+  tokenPrice,
+  tokenSymbol,
+}: {
+  incident: ClusterIncident;
+  tokenPrice: number;
+  tokenSymbol: string;
+}) {
   const [isOpen, setIsOpen] = useState(false);
-  const [validatorsPage, setValidatorsPage] = useState(1);
   const {
     data: validatorsData,
     isLoading,
     error,
-  } = useIncidentAffectedValidators(incident.id, validatorsPage, isOpen);
-
-  const totalValidatorPages = validatorsData
-    ? Math.ceil(validatorsData.totalCount / validatorsData.pageSize)
-    : 0;
-
-  const durationLabel =
-    incident.durationSlots !== null ? `${incident.durationSlots.toLocaleString()} slots` : 'Open';
+  } = useIncidentAffectedValidators(incident.id, 1, isOpen);
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <CollapsibleTrigger className="w-full">
         <div className="flex items-center gap-2 md:gap-3 p-2 md:p-3 rounded-lg bg-accent hover:bg-accent/80 transition-colors group cursor-pointer border border-border/50 hover:border-border">
-          <div className="flex-1 flex items-center gap-2 text-left min-w-0">
+          <div className="flex-1 grid grid-cols-[auto_auto_1fr] items-center gap-2 text-left min-w-0">
+            <span className="text-xs md:text-sm font-mono text-muted-foreground whitespace-nowrap">
+              {formatIncidentDateTime(incident.openedAt)}
+            </span>
             <span className="text-xs md:text-sm font-mono text-muted-foreground whitespace-nowrap capitalize">
               {incident.status}
             </span>
-            <span className="text-xs md:text-sm font-mono whitespace-nowrap">
-              Slot #{incident.openedSlot.toLocaleString()}
-            </span>
             <span className="text-xs md:text-sm text-muted-foreground truncate">
-              {durationLabel}
+              {formatIncidentDuration(incident)}
             </span>
           </div>
 
@@ -244,15 +259,13 @@ function IncidentItem({ incident }: { incident: ClusterIncident }) {
 
       <CollapsibleContent>
         <div className="px-3 py-3 ml-6 md:ml-11 space-y-3 text-sm border-l-2 border-border">
-          <IncidentDetails incident={incident} />
-          <AffectedValidatorsSection
-            validators={validatorsData?.validators ?? []}
+          <IncidentDetails
+            incident={incident}
             isLoading={isLoading}
             errorMessage={error?.message}
-            totalPages={totalValidatorPages}
-            currentPage={validatorsPage}
-            onPreviousPage={() => setValidatorsPage((p) => Math.max(1, p - 1))}
-            onNextPage={() => setValidatorsPage((p) => Math.min(totalValidatorPages, p + 1))}
+            tokenPrice={tokenPrice}
+            tokenSymbol={tokenSymbol}
+            validatorsAffected={validatorsData?.totalCount}
           />
         </div>
       </CollapsibleContent>
@@ -261,127 +274,139 @@ function IncidentItem({ incident }: { incident: ClusterIncident }) {
 }
 
 /** Renders static incident metadata. */
-function IncidentDetails({ incident }: { incident: ClusterIncident }) {
+function IncidentDetails({
+  incident,
+  isLoading,
+  errorMessage,
+  tokenPrice,
+  tokenSymbol,
+  validatorsAffected,
+}: {
+  incident: ClusterIncident;
+  isLoading: boolean;
+  errorMessage?: string;
+  tokenPrice: number;
+  tokenSymbol: string;
+  validatorsAffected?: number;
+}) {
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-4">
-        <span className="text-muted-foreground text-xs md:text-sm">Opened</span>
-        <span className="font-mono text-xs break-all">{incident.openedAt}</span>
+        <span className="text-muted-foreground text-xs md:text-sm">Open</span>
+        <span className="font-mono text-xs break-all">
+          {formatIncidentDateTime(incident.openedAt)}
+        </span>
       </div>
-      {incident.closedAt && (
-        <div className="flex items-center justify-between gap-4">
-          <span className="text-muted-foreground text-xs md:text-sm">Closed</span>
-          <span className="font-mono text-xs break-all">{incident.closedAt}</span>
-        </div>
-      )}
       <div className="flex items-center justify-between gap-4">
-        <span className="text-muted-foreground text-xs md:text-sm">Opened Slot</span>
+        <span className="text-muted-foreground text-xs md:text-sm">Close</span>
+        <span className="font-mono text-xs break-all">
+          {incident.closedAt ? formatIncidentDateTime(incident.closedAt) : '-'}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Duration</span>
+        <span className="font-mono text-xs md:text-sm">{formatIncidentDuration(incident)}</span>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Open Slot</span>
         <span className="font-mono text-xs md:text-sm">{incident.openedSlot.toLocaleString()}</span>
       </div>
-      {incident.closedSlot !== null && (
-        <div className="flex items-center justify-between gap-4">
-          <span className="text-muted-foreground text-xs md:text-sm">Closed Slot</span>
-          <span className="font-mono text-xs md:text-sm">
-            {incident.closedSlot.toLocaleString()}
-          </span>
-        </div>
-      )}
-      {incident.missedConsensusRewards !== null && (
-        <div className="flex items-center justify-between gap-4">
-          <span className="text-muted-foreground text-xs md:text-sm">Missed Consensus Rewards</span>
-          <span className="font-normal text-destructive text-xs md:text-sm">
-            {incident.missedConsensusRewards}
-          </span>
-        </div>
-      )}
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Close Slot</span>
+        <span className="font-mono text-xs md:text-sm">
+          {incident.closedSlot !== null ? incident.closedSlot.toLocaleString() : '-'}
+        </span>
+      </div>
+      <IncidentRewards incident={incident} tokenPrice={tokenPrice} tokenSymbol={tokenSymbol} />
+      <AffectedValidatorsCount
+        isLoading={isLoading}
+        errorMessage={errorMessage}
+        validatorsAffected={validatorsAffected}
+      />
     </div>
   );
 }
 
-interface AffectedValidatorsSectionProps {
-  validators: IncidentAffectedValidator[];
-  isLoading: boolean;
-  errorMessage?: string;
-  totalPages: number;
-  currentPage: number;
-  onPreviousPage: () => void;
-  onNextPage: () => void;
+/** Renders the incident missed rewards state and value. */
+function IncidentRewards({
+  incident,
+  tokenPrice,
+  tokenSymbol,
+}: {
+  incident: ClusterIncident;
+  tokenPrice: number;
+  tokenSymbol: string;
+}) {
+  if (!incident.rewardsFinalized) {
+    return (
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Missed Rewards</span>
+        <span className="text-xs md:text-sm text-muted-foreground">
+          Rewards are still processing
+        </span>
+      </div>
+    );
+  }
+
+  if (incident.missedConsensusRewards === null) {
+    return (
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Missed Rewards</span>
+        <span className="text-xs md:text-sm text-muted-foreground">No missed rewards recorded</span>
+      </div>
+    );
+  }
+
+  const missedRewards = Number(incident.missedConsensusRewards);
+  const hasTokenPrice = Number.isFinite(tokenPrice) && tokenPrice > 0;
+  const missedRewardsUsd = hasTokenPrice ? ` ($${formatNumber(missedRewards * tokenPrice)})` : '';
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className="text-muted-foreground text-xs md:text-sm">Missed Rewards</span>
+      <span className="font-normal text-destructive text-xs md:text-sm text-right">
+        {incident.missedConsensusRewards} {tokenSymbol}
+        {missedRewardsUsd}
+      </span>
+    </div>
+  );
 }
 
-/** Renders the lazy-loaded affected validators list. */
-function AffectedValidatorsSection({
-  validators,
+/** Renders the lazy-loaded affected validators count. */
+function AffectedValidatorsCount({
   isLoading,
   errorMessage,
-  totalPages,
-  currentPage,
-  onPreviousPage,
-  onNextPage,
-}: AffectedValidatorsSectionProps) {
+  validatorsAffected,
+}: {
+  isLoading: boolean;
+  errorMessage?: string;
+  validatorsAffected?: number;
+}) {
   if (isLoading) {
     return (
-      <div className="space-y-2">
-        <p className="text-xs uppercase tracking-wider text-muted-foreground">
-          Affected Validators
-        </p>
-        <div className="h-12 bg-foreground/5 rounded-lg animate-pulse" />
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Validators Affected</span>
+        <span className="text-xs md:text-sm text-muted-foreground">
+          Loading affected validators...
+        </span>
       </div>
     );
   }
 
   if (errorMessage) {
-    return <p className="text-sm text-destructive py-2">{errorMessage}</p>;
-  }
-
-  if (validators.length === 0) {
-    return <p className="text-sm text-muted-foreground py-2">No affected validators</p>;
-  }
-
-  return (
-    <div className="space-y-2">
-      <p className="text-xs uppercase tracking-wider text-muted-foreground">Affected Validators</p>
-      <div className="space-y-1">
-        {validators.map((validator) => (
-          <AffectedValidatorItem key={validator.validatorIndex} validator={validator} />
-        ))}
+    return (
+      <div className="flex items-center justify-between gap-4">
+        <span className="text-muted-foreground text-xs md:text-sm">Validators Affected</span>
+        <span className="text-xs md:text-sm text-destructive">{errorMessage}</span>
       </div>
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-2">
-          <Button variant="ghost" size="sm" onClick={onPreviousPage} disabled={currentPage <= 1}>
-            Prev
-          </Button>
-          <span className="text-xs text-muted-foreground">
-            Page {currentPage} of {totalPages}
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onNextPage}
-            disabled={currentPage >= totalPages}
-          >
-            Next
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-/** Renders one affected validator row. */
-function AffectedValidatorItem({ validator }: { validator: IncidentAffectedValidator }) {
-  const slotRange =
-    validator.inactiveToSlot !== null
-      ? `${validator.inactiveFromSlot.toLocaleString()}-${validator.inactiveToSlot.toLocaleString()}`
-      : `${validator.inactiveFromSlot.toLocaleString()}-open`;
+    );
+  }
 
   return (
-    <div className="flex items-center justify-between gap-3 rounded-md bg-background/60 border border-border/50 px-2 py-1.5">
-      <span className="font-mono text-xs md:text-sm whitespace-nowrap">
-        Val #{validator.validatorIndex}
-      </span>
-      <span className="font-mono text-xs text-muted-foreground truncate">Slots {slotRange}</span>
-      <span className="font-normal text-destructive text-xs md:text-sm whitespace-nowrap">
-        {validator.missedConsensusRewards}
+    <div className="flex items-center justify-between gap-4">
+      <span className="text-muted-foreground text-xs md:text-sm">Validators Affected</span>
+      <span className="font-mono text-xs md:text-sm">
+        {validatorsAffected !== undefined ? validatorsAffected.toLocaleString() : '-'}
       </span>
     </div>
   );

--- a/packages/webapp/lib/utils.ts
+++ b/packages/webapp/lib/utils.ts
@@ -1,4 +1,5 @@
 import { clsx, type ClassValue } from 'clsx';
+import { format, formatDuration, intervalToDuration, parseISO } from 'date-fns';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
@@ -13,6 +14,45 @@ export function formatTime(timestamp: string) {
     hour: '2-digit',
     minute: '2-digit',
   });
+}
+
+/** Formats an incident timestamp as dd/MM HH:mm. */
+export function formatIncidentDateTime(timestamp: string): string {
+  return format(parseISO(timestamp), 'dd/MM HH:mm');
+}
+
+/** Formats incident duration seconds or derives it from open and close timestamps. */
+export function formatIncidentDuration({
+  closedAt,
+  durationSeconds,
+  openedAt,
+}: {
+  closedAt: string | null;
+  durationSeconds: number | null;
+  openedAt: string;
+}): string {
+  const resolvedDurationSeconds =
+    durationSeconds ??
+    Math.max(
+      0,
+      Math.floor(
+        ((closedAt ? parseISO(closedAt) : new Date()).getTime() - parseISO(openedAt).getTime()) /
+          1000,
+      ),
+    );
+
+  if (resolvedDurationSeconds === 0) return '0 seconds';
+
+  return formatDuration(
+    intervalToDuration({
+      start: 0,
+      end: resolvedDurationSeconds * 1000,
+    }),
+    {
+      format: ['days', 'hours', 'minutes', 'seconds'],
+      zero: false,
+    },
+  );
 }
 
 const WEI_PER_GWEI = 10 ** 9;


### PR DESCRIPTION
## Summary

- Add dismiss buttons to opened and closed Telegram incident notifications.
- Format Telegram incident timestamps as readable UTC date-times.
- Update the web incidents feed to show compact incident rows and expanded incident details without rendering affected validator lists.
- Lazy-load the affected validator count only when an incident row is expanded.
- Show missed rewards processing, empty, token, and USD states in the expanded incident detail.

## Validation

- `pnpm --filter telegram-bot test`
- `pnpm --filter telegram-bot type-check`
- `pnpm --filter telegram-bot lint`
- `pnpm --filter @beacon-indexer/webapp type-check`
- `pnpm --filter @beacon-indexer/webapp lint`
- Commit hooks: telegram-bot type-check, api build, webapp type-check, eslint/prettier on staged files