### PR TITLE
Speed up validator activity status sync

### DIFF
--- a/packages/db/prisma/migrations/20251210144216_initial/migration.sql
+++ b/packages/db/prisma/migrations/20251210144216_initial/migration.sql
@@ -447,12 +447,12 @@ CREATE TABLE "public"."cluster" (
 );
 
 -- CreateTable
-CREATE TABLE "public"."incident_processor_state" (
+CREATE TABLE "public"."validator_activity_processor_state" (
     "processor" VARCHAR(64) NOT NULL,
-    "last_processed_slot" INTEGER NOT NULL,
+    "last_evaluated_duty_slot" INTEGER NOT NULL,
     "updated_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT "incident_processor_state_pkey" PRIMARY KEY ("processor")
+    CONSTRAINT "validator_activity_processor_state_pkey" PRIMARY KEY ("processor")
 );
 
 -- CreateTable
@@ -482,6 +482,11 @@ CREATE INDEX "committee_validator_index_slot_attestation_delay_idx" ON "public".
 
 -- CreateIndex
 CREATE INDEX "slot_slot_processed_idx" ON "public"."slot"("slot", "processed");
+
+-- CreateIndex
+CREATE INDEX "slot_processed_true_slot_desc_idx"
+ON "public"."slot"("slot" DESC)
+WHERE "processed" = true;
 
 -- CreateIndex
 CREATE INDEX "slot_proposer_index_slot_idx" ON "public"."slot"("proposer_index", "slot" DESC);
@@ -514,6 +519,11 @@ CREATE INDEX "notification_queue_user_id_delivered_idx" ON "public"."notificatio
 
 -- CreateIndex
 CREATE INDEX "cluster_incident_cluster_id_idx" ON "public"."cluster_incident"("cluster_id");
+
+-- CreateIndex
+CREATE INDEX "validators_snapshot_activity_inactive_validator_idx"
+ON "public"."validators_snapshot_activity"("validator_index", "inactive_since_slot")
+WHERE "is_inactive" = true AND "inactive_since_slot" IS NOT NULL;
 
 -- CreateIndex
 CREATE INDEX "cluster_incident_status_opened_at_idx" ON "public"."cluster_incident"("status", "opened_at" DESC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -465,12 +465,12 @@ model ValidatorsSnapshotPerformance {
   @@map("validators_snapshot_performance")
 }
 
-model IncidentProcessorState {
-  processor         String   @id @map("processor") @db.VarChar(64)
-  lastProcessedSlot Int      @map("last_processed_slot")
-  updatedAt         DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamp
+model ValidatorActivityProcessorState {
+  processor             String   @id @map("processor") @db.VarChar(64)
+  lastEvaluatedDutySlot Int      @map("last_evaluated_duty_slot")
+  updatedAt             DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamp
 
-  @@map("incident_processor_state")
+  @@map("validator_activity_processor_state")
 }
 
 model ChainEpochStats {

--- a/packages/indexer/e2e/incidents/incidentRewards.test.ts
+++ b/packages/indexer/e2e/incidents/incidentRewards.test.ts
@@ -73,7 +73,7 @@ describe('Incident Rewards', () => {
       delaySlotsToHead: gnosisConfig.beacon.delaySlotsToHead,
     });
 
-    // Provide the controller dependency required by the new controller-level runSync boundary.
+    // Provide the controller dependency required by the controller-level sync boundary.
     slotStorage = {
       getLastProcessedSlot: vi.fn(),
     } as unknown as SlotStorage;
@@ -88,7 +88,6 @@ describe('Incident Rewards', () => {
         gnosisConfig.beacon.slotsPerEpoch,
       ),
       slotStorage,
-      beaconTime,
     );
 
     incidentRewardsController = new IncidentRewardsController(
@@ -103,7 +102,7 @@ describe('Incident Rewards', () => {
     await prisma.notificationQueue.deleteMany({});
     await prisma.clusterIncidentValidator.deleteMany({});
     await prisma.clusterIncident.deleteMany({});
-    await prisma.incidentProcessorState.deleteMany({});
+    await prisma.validatorActivityProcessorState.deleteMany({});
     await prisma.clusterValidator.deleteMany({});
     await prisma.cluster.deleteMany({});
     await prisma.user.deleteMany({});
@@ -295,13 +294,9 @@ describe('Incident Rewards', () => {
       ],
     });
 
-    // Keep enough distance from head so slot 104 is still safe to judge.
-    vi.spyOn(beaconTime, 'getChainCurrentSlot').mockReturnValue(121);
-
     // Refresh current liveness state from the indexed committee data.
+    vi.mocked(slotStorage.getLastProcessedSlot).mockResolvedValue(105);
     await validatorActivityStatusController.syncCurrentActivityStatus({
-      lastIndexedSlot: 105,
-      skipValidatorStatusUpdateWhenBehindHeadSlots: gnosisConfig.beacon.slotsPerEpoch,
       maxAttestationDelay: 1,
       inactiveMissedCount: 4,
     });

--- a/packages/indexer/e2e/validatorActivityStatus/validatorActivityStatus.test.ts
+++ b/packages/indexer/e2e/validatorActivityStatus/validatorActivityStatus.test.ts
@@ -56,15 +56,15 @@ describe('Validator Activity Status Updater', () => {
       gnosisConfig.beacon.slotsPerEpoch,
     );
 
-    // Provide the controller dependency required by the new controller-level runSync boundary.
+    // Provide the controller dependency required by the controller-level sync boundary.
     slotStorage = {
       getLastProcessedSlot: vi.fn(),
     } as unknown as SlotStorage;
-    controller = new ValidatorActivityStatusController(storage, slotStorage, beaconTime);
+    controller = new ValidatorActivityStatusController(storage, slotStorage);
 
     // Remove only the data touched by this suite, keeping the setup isolated and deterministic.
     await prisma.notificationQueue.deleteMany({});
-    await prisma.incidentProcessorState.deleteMany({});
+    await prisma.validatorActivityProcessorState.deleteMany({});
     await prisma.clusterIncidentValidator.deleteMany({});
     await prisma.clusterIncident.deleteMany({});
     await prisma.clusterValidator.deleteMany({});
@@ -236,19 +236,15 @@ describe('Validator Activity Status Updater', () => {
 
   // This helper keeps the activity-sync call sites short in the slot-driven scenarios below.
   async function runActivitySyncThrough(
-    lastIndexedSlot: number,
+    lastProcessedSlot: number,
     maxAttestationDelay: number,
     inactiveMissedCount: number,
   ) {
-    // Keep enough distance from head and still allow the newest indexed duty to be judged.
-    vi.spyOn(beaconTime, 'getChainCurrentSlot').mockReturnValue(
-      lastIndexedSlot + maxAttestationDelay + gnosisConfig.beacon.slotsPerEpoch,
-    );
+    // The controller reads the latest slot completed by the slot pipeline.
+    vi.mocked(slotStorage.getLastProcessedSlot).mockResolvedValue(lastProcessedSlot);
 
     // Run the same controller entrypoint the production worker uses.
     await controller.syncCurrentActivityStatus({
-      lastIndexedSlot,
-      skipValidatorStatusUpdateWhenBehindHeadSlots: gnosisConfig.beacon.slotsPerEpoch,
       maxAttestationDelay,
       inactiveMissedCount,
     });
@@ -270,11 +266,11 @@ describe('Validator Activity Status Updater', () => {
       },
     });
 
-    // Seed the dedicated processor cursor row used by the activity-status updater.
-    await prisma.incidentProcessorState.create({
+    // Seed the dedicated evaluated-duty cursor row used by the activity-status updater.
+    await prisma.validatorActivityProcessorState.create({
       data: {
         processor: 'validator-activity-status',
-        lastProcessedSlot: 9001,
+        lastEvaluatedDutySlot: 9001,
       },
     });
 
@@ -282,13 +278,13 @@ describe('Validator Activity Status Updater', () => {
     const snapshot = await prisma.validatorsSnapshotActivity.findUniqueOrThrow({
       where: { validatorIndex: 101 },
     });
-    const processorState = await prisma.incidentProcessorState.findUniqueOrThrow({
+    const processorState = await prisma.validatorActivityProcessorState.findUniqueOrThrow({
       where: { processor: 'validator-activity-status' },
     });
 
     expect(snapshot.consecutiveMissedAttestations).toBe(0);
     expect(snapshot.missedRewardsProcessedThroughSlot).toBe(88);
-    expect(processorState.lastProcessedSlot).toBe(9001);
+    expect(processorState.lastEvaluatedDutySlot).toBe(9001);
   });
 
   // This scenario proves the processor still advances through already-safe duties even when head is far ahead.
@@ -297,13 +293,9 @@ describe('Validator Activity Status Updater', () => {
     await seedSnapshotValidator(101);
     await seedCommitteeMisses([120, 121, 122, 123], 101);
 
-    // Simulate the chain head being far ahead of the indexed slot.
-    vi.spyOn(beaconTime, 'getChainCurrentSlot').mockReturnValue(140);
-
-    // Run the updater even though the live head is well ahead of the indexed boundary.
+    // Run the updater through the indexed slot boundary owned by slot processing.
+    vi.mocked(slotStorage.getLastProcessedSlot).mockResolvedValue(124);
     await controller.syncCurrentActivityStatus({
-      lastIndexedSlot: 124,
-      skipValidatorStatusUpdateWhenBehindHeadSlots: gnosisConfig.beacon.slotsPerEpoch,
       maxAttestationDelay: 1,
       inactiveMissedCount: 4,
     });
@@ -322,13 +314,9 @@ describe('Validator Activity Status Updater', () => {
     await seedSnapshotValidator(101);
     await seedCommitteeMisses([120, 121, 122, 123], 101);
 
-    // Keep enough distance from head so slot 123 is still safe to judge.
-    vi.spyOn(beaconTime, 'getChainCurrentSlot').mockReturnValue(140);
-
     // Run the updater using the same indexed slot, now treated as fresh.
+    vi.mocked(slotStorage.getLastProcessedSlot).mockResolvedValue(124);
     await controller.syncCurrentActivityStatus({
-      lastIndexedSlot: 124,
-      skipValidatorStatusUpdateWhenBehindHeadSlots: gnosisConfig.beacon.slotsPerEpoch,
       maxAttestationDelay: 1,
       inactiveMissedCount: 4,
     });
@@ -356,12 +344,8 @@ describe('Validator Activity Status Updater', () => {
         (123, 3, 101, 3, ${null})
     `;
 
-    // Keep enough distance from head so slot 123 is still safe to judge.
-    vi.spyOn(beaconTime, 'getChainCurrentSlot').mockReturnValue(140);
-
+    vi.mocked(slotStorage.getLastProcessedSlot).mockResolvedValue(124);
     await controller.syncCurrentActivityStatus({
-      lastIndexedSlot: 124,
-      skipValidatorStatusUpdateWhenBehindHeadSlots: gnosisConfig.beacon.slotsPerEpoch,
       maxAttestationDelay: 1,
       inactiveMissedCount: 3,
     });

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -211,7 +211,6 @@ async function main() {
   const validatorActivityStatusController = new ValidatorActivityStatusController(
     validatorActivityStatusStorage,
     slotStorage,
-    beaconTime,
   );
 
   // Start indexing the beacon chain

--- a/packages/indexer/src/services/consensus/controllers/validatorActivityStatus.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/validatorActivityStatus.test.ts
@@ -10,38 +10,31 @@ vi.mock('@/src/lib/pino.js', () => ({
 }));
 
 describe('ValidatorActivityStatusController', () => {
-  it('uses the smaller limit between the indexed slot and the safe distance from head', async () => {
+  it('processes up to the newest slot already marked as processed', async () => {
     // Expose only the storage method that should receive the computed slot limit.
     const storage = {
       syncCurrentActivityStatus: vi.fn().mockResolvedValue(undefined),
     };
 
-    // The controller reads the last indexed slot from storage.
+    // The controller reads the newest fully processed slot from slot storage.
     const slotStorage = {
       getLastProcessedSlot: vi.fn().mockResolvedValue(120),
-    };
-
-    // Head is slightly ahead, but we still keep a distance from it.
-    const beaconTime = {
-      getChainCurrentSlot: vi.fn().mockReturnValue(100),
     };
 
     const controller = new ValidatorActivityStatusController(
       storage as never,
       slotStorage as never,
-      beaconTime as never,
     );
 
-    // head - distanceToHead = 98, so the head-side limit is smaller than the
-    // indexed slot. After the attestation delay, the last safe slot becomes 95.
-    await controller.runSync({
-      skipValidatorStatusUpdateWhenBehindHeadSlots: 2,
+    // The activity sync should trust the slot pipeline and avoid adding another
+    // head delay after slot processing has completed.
+    await controller.syncCurrentActivityStatus({
       maxAttestationDelay: 3,
       inactiveMissedCount: 4,
     });
 
     expect(storage.syncCurrentActivityStatus).toHaveBeenCalledWith({
-      newestProcessableSlot: 95,
+      newestEvaluableDutySlot: 117,
       inactiveMissedCount: 4,
       maxAttestationDelay: 3,
     });

--- a/packages/indexer/src/services/consensus/controllers/validatorActivityStatus.ts
+++ b/packages/indexer/src/services/consensus/controllers/validatorActivityStatus.ts
@@ -1,5 +1,3 @@
-import { BeaconTime } from '@beacon-indexer/beacon-utils/beaconTime';
-
 import type { SlotStorage } from '../storage/slot.js';
 import { ValidatorActivityStatusStorage } from '../storage/validatorActivityStatus.js';
 
@@ -11,62 +9,32 @@ export class ValidatorActivityStatusController {
   constructor(
     private readonly storage: ValidatorActivityStatusStorage,
     private readonly slotStorage: SlotStorage,
-    private readonly beaconTime: BeaconTime,
   ) {}
 
-  async runSync(params: {
-    skipValidatorStatusUpdateWhenBehindHeadSlots: number;
-    maxAttestationDelay: number;
-    inactiveMissedCount: number;
-  }): Promise<void> {
-    // Skip the refresh entirely until the slot pipeline has indexed at least one
-    // committee window that can be evaluated safely.
-    const lastIndexedSlot = await this.slotStorage.getLastProcessedSlot();
-    if (lastIndexedSlot === null) {
-      return;
-    }
-
-    // Reuse the controller's freshness and safe-slot rules once the cursor exists.
-    await this.syncCurrentActivityStatus({
-      lastIndexedSlot,
-      skipValidatorStatusUpdateWhenBehindHeadSlots:
-        params.skipValidatorStatusUpdateWhenBehindHeadSlots,
-      maxAttestationDelay: params.maxAttestationDelay,
-      inactiveMissedCount: params.inactiveMissedCount,
-    });
-  }
-
   async syncCurrentActivityStatus(params: {
-    lastIndexedSlot: number;
-    skipValidatorStatusUpdateWhenBehindHeadSlots: number;
     maxAttestationDelay: number;
     inactiveMissedCount: number;
   }): Promise<void> {
-    // Reads the current chain head to avoid judging slots too close to it.
-    const headSlot = this.beaconTime.getChainCurrentSlot();
-
-    // Keeps a small gap from head so the node has time to expose fresh data.
-    const lastSlotSafeToReadFromNode =
-      headSlot - params.skipValidatorStatusUpdateWhenBehindHeadSlots;
-
-    // Uses the smaller limit between what we already indexed and what is safe
-    // to read from the node.
-    const lastIndexedSlotSafeToUse = Math.min(params.lastIndexedSlot, lastSlotSafeToReadFromNode);
-
-    // Gets the newest slot we can process in this iteration.
-    const newestProcessableSlot = lastIndexedSlotSafeToUse - params.maxAttestationDelay;
-    if (newestProcessableSlot < 0) {
+    // Skip the refresh until the slot pipeline has completed at least one slot.
+    const lastProcessedSlot = await this.slotStorage.getLastProcessedSlot();
+    if (lastProcessedSlot === null) {
       return;
     }
 
-    // Replays the snapshot only up to the newest safe slot.
+    // Evaluate only duties whose attestation inclusion window has fully elapsed.
+    const newestEvaluableDutySlot = lastProcessedSlot - params.maxAttestationDelay;
+    if (newestEvaluableDutySlot < 0) {
+      return;
+    }
+
+    // Replay activity state through the newest duty slot that can be judged.
     await this.storage.syncCurrentActivityStatus({
-      newestProcessableSlot,
+      newestEvaluableDutySlot,
       inactiveMissedCount: params.inactiveMissedCount,
       maxAttestationDelay: params.maxAttestationDelay,
     });
     this.logger.info('Synchronized current validator activity status', {
-      newestProcessableSlot,
+      newestEvaluableDutySlot,
     });
   }
 }

--- a/packages/indexer/src/services/consensus/storage/validatorActivityStatus.test.ts
+++ b/packages/indexer/src/services/consensus/storage/validatorActivityStatus.test.ts
@@ -6,12 +6,12 @@ describe('ValidatorActivityStatusStorage transaction scope', () => {
   let prisma: {
     $executeRaw: ReturnType<typeof vi.fn>;
     $transaction: ReturnType<typeof vi.fn>;
-    incidentProcessorState: {
+    validatorActivityProcessorState: {
       upsert: ReturnType<typeof vi.fn>;
     };
   };
   let tx: {
-    incidentProcessorState: {
+    validatorActivityProcessorState: {
       upsert: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
     };
@@ -23,10 +23,10 @@ describe('ValidatorActivityStatusStorage transaction scope', () => {
     // Recreate the mocked Prisma client and transaction client for each test so
     // every assertion observes only the calls made by that scenario.
     tx = {
-      incidentProcessorState: {
+      validatorActivityProcessorState: {
         upsert: vi.fn().mockResolvedValue({
           processor: 'validator-activity-status',
-          lastProcessedSlot: 4,
+          lastEvaluatedDutySlot: 4,
         }),
         update: vi.fn().mockResolvedValue(undefined),
       },
@@ -38,10 +38,10 @@ describe('ValidatorActivityStatusStorage transaction scope', () => {
       $transaction: vi.fn(async (callback: (transactionClient: typeof tx) => Promise<unknown>) =>
         callback(tx),
       ),
-      incidentProcessorState: {
+      validatorActivityProcessorState: {
         upsert: vi.fn().mockResolvedValue({
           processor: 'validator-activity-status',
-          lastProcessedSlot: 4,
+          lastEvaluatedDutySlot: 4,
         }),
       },
     };
@@ -72,15 +72,15 @@ describe('ValidatorActivityStatusStorage transaction scope', () => {
     // Process two pending slots so the test can observe whether storage keeps
     // one large transaction or commits each slot independently.
     await storage.syncCurrentActivityStatus({
-      newestProcessableSlot: 6,
+      newestEvaluableDutySlot: 6,
       inactiveMissedCount: 1,
       maxAttestationDelay: 1,
     });
 
-    // The processor state bootstrap is not part of the per-slot work. After
-    // that, each slot must execute inside its own short transaction.
-    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
-    expect(prisma.incidentProcessorState.upsert).toHaveBeenCalledTimes(1);
+    // Mid-epoch processing should avoid the activity-row bootstrap scan. Each
+    // slot must still execute inside its own short transaction.
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(0);
+    expect(prisma.validatorActivityProcessorState.upsert).toHaveBeenCalledTimes(1);
     expect(prisma.$transaction).toHaveBeenCalledTimes(2);
 
     // The slot-local work must still run for both pending slots and use the
@@ -96,13 +96,38 @@ describe('ValidatorActivityStatusStorage transaction scope', () => {
 
     // The durable bookmark must advance inside each slot transaction so a
     // crash can only replay at most one slot on the next run.
-    expect(tx.incidentProcessorState.update).toHaveBeenNthCalledWith(1, {
+    expect(tx.validatorActivityProcessorState.update).toHaveBeenNthCalledWith(1, {
       where: { processor: 'validator-activity-status' },
-      data: { lastProcessedSlot: 5 },
+      data: { lastEvaluatedDutySlot: 5 },
     });
-    expect(tx.incidentProcessorState.update).toHaveBeenNthCalledWith(2, {
+    expect(tx.validatorActivityProcessorState.update).toHaveBeenNthCalledWith(2, {
       where: { processor: 'validator-activity-status' },
-      data: { lastProcessedSlot: 6 },
+      data: { lastEvaluatedDutySlot: 6 },
     });
+  });
+
+  it('inserts missing activity rows only before processing the first slot of an epoch', async () => {
+    // Stub the slot-local SQL helpers so the test can count only bootstrap
+    // activity-row inserts around the replay loop.
+    vi.spyOn(storage as never, 'updateSlotSnapshots').mockResolvedValue(undefined);
+    vi.spyOn(storage as never, 'reconcileOpenIncidents').mockResolvedValue(undefined);
+
+    // Start from slot 15 so the batch crosses slot 16, which is the first slot
+    // of the next epoch for this test storage.
+    prisma.validatorActivityProcessorState.upsert.mockResolvedValue({
+      processor: 'validator-activity-status',
+      lastEvaluatedDutySlot: 15,
+    });
+
+    // Process one full epoch-boundary slot and one mid-epoch slot.
+    await storage.syncCurrentActivityStatus({
+      newestEvaluableDutySlot: 17,
+      inactiveMissedCount: 1,
+      maxAttestationDelay: 1,
+    });
+
+    // The bootstrap insert should run once for slot 16 and not repeat for slot
+    // 17, avoiding repeated cluster-validator scans during hot polling.
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/indexer/src/services/consensus/storage/validatorActivityStatus.ts
+++ b/packages/indexer/src/services/consensus/storage/validatorActivityStatus.ts
@@ -3,8 +3,8 @@ import { Prisma, PrismaClient } from '@beacon-indexer/db';
 import { getActivityLookbackSlots } from './activityLookback.js';
 
 type SyncCurrentActivityStatusParams = {
-  // Newest slot we can process in this run.
-  newestProcessableSlot: number;
+  // Newest duty slot whose attestation inclusion window has fully elapsed.
+  newestEvaluableDutySlot: number;
   // Missed duties in a row needed to mark a validator inactive.
   inactiveMissedCount: number;
   // Attestations later than this delay count as missed.
@@ -53,6 +53,11 @@ export class ValidatorActivityStatusStorage {
         INTERVAL '1 second'
       )
     `;
+  }
+
+  /** Checks whether a slot is the first slot of its epoch. */
+  private isFirstSlotOfEpoch(slot: number): boolean {
+    return slot % this.slotsPerEpoch === 0;
   }
 
   /** Opens and closes incidents from the current inactive snapshot. */
@@ -287,39 +292,45 @@ export class ValidatorActivityStatusStorage {
     `;
   }
 
-  /** Replays safe slots and keeps snapshots and incidents up to date. */
+  /** Replays mature duty slots and keeps snapshots and incidents up to date. */
   async syncCurrentActivityStatus(params: SyncCurrentActivityStatusParams): Promise<void> {
-    const { newestProcessableSlot, inactiveMissedCount, maxAttestationDelay } = params;
+    const { newestEvaluableDutySlot, inactiveMissedCount, maxAttestationDelay } = params;
 
     // Gets how many slots we need to look back.
     const slotsToLookBack = getActivityLookbackSlots(this.slotsPerEpoch, inactiveMissedCount);
 
-    // Gets the oldest slot we need to process in this run.
-    const oldestProcessableSlot = newestProcessableSlot - slotsToLookBack;
+    // Gets the oldest duty slot we need to evaluate in this run.
+    const oldestEvaluableDutySlot = newestEvaluableDutySlot - slotsToLookBack;
 
-    // Gets or creates the slot cursor for this processor.
-    const processorState = await this.prisma.incidentProcessorState.upsert({
+    // Gets or creates the evaluated-duty cursor for this processor.
+    const processorState = await this.prisma.validatorActivityProcessorState.upsert({
       where: { processor: VALIDATOR_ACTIVITY_PROCESSOR },
       update: {},
       create: {
         processor: VALIDATOR_ACTIVITY_PROCESSOR,
-        lastProcessedSlot: Math.max(oldestProcessableSlot - 1, -1),
+        lastEvaluatedDutySlot: Math.max(oldestEvaluableDutySlot - 1, -1),
       },
     });
 
-    // Gets the last slot we already covered
-    const lastCoveredSlot = Math.max(processorState.lastProcessedSlot, oldestProcessableSlot - 1);
+    // Gets the last mature duty slot already evaluated.
+    const lastEvaluatedDutySlot = Math.max(
+      processorState.lastEvaluatedDutySlot,
+      oldestEvaluableDutySlot - 1,
+    );
 
-    // Stops here when there are no new safe slots left to replay.
-    if (lastCoveredSlot >= newestProcessableSlot) {
+    // Stops here when there are no new mature duty slots left to evaluate.
+    if (lastEvaluatedDutySlot >= newestEvaluableDutySlot) {
       return;
     }
 
-    // Creates missing hot-state rows before replaying safe duties.
-    await this.insertMissingActivityRows();
+    // Processes one mature duty slot at a time.
+    for (let slot = lastEvaluatedDutySlot + 1; slot <= newestEvaluableDutySlot; slot += 1) {
+      // Refresh tracked-validator snapshot rows only when epoch duties can add
+      // new validators to the activity window.
+      if (this.isFirstSlotOfEpoch(slot)) {
+        await this.insertMissingActivityRows();
+      }
 
-    // Processes one slot at a time up to the newest safe slot.
-    for (let slot = lastCoveredSlot + 1; slot <= newestProcessableSlot; slot += 1) {
       await this.prisma.$transaction(async (tx) => {
         await this.updateSlotSnapshots(tx, slot, inactiveMissedCount, maxAttestationDelay);
 
@@ -329,9 +340,9 @@ export class ValidatorActivityStatusStorage {
         });
 
         // Saves the slot cursor after this slot is done.
-        await tx.incidentProcessorState.update({
+        await tx.validatorActivityProcessorState.update({
           where: { processor: VALIDATOR_ACTIVITY_PROCESSOR },
-          data: { lastProcessedSlot: slot },
+          data: { lastEvaluatedDutySlot: slot },
         });
       });
     }

--- a/packages/indexer/src/xstate/index.ts
+++ b/packages/indexer/src/xstate/index.ts
@@ -79,8 +79,6 @@ export default function initXstateMachines(
 
   const validatorActivityStatusActor = getValidatorActivityStatusActor(
     validatorActivityStatusController,
-    slotDuration,
-    slotsPerEpoch,
     maxAttestationDelay,
     missedAttestationsForInactivity,
   );

--- a/packages/indexer/src/xstate/validatorActivityStatus/index.ts
+++ b/packages/indexer/src/xstate/validatorActivityStatus/index.ts
@@ -9,8 +9,6 @@ export { validatorActivityStatusMachine } from './validatorActivityStatus.machin
 
 export const getValidatorActivityStatusActor = (
   validatorActivityStatusController: ValidatorActivityStatusController,
-  slotDuration: number,
-  skipValidatorStatusUpdateWhenBehindHeadSlots: number,
   maxAttestationDelay: number,
   inactiveMissedCount: number,
 ) => {
@@ -19,8 +17,6 @@ export const getValidatorActivityStatusActor = (
   const actor = createActor(validatorActivityStatusMachine, {
     input: {
       validatorActivityStatusController,
-      slotDuration,
-      skipValidatorStatusUpdateWhenBehindHeadSlots,
       maxAttestationDelay,
       inactiveMissedCount,
     },

--- a/packages/indexer/src/xstate/validatorActivityStatus/validatorActivityStatus.machine.test.ts
+++ b/packages/indexer/src/xstate/validatorActivityStatus/validatorActivityStatus.machine.test.ts
@@ -16,21 +16,19 @@ describe('validatorActivityStatusMachine', () => {
     vi.restoreAllMocks();
   });
 
-  it('delegates each polling tick to the controller runSync method', async () => {
+  it('polls every second and delegates each tick to the controller sync method', async () => {
     // Use fake timers so the polling loop can be triggered without wall-clock delay.
     vi.useFakeTimers();
 
     // Expose only the controller method that should be called by the machine.
-    const runSync = vi.fn().mockResolvedValue(undefined);
+    const syncCurrentActivityStatus = vi.fn().mockResolvedValue(undefined);
 
     // Start the actor with the controller-only contract that the refactor requires.
     const actor = createActor(validatorActivityStatusMachine, {
       input: {
         validatorActivityStatusController: {
-          runSync,
+          syncCurrentActivityStatus,
         } as unknown as ValidatorActivityStatusController,
-        slotDuration: 1,
-        skipValidatorStatusUpdateWhenBehindHeadSlots: 4,
         maxAttestationDelay: 2,
         inactiveMissedCount: 3,
       } as never,
@@ -38,11 +36,15 @@ describe('validatorActivityStatusMachine', () => {
 
     actor.start();
 
-    // Advance one polling interval so the machine invokes the controller sync.
+    // Advance just below one polling interval so no early sync can run.
+    await vi.advanceTimersByTimeAsync(999);
+
+    expect(syncCurrentActivityStatus).not.toHaveBeenCalled();
+
+    // Advance to exactly one second so the machine invokes the controller sync.
     await vi.advanceTimersByTimeAsync(1);
 
-    expect(runSync).toHaveBeenCalledWith({
-      skipValidatorStatusUpdateWhenBehindHeadSlots: 4,
+    expect(syncCurrentActivityStatus).toHaveBeenCalledWith({
       maxAttestationDelay: 2,
       inactiveMissedCount: 3,
     });

--- a/packages/indexer/src/xstate/validatorActivityStatus/validatorActivityStatus.machine.ts
+++ b/packages/indexer/src/xstate/validatorActivityStatus/validatorActivityStatus.machine.ts
@@ -3,22 +3,27 @@ import { setup, fromPromise } from 'xstate';
 import { ValidatorActivityStatusController } from '@/src/services/consensus/controllers/validatorActivityStatus.js';
 import { pinoLog } from '@/src/xstate/pinoLog.js';
 
-const runSync = fromPromise(
+const VALIDATOR_ACTIVITY_STATUS_POLLING_INTERVAL_MS = 1000;
+
+// The activity worker runs often, but the controller evaluates only mature duty
+// slots. Example: with maxAttestationDelay = 5 and latest processed slot = 105,
+// validator duties for slot 100 can be judged. A null attestation delay at slot
+// 100 is then a missed duty; an attestation delay <= 5 is successful. The worker
+// advances that evaluated-duty cursor and updates the validator activity
+// snapshot, which can open or close cluster incidents.
+const syncCurrentActivityStatus = fromPromise(
   async ({
     input,
   }: {
     input: {
       validatorActivityStatusController: ValidatorActivityStatusController;
-      skipValidatorStatusUpdateWhenBehindHeadSlots: number;
       maxAttestationDelay: number;
       inactiveMissedCount: number;
     };
   }) => {
     // Delegate the entire refresh pass to the controller so the machine stays
     // orchestration-only.
-    await input.validatorActivityStatusController.runSync({
-      skipValidatorStatusUpdateWhenBehindHeadSlots:
-        input.skipValidatorStatusUpdateWhenBehindHeadSlots,
+    await input.validatorActivityStatusController.syncCurrentActivityStatus({
       maxAttestationDelay: input.maxAttestationDelay,
       inactiveMissedCount: input.inactiveMissedCount,
     });
@@ -29,35 +34,27 @@ export const validatorActivityStatusMachine = setup({
   types: {} as {
     context: {
       validatorActivityStatusController: ValidatorActivityStatusController;
-      slotDuration: number;
-      skipValidatorStatusUpdateWhenBehindHeadSlots: number;
       maxAttestationDelay: number;
       inactiveMissedCount: number;
     };
     input: {
       validatorActivityStatusController: ValidatorActivityStatusController;
-      slotDuration: number;
-      skipValidatorStatusUpdateWhenBehindHeadSlots: number;
       maxAttestationDelay: number;
       inactiveMissedCount: number;
     };
   },
   delays: {
-    // Poll at slot cadence so validator activity state tracks the latest safe slot
-    // as soon as new committee data becomes final.
-    tickInterval: ({ context }) => context.slotDuration,
+    // Poll quickly so incidents are opened soon after slot processing completes.
+    tickInterval: () => VALIDATOR_ACTIVITY_STATUS_POLLING_INTERVAL_MS,
   },
   actors: {
-    runSync,
+    syncCurrentActivityStatus,
   },
 }).createMachine({
   id: 'ValidatorActivityStatus',
   initial: 'waiting',
   context: ({ input }) => ({
     validatorActivityStatusController: input.validatorActivityStatusController,
-    slotDuration: input.slotDuration,
-    skipValidatorStatusUpdateWhenBehindHeadSlots:
-      input.skipValidatorStatusUpdateWhenBehindHeadSlots,
     maxAttestationDelay: input.maxAttestationDelay,
     inactiveMissedCount: input.inactiveMissedCount,
   }),
@@ -74,11 +71,9 @@ export const validatorActivityStatusMachine = setup({
       invoke: {
         // Execute one refresh pass and always return to the waiting state whether
         // the pass succeeded or failed.
-        src: 'runSync',
+        src: 'syncCurrentActivityStatus',
         input: ({ context }) => ({
           validatorActivityStatusController: context.validatorActivityStatusController,
-          skipValidatorStatusUpdateWhenBehindHeadSlots:
-            context.skipValidatorStatusUpdateWhenBehindHeadSlots,
           maxAttestationDelay: context.maxAttestationDelay,
           inactiveMissedCount: context.inactiveMissedCount,
         }),


### PR DESCRIPTION
## Summary

- Poll validator activity status every second instead of at slot cadence.
- Use the latest `slot.processed = true` slot as the processing boundary, removing the extra head/epoch delay from this worker.
- Limit missing activity row bootstrap work to epoch-start slots.
- Add hot-path indexes for newest processed slot lookup and inactive validator reconciliation.

## Root Cause

The validator activity worker was applying an additional freshness window after the slot pipeline had already marked slots as processed. In production wiring, `slotsPerEpoch` was passed as the skip distance, which kept activity status roughly one epoch plus attestation delay behind.

## Validation

- `pnpm --filter indexer test -- --run`
- `pnpm --filter indexer type-check`
- `pnpm --filter indexer lint`