### PR TITLE
refactor: make api DI explicit

### DIFF
--- a/packages/api/e2e/chain.test.ts
+++ b/packages/api/e2e/chain.test.ts
@@ -1,11 +1,8 @@
-import { createServer } from 'node:http';
-
 import { PrismaClient } from '@beacon-indexer/db';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { authHeaders } from './helpers.js';
-
-import { createHttpServer } from '@/server.js';
+import { FIXED_TOKEN_PRICE, startE2EServer } from './server.js';
 
 interface ChainStatsResponse {
   success: boolean;
@@ -16,6 +13,7 @@ interface ChainStatsResponse {
     validatorsEntering: number;
     validatorsExiting: number;
     validatorsConsolidating: number;
+    tokenPrice: number;
   };
   error?: {
     code: string;
@@ -28,8 +26,8 @@ interface ChainStatsResponse {
 
 describe('Chain Stats Endpoint E2E Tests', () => {
   let prisma: PrismaClient;
-  let server: ReturnType<typeof createServer>;
   let baseUrl: string;
+  let closeServer: () => Promise<void>;
 
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) {
@@ -46,28 +44,16 @@ describe('Chain Stats Endpoint E2E Tests', () => {
 
     await prisma.$connect();
 
-    server = createHttpServer();
-    await new Promise<void>((resolve) => {
-      server.listen(0, '127.0.0.1', () => {
-        const address = server.address();
-        if (address && typeof address === 'object') {
-          baseUrl = `http://127.0.0.1:${address.port}`;
-        }
-        resolve();
-      });
-    });
+    const started = await startE2EServer();
+    baseUrl = started.baseUrl;
+    closeServer = started.close;
   });
 
   afterAll(async () => {
     // Clean up test data
     await prisma.$executeRaw`DELETE FROM chain_epoch_stats WHERE epoch >= 900000`;
 
-    await new Promise<void>((resolve, reject) => {
-      server.close((err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+    await closeServer();
     await prisma.$disconnect();
   });
 
@@ -106,6 +92,7 @@ describe('Chain Stats Endpoint E2E Tests', () => {
       expect(body.data!.validatorsEntering).toBe(2300);
       expect(body.data!.validatorsExiting).toBe(500);
       expect(body.data!.validatorsConsolidating).toBe(50);
+      expect(body.data!.tokenPrice).toBe(FIXED_TOKEN_PRICE);
     });
 
     it('should return the latest epoch stats', async () => {

--- a/packages/api/e2e/cluster.test.ts
+++ b/packages/api/e2e/cluster.test.ts
@@ -1,9 +1,8 @@
-import { createServer } from 'node:http';
-
 import { PrismaClient } from '@beacon-indexer/db';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { E2E_SESSION_ID, userAuthHeaders } from './helpers.js';
+import { startE2EServer } from './server.js';
 
 import type {
   AddValidatorsResponse as AddValidatorsData,
@@ -11,7 +10,6 @@ import type {
   ClusterDetail,
   ClusterWithCount,
 } from '@/routers/cluster/schemas.js';
-import { createHttpServer } from '@/server.js';
 import type { ApiResponse } from '@/utils/response.js';
 
 // Response types using ApiResponse wrapper with schema types
@@ -25,8 +23,8 @@ type RemoveValidatorsResponse = ApiResponse<{ removed: number }>;
 
 describe('Cluster API E2E Tests', () => {
   let prisma: PrismaClient;
-  let server: ReturnType<typeof createServer>;
   let baseUrl: string;
+  let closeServer: () => Promise<void>;
   // Fixed test user ID (string, matching the new User.id type)
   const testOwnerId = 'e2e-test-owner-id';
   // Use a second anonymous session to simulate a different authenticated user.
@@ -59,16 +57,9 @@ describe('Cluster API E2E Tests', () => {
       },
     });
 
-    server = createHttpServer();
-    await new Promise<void>((resolve) => {
-      server.listen(0, '127.0.0.1', () => {
-        const address = server.address();
-        if (address && typeof address === 'object') {
-          baseUrl = `http://127.0.0.1:${address.port}`;
-        }
-        resolve();
-      });
-    });
+    const started = await startE2EServer();
+    baseUrl = started.baseUrl;
+    closeServer = started.close;
   });
 
   afterEach(async () => {
@@ -80,12 +71,7 @@ describe('Cluster API E2E Tests', () => {
   });
 
   afterAll(async () => {
-    await new Promise<void>((resolve, reject) => {
-      server.close((err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+    await closeServer();
     await prisma.$disconnect();
   });
 

--- a/packages/api/e2e/health.test.ts
+++ b/packages/api/e2e/health.test.ts
@@ -1,9 +1,7 @@
-import { createServer } from 'node:http';
-
 import { PrismaClient } from '@beacon-indexer/db';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { createHttpServer } from '@/server.js';
+import { startE2EServer } from './server.js';
 
 interface HealthResponse {
   success: boolean;
@@ -24,8 +22,8 @@ interface HealthResponse {
 
 describe('Health Endpoint E2E Tests', () => {
   let prisma: PrismaClient;
-  let server: ReturnType<typeof createServer>;
   let baseUrl: string;
+  let closeServer: () => Promise<void>;
 
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) {
@@ -43,26 +41,14 @@ describe('Health Endpoint E2E Tests', () => {
 
     await prisma.$connect();
 
-    // Start the HTTP server
-    server = createHttpServer();
-    await new Promise<void>((resolve) => {
-      server.listen(0, '127.0.0.1', () => {
-        const address = server.address();
-        if (address && typeof address === 'object') {
-          baseUrl = `http://127.0.0.1:${address.port}`;
-        }
-        resolve();
-      });
-    });
+    // Start the HTTP server with the real API bootstrap wiring.
+    const started = await startE2EServer();
+    baseUrl = started.baseUrl;
+    closeServer = started.close;
   });
 
   afterAll(async () => {
-    await new Promise<void>((resolve, reject) => {
-      server.close((err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+    await closeServer();
     await prisma.$disconnect();
   });
 

--- a/packages/api/e2e/incidents.test.ts
+++ b/packages/api/e2e/incidents.test.ts
@@ -1,11 +1,9 @@
-import { createServer } from 'node:http';
-
 import { PrismaClient } from '@beacon-indexer/db';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { botAuthHeaders, E2E_SESSION_ID, userAuthHeaders } from './helpers.js';
+import { startE2EServer } from './server.js';
 
-import { createHttpServer } from '@/server.js';
 import type { ApiResponse } from '@/utils/response.js';
 
 type IncidentListItem = {
@@ -57,8 +55,8 @@ type IncidentNotificationPayload = {
 
 describe('Incident API E2E Tests', () => {
   let prisma: PrismaClient;
-  let server: ReturnType<typeof createServer>;
   let baseUrl: string;
+  let closeServer: () => Promise<void>;
 
   // This user matches the anonymous auth helper used in API tests.
   const anonymousOwnerId = 'e2e-test-owner-id';
@@ -126,19 +124,9 @@ describe('Incident API E2E Tests', () => {
     });
 
     // This server instance exposes the same REST handlers used in production.
-    server = createHttpServer();
-    await new Promise<void>((resolve) => {
-      server.listen(0, '127.0.0.1', () => {
-        const address = server.address();
-
-        // This local URL is used by every request in the suite.
-        if (address && typeof address === 'object') {
-          baseUrl = `http://127.0.0.1:${address.port}`;
-        }
-
-        resolve();
-      });
-    });
+    const started = await startE2EServer();
+    baseUrl = started.baseUrl;
+    closeServer = started.close;
   });
 
   afterEach(async () => {
@@ -164,12 +152,7 @@ describe('Incident API E2E Tests', () => {
 
   afterAll(async () => {
     // This closes the HTTP server before disconnecting the test database.
-    await new Promise<void>((resolve, reject) => {
-      server.close((err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+    await closeServer();
 
     // This disconnect prevents hanging Vitest workers.
     await prisma.$disconnect();

--- a/packages/api/e2e/server.ts
+++ b/packages/api/e2e/server.ts
@@ -1,0 +1,237 @@
+import { createServer } from 'node:http';
+
+import { createAuthProcedures } from '@/auth/middleware.js';
+import { isOriginAllowed } from '@/auth/origin.js';
+import { createBotSignatureAuthenticator } from '@/auth/strategies/bot-signature.js';
+import { createTelegramAuthenticator } from '@/auth/strategies/telegram.js';
+import { createApiKeyAuthenticator } from '@/auth/strategies/token.js';
+import { parseEnv } from '@/config/env.js';
+import { SystemConfigController } from '@/controllers/systemConfig.js';
+import { ValidatorController } from '@/controllers/validator.js';
+import { createLogger } from '@/lib/logger.js';
+import { createPrisma, disconnectPrisma } from '@/lib/prisma.js';
+import { createRouter } from '@/routers/index.js';
+import { createHttpServer } from '@/server.js';
+import { AnalyticsStorage } from '@/storage/analytics.js';
+import { BlockStorage } from '@/storage/block.js';
+import { BotCommunicationsStorage } from '@/storage/bot-communications.js';
+import { BotIncidentNotificationsStorage } from '@/storage/bot-incident-notifications.js';
+import { BotNotificationsStorage } from '@/storage/bot-notifications.js';
+import { BotUsersStorage } from '@/storage/bot-users.js';
+import { ClusterStorage } from '@/storage/cluster.js';
+import { IncidentStorage } from '@/storage/incident.js';
+import { SystemConfigStorage } from '@/storage/systemConfig.js';
+import { UserStorage } from '@/storage/user.js';
+import { ValidatorStorage } from '@/storage/validator.js';
+import { createBeaconHelpers } from '@/utils/beaconTime.js';
+
+interface E2EServerOverrides {
+  allowedOrigins?: string;
+  apiTokenSecret?: string;
+  chain?: 'ethereum' | 'gnosis';
+  consensusLookbackSlot?: number;
+  databaseUrl?: string;
+  nativeTokenDecimals?: number;
+  telegramBotToken?: string;
+  telegramInitDataMaxAgeSeconds?: number;
+  tokenPriceApiUrl?: string;
+  tokenPriceTokenName?: string;
+}
+
+const FIXED_TOKEN_PRICE = 123.45;
+
+export { FIXED_TOKEN_PRICE };
+
+/**
+ * Starts a local stub server that returns a fixed token price.
+ * This keeps e2e tests off the network while still exercising the configured URL path.
+ */
+async function startTokenPriceStubServer(params: { tokenName: string }): Promise<{
+  apiUrl: string;
+  close: () => Promise<void>;
+}> {
+  const server = createServer((req, res) => {
+    const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const requestedToken = requestUrl.searchParams.get('ids');
+    const requestedCurrency = requestUrl.searchParams.get('vs_currencies');
+
+    // Reject unexpected requests so tests prove the API used the configured URL and params.
+    if (requestedToken !== params.tokenName || requestedCurrency !== 'usd') {
+      res.statusCode = 400;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(
+        JSON.stringify({
+          error: 'Unexpected token price request',
+        }),
+      );
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(
+      JSON.stringify({
+        [params.tokenName]: {
+          usd: FIXED_TOKEN_PRICE,
+        },
+      }),
+    );
+  });
+
+  const apiUrl = await new Promise<string>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+
+      if (!address || typeof address !== 'object') {
+        throw new Error('Failed to resolve token price stub address');
+      }
+
+      resolve(`http://127.0.0.1:${address.port}/simple/price`);
+    });
+  });
+
+  return {
+    apiUrl,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+  };
+}
+
+/**
+ * Starts an API server instance for E2E tests.
+ */
+export async function startE2EServer(overrides: E2EServerOverrides = {}): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+  server: ReturnType<typeof createServer>;
+}> {
+  const tokenName = overrides.tokenPriceTokenName ?? process.env.COINGECKO_TOKEN_NAME ?? 'ethereum';
+  const tokenPriceStub =
+    overrides.tokenPriceApiUrl === undefined
+      ? await startTokenPriceStubServer({ tokenName })
+      : null;
+
+  const env = parseEnv({
+    ...process.env,
+    ALLOWED_ORIGINS: overrides.allowedOrigins ?? process.env.ALLOWED_ORIGINS,
+    API_TOKEN_SECRET: overrides.apiTokenSecret ?? process.env.API_TOKEN_SECRET,
+    CHAIN: overrides.chain ?? process.env.CHAIN,
+    CONSENSUS_LOOKBACK_SLOT:
+      overrides.consensusLookbackSlot?.toString() ?? process.env.CONSENSUS_LOOKBACK_SLOT,
+    COINGECKO_TOKEN_PRICE_API_URL:
+      overrides.tokenPriceApiUrl ??
+      tokenPriceStub?.apiUrl ??
+      process.env.COINGECKO_TOKEN_PRICE_API_URL,
+    COINGECKO_TOKEN_NAME: tokenName,
+    DATABASE_URL: overrides.databaseUrl ?? process.env.DATABASE_URL,
+    NATIVE_TOKEN_DECIMALS:
+      overrides.nativeTokenDecimals?.toString() ?? process.env.NATIVE_TOKEN_DECIMALS,
+    TELEGRAM_BOT_TOKEN: overrides.telegramBotToken ?? process.env.TELEGRAM_BOT_TOKEN,
+    TELEGRAM_INIT_DATA_MAX_AGE_SECONDS:
+      overrides.telegramInitDataMaxAgeSeconds?.toString() ??
+      process.env.TELEGRAM_INIT_DATA_MAX_AGE_SECONDS,
+  });
+  const logger = createLogger({
+    logLevel: 'silent',
+    nodeEnv: env.NODE_ENV,
+  });
+  const prisma = createPrisma(env.DATABASE_URL, logger);
+  await prisma.$connect();
+  const beaconHelpers = createBeaconHelpers({
+    chain: env.CHAIN,
+    lookbackSlot: env.CONSENSUS_LOOKBACK_SLOT,
+  });
+  const userStorage = new UserStorage(prisma);
+  const procedures = createAuthProcedures({
+    ...createApiKeyAuthenticator(env.API_TOKEN_SECRET),
+    ...createBotSignatureAuthenticator(env.TELEGRAM_BOT_TOKEN),
+    ...createTelegramAuthenticator({
+      maxAgeSeconds: env.TELEGRAM_INIT_DATA_MAX_AGE_SECONDS,
+      telegramBotToken: env.TELEGRAM_BOT_TOKEN,
+    }),
+    isOriginAllowed: (origin) =>
+      isOriginAllowed(origin, {
+        allowedOrigins: env.ALLOWED_ORIGINS,
+        logger,
+      }),
+    userStorage,
+  });
+  const validatorStorage = new ValidatorStorage(prisma);
+  const validatorController = new ValidatorController({
+    storage: validatorStorage,
+    beaconHelpers,
+    chain: env.CHAIN,
+  });
+  const systemConfigStorage = new SystemConfigStorage(prisma);
+  const systemConfigController = new SystemConfigController(systemConfigStorage);
+  const deps = {
+    analyticsStorage: new AnalyticsStorage(prisma),
+    beaconHelpers,
+    blockStorage: new BlockStorage(prisma),
+    botCommunicationsStorage: new BotCommunicationsStorage(prisma),
+    botIncidentNotificationsStorage: new BotIncidentNotificationsStorage(prisma),
+    botNotificationsStorage: new BotNotificationsStorage(prisma),
+    botUsersStorage: new BotUsersStorage(prisma),
+    chain: env.CHAIN,
+    clusterStorage: new ClusterStorage(prisma),
+    incidentStorage: new IncidentStorage(prisma),
+    logger,
+    nativeTokenDecimals: env.NATIVE_TOKEN_DECIMALS,
+    prisma,
+    procedures,
+    systemConfigController,
+    tokenPriceApiUrl: env.COINGECKO_TOKEN_PRICE_API_URL,
+    tokenPriceTokenName: env.COINGECKO_TOKEN_NAME,
+    userStorage,
+    validatorController,
+    validatorStorage,
+  };
+  const router = createRouter(deps);
+  const server = createHttpServer({
+    allowedOrigins: env.ALLOWED_ORIGINS,
+    logger,
+    router,
+  });
+
+  const baseUrl = await new Promise<string>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+
+      if (!address || typeof address !== 'object') {
+        throw new Error('Failed to resolve E2E server address');
+      }
+
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+
+  return {
+    baseUrl,
+    server,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+
+      await disconnectPrisma(prisma, logger);
+      if (tokenPriceStub) {
+        await tokenPriceStub.close();
+      }
+    },
+  };
+}

--- a/packages/api/e2e/setup.ts
+++ b/packages/api/e2e/setup.ts
@@ -1,5 +1,12 @@
 const E2E_DATABASE_URL =
   'postgresql://e2e_user:e2e_password@localhost:5499/e2e_beacon?schema=public';
+const E2E_API_TOKEN_SECRET = 'e2e-test-api-token-secret-1234567890';
+const E2E_TELEGRAM_BOT_TOKEN = 'e2e-test-telegram-bot-token';
+const E2E_ALLOWED_ORIGINS = 'http://localhost:3000';
+const E2E_CHAIN = 'ethereum';
+const E2E_NATIVE_TOKEN_DECIMALS = '18';
+const E2E_COINGECKO_TOKEN_PRICE_API_URL = 'https://api.coingecko.com/api/v3/simple/price';
+const E2E_COINGECKO_TOKEN_NAME = 'ethereum';
 
 /**
  * Forces API e2e tests to use the local Docker test database.
@@ -8,6 +15,24 @@ function forceE2eDatabaseUrl() {
   process.env.DATABASE_URL = E2E_DATABASE_URL;
 }
 
+/**
+ * Sets default runtime values used by API e2e tests.
+ * Individual suites can override these values via startE2EServer(overrides).
+ */
+function setE2eDefaults() {
+  process.env.API_TOKEN_SECRET = process.env.API_TOKEN_SECRET ?? E2E_API_TOKEN_SECRET;
+  process.env.TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN ?? E2E_TELEGRAM_BOT_TOKEN;
+  process.env.ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS ?? E2E_ALLOWED_ORIGINS;
+  process.env.CHAIN = process.env.CHAIN ?? E2E_CHAIN;
+  process.env.CONSENSUS_LOOKBACK_SLOT = process.env.CONSENSUS_LOOKBACK_SLOT ?? '0';
+  process.env.NATIVE_TOKEN_DECIMALS =
+    process.env.NATIVE_TOKEN_DECIMALS ?? E2E_NATIVE_TOKEN_DECIMALS;
+  process.env.COINGECKO_TOKEN_PRICE_API_URL =
+    process.env.COINGECKO_TOKEN_PRICE_API_URL ?? E2E_COINGECKO_TOKEN_PRICE_API_URL;
+  process.env.COINGECKO_TOKEN_NAME = process.env.COINGECKO_TOKEN_NAME ?? E2E_COINGECKO_TOKEN_NAME;
+}
+
 forceE2eDatabaseUrl();
+setE2eDefaults();
 
 export {};

--- a/packages/api/src/auth/middleware.ts
+++ b/packages/api/src/auth/middleware.ts
@@ -17,17 +17,12 @@ interface AuthProcedureDeps {
   userStorage: UserStorage;
 }
 
-export interface ApiProcedures {
-  apiKeyProcedure: any;
-  publicProcedure: typeof publicProcedure;
-  securedProcedure: any;
-  telegramAuthProcedure: any;
-}
+export type ApiProcedures = ReturnType<typeof createAuthProcedures>;
 
 /**
  * Builds the API auth procedures from explicit dependencies.
  */
-export function createAuthProcedures(deps: AuthProcedureDeps): ApiProcedures {
+export function createAuthProcedures(deps: AuthProcedureDeps) {
   /**
    * Reads a string header from the raw request headers.
    */

--- a/packages/api/src/auth/middleware.ts
+++ b/packages/api/src/auth/middleware.ts
@@ -1,131 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ORPCError } from '@orpc/server';
 
-import { isOriginAllowed } from './origin.js';
-import { authenticateBotSignature } from './strategies/bot-signature.js';
-import { authenticateTelegram } from './strategies/telegram.js';
-import { authenticateApiKey } from './strategies/token.js';
 import { AuthStrategy } from './types.js';
 
-import { baseProcedure } from '@/lib/orpc.js';
-import { UserStorage } from '@/storage/user.js';
+import { baseProcedure, publicProcedure } from '@/lib/orpc.js';
+import type { UserStorage } from '@/storage/user.js';
 
-async function resolveTelegramUser(telegramInitData: string) {
-  const tgUser = await authenticateTelegram(telegramInitData);
-  const storage = new UserStorage();
-  return storage.getOrCreateTelegram({
-    telegramId: tgUser.telegramId,
-    username: tgUser.username,
-  });
+interface AuthProcedureDeps {
+  authenticateApiKey: (header: string) => void;
+  authenticateBotSignature: (signature: string, telegramId: string, timestamp: string) => void;
+  authenticateTelegram: (initData: string) => Promise<{
+    telegramId: string;
+    username?: string;
+  }>;
+  isOriginAllowed: (origin: string | undefined) => boolean;
+  userStorage: UserStorage;
 }
 
-async function resolveBotUser(telegramId: string) {
-  const storage = new UserStorage();
-  return storage.findByTelegramId(telegramId);
-}
-
-async function resolveAnonymousUser(sessionId: string) {
-  const storage = new UserStorage();
-  return storage.getOrCreateAnonymous(sessionId);
-}
-
-function getHeader(
-  headers: Record<string, string | string[] | undefined>,
-  name: string,
-): string | undefined {
-  const value = headers[name];
-  return Array.isArray(value) ? value[0] : value;
+export interface ApiProcedures {
+  apiKeyProcedure: any;
+  publicProcedure: typeof publicProcedure;
+  securedProcedure: any;
+  telegramAuthProcedure: any;
 }
 
 /**
- * Secured procedure — the default for all endpoints (except health check).
- *
- * Check order:
- *  1. Telegram initData header → validate HMAC, find-or-create DB user
- *  2. Bot-signature headers → validate HMAC, resolve DB user by telegramId
- *  3. API key via Authorization header → no user in context
- *  4. Anonymous session header + valid origin → find-or-create anonymous DB user
+ * Builds the API auth procedures from explicit dependencies.
  */
-export const securedProcedure = baseProcedure.use(async ({ context, next }) => {
-  const { headers } = context;
+export function createAuthProcedures(deps: AuthProcedureDeps): ApiProcedures {
+  /**
+   * Reads a string header from the raw request headers.
+   */
+  function getHeader(
+    headers: Record<string, string | string[] | undefined>,
+    name: string,
+  ): string | undefined {
+    const value = headers[name];
+    return Array.isArray(value) ? value[0] : value;
+  }
 
-  const telegramInitData = getHeader(headers, 'x-telegram-init-data');
-  const botSignature = getHeader(headers, 'bot-signature');
-  const botUserId = getHeader(headers, 'bot-user-id');
-  const botTimestamp = getHeader(headers, 'bot-timestamp');
-  const authHeader = getHeader(headers, 'authorization');
-  const anonymousId = getHeader(headers, 'ns-anonymous-id');
-  const origin = getHeader(headers, 'origin');
+  /**
+   * Resolves and upserts the authenticated Telegram user.
+   */
+  async function resolveTelegramUser(telegramInitData: string) {
+    const telegramUser = await deps.authenticateTelegram(telegramInitData);
+    return deps.userStorage.getOrCreateTelegram({
+      telegramId: telegramUser.telegramId,
+      username: telegramUser.username,
+    });
+  }
 
-  // 1. Telegram Mini App auth — highest priority
-  if (telegramInitData) {
+  /**
+   * Resolves the bot target user when one exists.
+   */
+  async function resolveBotUser(telegramId: string) {
+    return deps.userStorage.findByTelegramId(telegramId);
+  }
+
+  /**
+   * Resolves and upserts the anonymous browser user.
+   */
+  async function resolveAnonymousUser(sessionId: string) {
+    return deps.userStorage.getOrCreateAnonymous(sessionId);
+  }
+
+  const securedProcedure = baseProcedure.use(async ({ context, next }) => {
+    const { headers } = context;
+
+    const telegramInitData = getHeader(headers, 'x-telegram-init-data');
+    const botSignature = getHeader(headers, 'bot-signature');
+    const botUserId = getHeader(headers, 'bot-user-id');
+    const botTimestamp = getHeader(headers, 'bot-timestamp');
+    const authHeader = getHeader(headers, 'authorization');
+    const anonymousId = getHeader(headers, 'ns-anonymous-id');
+    const origin = getHeader(headers, 'origin');
+
+    if (telegramInitData) {
+      const user = await resolveTelegramUser(telegramInitData);
+      return next({ context: { ...context, user, authStrategy: AuthStrategy.TELEGRAM } });
+    }
+
+    if (botSignature && botUserId && botTimestamp) {
+      deps.authenticateBotSignature(botSignature, botUserId, botTimestamp);
+      const user = await resolveBotUser(botUserId);
+      return next({
+        context: { ...context, user: user ?? undefined, authStrategy: AuthStrategy.BOT_SIGNATURE },
+      });
+    }
+
+    if (authHeader) {
+      deps.authenticateApiKey(authHeader);
+      return next({ context: { ...context, authStrategy: AuthStrategy.API_KEY } });
+    }
+
+    if (anonymousId && deps.isOriginAllowed(origin)) {
+      const user = await resolveAnonymousUser(anonymousId);
+      return next({ context: { ...context, user, authStrategy: AuthStrategy.ANONYMOUS } });
+    }
+
+    throw new ORPCError('UNAUTHORIZED', {
+      message: 'Authentication required',
+    });
+  });
+
+  const telegramAuthProcedure = baseProcedure.use(async ({ context, next }) => {
+    const telegramInitData = getHeader(context.headers, 'x-telegram-init-data');
+
+    if (!telegramInitData) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'Telegram authentication required',
+      });
+    }
+
     const user = await resolveTelegramUser(telegramInitData);
+
     return next({ context: { ...context, user, authStrategy: AuthStrategy.TELEGRAM } });
-  }
-
-  // 2. Bot-signature auth — bot acting on behalf of a user
-  //    The HMAC signature proves the caller is the legitimate bot.
-  //    User lookup is best-effort: some bot endpoints (e.g. bot.users)
-  //    don't operate on behalf of a specific user.
-  if (botSignature && botUserId && botTimestamp) {
-    authenticateBotSignature(botSignature, botUserId, botTimestamp);
-    const user = await resolveBotUser(botUserId);
-    return next({
-      context: { ...context, user: user ?? undefined, authStrategy: AuthStrategy.BOT_SIGNATURE },
-    });
-  }
-
-  // 3. API key — non-browser clients
-  if (authHeader) {
-    authenticateApiKey(authHeader);
-    return next({ context: { ...context, authStrategy: AuthStrategy.API_KEY } });
-  }
-
-  // 4. Anonymous web session — requires valid origin + session UUID
-  if (anonymousId && isOriginAllowed(origin)) {
-    const user = await resolveAnonymousUser(anonymousId);
-    return next({ context: { ...context, user, authStrategy: AuthStrategy.ANONYMOUS } });
-  }
-
-  throw new ORPCError('UNAUTHORIZED', {
-    message: 'Authentication required',
   });
-});
 
-/**
- * Telegram-authenticated procedure.
- * Requires valid Telegram initData — use for endpoints that need a guaranteed user identity.
- */
-export const telegramAuthProcedure = baseProcedure.use(async ({ context, next }) => {
-  const { headers } = context;
+  const apiKeyProcedure = baseProcedure.use(async ({ context, next }) => {
+    const authHeader = getHeader(context.headers, 'authorization');
 
-  const telegramInitData = getHeader(headers, 'x-telegram-init-data');
+    if (!authHeader) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'API key authentication required',
+      });
+    }
 
-  if (!telegramInitData) {
-    throw new ORPCError('UNAUTHORIZED', {
-      message: 'Telegram authentication required',
-    });
-  }
+    deps.authenticateApiKey(authHeader);
 
-  const user = await resolveTelegramUser(telegramInitData);
+    return next({ context: { ...context, authStrategy: AuthStrategy.API_KEY } });
+  });
 
-  return next({ context: { ...context, user, authStrategy: AuthStrategy.TELEGRAM } });
-});
-
-/**
- * API key authenticated procedure.
- * Requires a valid Authorization header and rejects other auth strategies.
- */
-export const apiKeyProcedure = baseProcedure.use(async ({ context, next }) => {
-  const { headers } = context;
-  const authHeader = getHeader(headers, 'authorization');
-
-  if (!authHeader) {
-    throw new ORPCError('UNAUTHORIZED', {
-      message: 'API key authentication required',
-    });
-  }
-
-  authenticateApiKey(authHeader);
-
-  return next({ context: { ...context, authStrategy: AuthStrategy.API_KEY } });
-});
+  return {
+    apiKeyProcedure,
+    publicProcedure,
+    securedProcedure,
+    telegramAuthProcedure,
+  };
+}

--- a/packages/api/src/auth/origin.ts
+++ b/packages/api/src/auth/origin.ts
@@ -1,44 +1,41 @@
-import { env } from '@/config/env.js';
-import { logger } from '@/lib/logger.js';
+import type { Logger } from '@/lib/logger.js';
 
-/**
- * Parse ALLOWED_ORIGINS env var into an array of patterns.
- */
-function parseAllowedOrigins(): string[] {
-  return env.ALLOWED_ORIGINS.split(',')
-    .map((o) => o.trim())
-    .filter(Boolean);
+export interface OriginCheckConfig {
+  allowedOrigins: string;
+  logger: Logger;
 }
 
 /**
- * Check if an origin matches a pattern.
- * Supports:
- *  - "*" (allow all)
- *  - "https://*.example.com" (wildcard subdomain)
- *  - "http://localhost:3000" (exact match)
+ * Returns true when the origin is allowed by config.
  */
-function matchesPattern(origin: string, pattern: string): boolean {
-  if (pattern === '*') return true;
+export function isOriginAllowed(origin: string | undefined, config: OriginCheckConfig): boolean {
+  const patterns = config.allowedOrigins
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
 
-  if (pattern.includes('*')) {
-    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[a-zA-Z0-9-]+');
-    return new RegExp(`^${escaped}$`).test(origin);
+  /**
+   * Checks whether one origin matches a configured pattern.
+   */
+  function matchesPattern(origin: string, pattern: string): boolean {
+    if (pattern === '*') {
+      return true;
+    }
+
+    if (pattern.includes('*')) {
+      const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '[a-zA-Z0-9-]+');
+      return new RegExp(`^${escaped}$`).test(origin);
+    }
+
+    return origin === pattern;
   }
 
-  return origin === pattern;
-}
-
-/**
- * Returns true if the given origin is in the allowed list.
- */
-export function isOriginAllowed(origin: string | undefined): boolean {
   if (!origin) {
-    logger.debug({ origin }, 'CORS: no origin header');
+    config.logger.debug({ origin }, 'CORS: no origin header');
     return false;
   }
 
-  const patterns = parseAllowedOrigins();
   const allowed = patterns.some((pattern) => matchesPattern(origin, pattern));
-  logger.debug({ origin, patterns, allowed }, 'CORS: origin check');
+  config.logger.debug({ origin, patterns, allowed }, 'CORS: origin check');
   return allowed;
 }

--- a/packages/api/src/auth/strategies/bot-signature.ts
+++ b/packages/api/src/auth/strategies/bot-signature.ts
@@ -2,51 +2,55 @@ import crypto from 'node:crypto';
 
 import { ORPCError } from '@orpc/server';
 
-import { env } from '@/config/env.js';
-
-/** Maximum age of bot-signature before it's considered expired */
+/** Maximum age of bot-signature before it's considered expired. */
 const BOT_SIGNATURE_MAX_AGE_SECONDS = 60;
 
+export interface BotSignatureAuthenticator {
+  authenticateBotSignature: (signature: string, telegramId: string, timestamp: string) => void;
+}
+
 /**
- * Bot-signature authentication strategy.
- * Validates HMAC-SHA256 signature created by the telegram bot using BOT_TOKEN.
- *
- * Headers:
- *   bot-signature: HMAC-SHA256(BOT_TOKEN, telegramId + ":" + timestamp)
- *   bot-user-id: telegram user ID (string)
- *   bot-timestamp: unix timestamp in seconds (string)
+ * Creates the bot-signature authentication strategy.
  */
-export function authenticateBotSignature(
-  signature: string,
-  telegramId: string,
-  timestamp: string,
-): void {
-  // Verify timestamp freshness
-  const ts = Number(timestamp);
-  const now = Math.floor(Date.now() / 1000);
+export function createBotSignatureAuthenticator(
+  telegramBotToken: string,
+): BotSignatureAuthenticator {
+  /**
+   * Authenticates a bot-signature request.
+   */
+  function authenticateBotSignature(
+    signature: string,
+    telegramId: string,
+    timestamp: string,
+  ): void {
+    const ts = Number(timestamp);
+    const now = Math.floor(Date.now() / 1000);
 
-  if (Number.isNaN(ts) || Math.abs(now - ts) > BOT_SIGNATURE_MAX_AGE_SECONDS) {
-    throw new ORPCError('UNAUTHORIZED', {
-      message: 'Bot signature expired or invalid timestamp',
-    });
+    if (Number.isNaN(ts) || Math.abs(now - ts) > BOT_SIGNATURE_MAX_AGE_SECONDS) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'Bot signature expired or invalid timestamp',
+      });
+    }
+
+    const expectedSignature = crypto
+      .createHmac('sha256', telegramBotToken)
+      .update(`${telegramId}:${timestamp}`)
+      .digest('hex');
+
+    const sigBuffer = Buffer.from(signature, 'hex');
+    const expectedBuffer = Buffer.from(expectedSignature, 'hex');
+
+    if (
+      sigBuffer.length !== expectedBuffer.length ||
+      !crypto.timingSafeEqual(sigBuffer, expectedBuffer)
+    ) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'Invalid bot signature',
+      });
+    }
   }
 
-  // Compute expected signature
-  const expectedSignature = crypto
-    .createHmac('sha256', env.TELEGRAM_BOT_TOKEN)
-    .update(`${telegramId}:${timestamp}`)
-    .digest('hex');
-
-  // Timing-safe comparison
-  const sigBuffer = Buffer.from(signature, 'hex');
-  const expectedBuffer = Buffer.from(expectedSignature, 'hex');
-
-  if (
-    sigBuffer.length !== expectedBuffer.length ||
-    !crypto.timingSafeEqual(sigBuffer, expectedBuffer)
-  ) {
-    throw new ORPCError('UNAUTHORIZED', {
-      message: 'Invalid bot signature',
-    });
-  }
+  return {
+    authenticateBotSignature,
+  };
 }

--- a/packages/api/src/auth/strategies/telegram.ts
+++ b/packages/api/src/auth/strategies/telegram.ts
@@ -4,93 +4,95 @@ import { ORPCError } from '@orpc/server';
 
 import { AuthStrategy, type TelegramUser } from '../types.js';
 
-import { env } from '@/config/env.js';
+export interface TelegramAuthenticator {
+  authenticateTelegram: (initData: string) => Promise<TelegramUser>;
+}
 
 /**
- * Telegram Mini App authentication strategy
- * Validates initData from Telegram Web Apps
- *
- * Reference: https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app
+ * Creates the Telegram Mini App authentication strategy.
  */
-export async function authenticateTelegram(initData: string): Promise<TelegramUser> {
-  try {
-    // Parse init data
-    const params = new URLSearchParams(initData);
-    const hash = params.get('hash');
-    params.delete('hash');
+export function createTelegramAuthenticator(config: {
+  maxAgeSeconds: number;
+  telegramBotToken: string;
+}): TelegramAuthenticator {
+  /**
+   * Authenticates Telegram Mini App init data.
+   */
+  async function authenticateTelegram(initData: string): Promise<TelegramUser> {
+    try {
+      const searchParams = new URLSearchParams(initData);
+      const hash = searchParams.get('hash');
+      searchParams.delete('hash');
 
-    if (!hash) {
+      if (!hash) {
+        throw new ORPCError('UNAUTHORIZED', {
+          message: 'Missing hash in init data',
+        });
+      }
+
+      const dataCheckArray: string[] = [];
+      searchParams.forEach((value, key) => {
+        dataCheckArray.push(`${key}=${value}`);
+      });
+      dataCheckArray.sort();
+      const dataCheckString = dataCheckArray.join('\n');
+
+      const secretKey = crypto
+        .createHmac('sha256', 'WebAppData')
+        .update(config.telegramBotToken)
+        .digest();
+
+      const computedHash = crypto
+        .createHmac('sha256', secretKey)
+        .update(dataCheckString)
+        .digest('hex');
+
+      if (computedHash !== hash) {
+        throw new ORPCError('UNAUTHORIZED', {
+          message: 'Invalid Telegram init data',
+        });
+      }
+
+      const authDate = Number(searchParams.get('auth_date'));
+      const now = Math.floor(Date.now() / 1000);
+
+      if (!authDate || now - authDate > config.maxAgeSeconds) {
+        throw new ORPCError('UNAUTHORIZED', {
+          message: 'Telegram init data expired',
+        });
+      }
+
+      const userJson = searchParams.get('user');
+      if (!userJson) {
+        throw new ORPCError('UNAUTHORIZED', {
+          message: 'Missing user data',
+        });
+      }
+
+      const userData = JSON.parse(userJson);
+
+      return {
+        id: userData.id.toString(),
+        telegramId: userData.id.toString(),
+        username: userData.username,
+        strategy: AuthStrategy.TELEGRAM,
+        metadata: {
+          chatId: searchParams.get('chat_id') || undefined,
+          initData,
+        },
+      };
+    } catch (error) {
+      if (error instanceof ORPCError) {
+        throw error;
+      }
+
       throw new ORPCError('UNAUTHORIZED', {
-        message: 'Missing hash in init data',
+        message: 'Failed to authenticate with Telegram',
       });
     }
-
-    // Create data check string
-    const dataCheckArray: string[] = [];
-    params.forEach((value, key) => {
-      dataCheckArray.push(`${key}=${value}`);
-    });
-    dataCheckArray.sort();
-    const dataCheckString = dataCheckArray.join('\n');
-
-    // Compute secret key
-    const secretKey = crypto
-      .createHmac('sha256', 'WebAppData')
-      .update(env.TELEGRAM_BOT_TOKEN)
-      .digest();
-
-    // Compute hash
-    const computedHash = crypto
-      .createHmac('sha256', secretKey)
-      .update(dataCheckString)
-      .digest('hex');
-
-    // Verify hash
-    if (computedHash !== hash) {
-      throw new ORPCError('UNAUTHORIZED', {
-        message: 'Invalid Telegram init data',
-      });
-    }
-
-    // Verify auth_date is not older than the configured session window.
-    // Telegram Mini Apps can stay open for long periods, so a short TTL
-    // causes valid in-app sessions to fail unexpectedly.
-    const authDate = Number(params.get('auth_date'));
-    const now = Math.floor(Date.now() / 1000);
-
-    if (!authDate || now - authDate > env.TELEGRAM_INIT_DATA_MAX_AGE_SECONDS) {
-      throw new ORPCError('UNAUTHORIZED', {
-        message: 'Telegram init data expired',
-      });
-    }
-
-    // Parse user data
-    const userJson = params.get('user');
-    if (!userJson) {
-      throw new ORPCError('UNAUTHORIZED', {
-        message: 'Missing user data',
-      });
-    }
-
-    const userData = JSON.parse(userJson);
-
-    return {
-      id: userData.id.toString(),
-      telegramId: userData.id.toString(),
-      username: userData.username,
-      strategy: AuthStrategy.TELEGRAM,
-      metadata: {
-        chatId: params.get('chat_id') || undefined,
-        initData,
-      },
-    };
-  } catch (error) {
-    if (error instanceof ORPCError) {
-      throw error;
-    }
-
-    throw new ORPCError('UNAUTHORIZED', {
-      message: 'Failed to authenticate with Telegram',
-    });
   }
+
+  return {
+    authenticateTelegram,
+  };
 }

--- a/packages/api/src/auth/strategies/token.ts
+++ b/packages/api/src/auth/strategies/token.ts
@@ -1,17 +1,27 @@
 import { ORPCError } from '@orpc/server';
 
-import { env } from '@/config/env.js';
+export interface ApiKeyAuthenticator {
+  authenticateApiKey: (header: string) => void;
+}
 
 /**
- * Authenticate by comparing the provided token directly against API_TOKEN_SECRET.
- * Used for external/non-browser clients that can't rely on origin whitelisting.
+ * Creates the API key authentication strategy.
  */
-export function authenticateApiKey(header: string): void {
-  const token = header.replace(/^Bearer\s+/i, '');
+export function createApiKeyAuthenticator(apiTokenSecret: string): ApiKeyAuthenticator {
+  /**
+   * Authenticates the API key from the Authorization header.
+   */
+  function authenticateApiKey(header: string): void {
+    const token = header.replace(/^Bearer\s+/i, '');
 
-  if (!token || token !== env.API_TOKEN_SECRET) {
-    throw new ORPCError('UNAUTHORIZED', {
-      message: 'Invalid API key',
-    });
+    if (!token || token !== apiTokenSecret) {
+      throw new ORPCError('UNAUTHORIZED', {
+        message: 'Invalid API key',
+      });
+    }
   }
+
+  return {
+    authenticateApiKey,
+  };
 }

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -1,10 +1,10 @@
 import { config } from 'dotenv';
 import { z } from 'zod';
 
-// Load environment variables
-config({ path: new URL('../../.env', import.meta.url) });
-
-const envSchema = z.object({
+/**
+ * Validates the API environment variables.
+ */
+export const envSchema = z.object({
   // Database
   DATABASE_URL: z.string().url(),
 
@@ -25,7 +25,7 @@ const envSchema = z.object({
   // Logging
   LOG_LEVEL: z.enum(['silent', 'fatal', 'error', 'warn', 'info', 'debug', 'trace']).default('info'),
 
-  // Chain config (same as indexer)
+  // Chain config
   CHAIN: z.enum(['ethereum', 'gnosis']),
   CONSENSUS_LOOKBACK_SLOT: z.coerce.number().int().min(0).default(0),
   NATIVE_TOKEN_DECIMALS: z.coerce.number().int().min(0).default(18),
@@ -37,11 +37,25 @@ const envSchema = z.object({
 
 export type Env = z.infer<typeof envSchema>;
 
-const parsed = envSchema.safeParse(process.env);
+/**
+ * Parses the environment from a raw object.
+ */
+export function parseEnv(source: Record<string, string | undefined>): Env {
+  const parsed = envSchema.safeParse(source);
 
-if (!parsed.success) {
-  console.error('❌ Invalid environment variables:', parsed.error.flatten().fieldErrors);
-  throw new Error('Invalid environment variables');
+  if (!parsed.success) {
+    console.error('❌ Invalid environment variables:', parsed.error.flatten().fieldErrors);
+    throw new Error('Invalid environment variables');
+  }
+
+  return parsed.data;
 }
 
-export const env = parsed.data;
+/**
+ * Loads dotenv and parses the current process environment.
+ */
+export function loadEnv(): Env {
+  config({ path: new URL('../../.env', import.meta.url) });
+
+  return parseEnv(process.env);
+}

--- a/packages/api/src/controllers/systemConfig.ts
+++ b/packages/api/src/controllers/systemConfig.ts
@@ -18,7 +18,7 @@ interface IndexerConfig {
 }
 
 export class SystemConfigController {
-  constructor(private readonly storage: SystemConfigStorage = new SystemConfigStorage()) {}
+  constructor(private readonly storage: SystemConfigStorage) {}
 
   /**
    * Get archive configuration

--- a/packages/api/src/controllers/validator.ts
+++ b/packages/api/src/controllers/validator.ts
@@ -9,7 +9,7 @@ import type {
 } from '@/routers/validator/schemas.js';
 
 import { ValidatorStorage } from '@/storage/validator.js';
-import { beaconTime } from '@/utils/beaconTime.js';
+import type { BeaconHelpers } from '@/utils/beaconTime.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 
 /** Reverse map: numeric status id → Beacon API string */
@@ -22,7 +22,19 @@ const STATUS_BY_ID: Record<number, string> = Object.fromEntries(
  * Orchestrates data retrieval and transforms flat DB rows into hierarchical structure
  */
 export class ValidatorController {
-  constructor(private readonly storage: ValidatorStorage = new ValidatorStorage()) {}
+  constructor(params: {
+    beaconHelpers: BeaconHelpers;
+    chain: 'ethereum' | 'gnosis';
+    storage: ValidatorStorage;
+  }) {
+    this.storage = params.storage;
+    this.beaconHelpers = params.beaconHelpers;
+    this.chain = params.chain;
+  }
+
+  private readonly beaconHelpers: BeaconHelpers;
+  private readonly chain: 'ethereum' | 'gnosis';
+  private readonly storage: ValidatorStorage;
 
   /**
    * Get validator details with timeline grouped by epoch → slot
@@ -67,9 +79,9 @@ export class ValidatorController {
               value: STATUS_BY_ID[validatorInfoRow.status] ?? 'unknown',
             }
           : null,
-      balance: formatBalance(validatorInfoRow.balance),
+      balance: formatBalance(validatorInfoRow.balance, this.chain),
       effectiveBalance: validatorInfoRow.effective_balance
-        ? formatBalance(validatorInfoRow.effective_balance)
+        ? formatBalance(validatorInfoRow.effective_balance, this.chain)
         : null,
     };
 
@@ -82,14 +94,14 @@ export class ValidatorController {
       epochsMap.set(epochReward.epoch, {
         epoch: epochReward.epoch,
         rewards: {
-          head: formatBalance(epochReward.head),
-          target: formatBalance(epochReward.target),
-          source: formatBalance(epochReward.source),
-          inactivity: formatBalance(epochReward.inactivity),
-          missedHead: formatBalance(epochReward.missed_head),
-          missedTarget: formatBalance(epochReward.missed_target),
-          missedSource: formatBalance(epochReward.missed_source),
-          missedInactivity: formatBalance(epochReward.missed_inactivity),
+          head: formatBalance(epochReward.head, this.chain),
+          target: formatBalance(epochReward.target, this.chain),
+          source: formatBalance(epochReward.source, this.chain),
+          inactivity: formatBalance(epochReward.inactivity, this.chain),
+          missedHead: formatBalance(epochReward.missed_head, this.chain),
+          missedTarget: formatBalance(epochReward.missed_target, this.chain),
+          missedSource: formatBalance(epochReward.missed_source, this.chain),
+          missedInactivity: formatBalance(epochReward.missed_inactivity, this.chain),
         },
         slot: null,
       });
@@ -98,7 +110,7 @@ export class ValidatorController {
     // Group slots by epoch
     // A validator attests only once per epoch, so we assign a single slot per epoch
     for (const slotRow of slotRows) {
-      const epoch = beaconTime.getEpochFromSlot(slotRow.slot);
+      const epoch = this.beaconHelpers.beaconTime.getEpochFromSlot(slotRow.slot);
 
       // Ensure epoch exists in map
       if (!epochsMap.has(epoch)) {

--- a/packages/api/src/dependencies.ts
+++ b/packages/api/src/dependencies.ts
@@ -1,0 +1,44 @@
+import type { PrismaClient } from '@beacon-indexer/db';
+
+import type { ApiProcedures } from '@/auth/middleware.js';
+import type { SystemConfigController } from '@/controllers/systemConfig.js';
+import type { ValidatorController } from '@/controllers/validator.js';
+import type { Logger } from '@/lib/logger.js';
+import type { AnalyticsStorage } from '@/storage/analytics.js';
+import type { BlockStorage } from '@/storage/block.js';
+import type { BotCommunicationsStorage } from '@/storage/bot-communications.js';
+import type { BotIncidentNotificationsStorage } from '@/storage/bot-incident-notifications.js';
+import type { BotNotificationsStorage } from '@/storage/bot-notifications.js';
+import type { BotUsersStorage } from '@/storage/bot-users.js';
+import type { ClusterStorage } from '@/storage/cluster.js';
+import type { IncidentStorage } from '@/storage/incident.js';
+import type { UserStorage } from '@/storage/user.js';
+import type { ValidatorStorage } from '@/storage/validator.js';
+import type { BeaconHelpers } from '@/utils/beaconTime.js';
+
+/**
+ * Shared runtime dependencies used by API factories.
+ * Values are composed explicitly in index.ts.
+ */
+export interface ApiDependencies {
+  analyticsStorage: AnalyticsStorage;
+  beaconHelpers: BeaconHelpers;
+  blockStorage: BlockStorage;
+  botCommunicationsStorage: BotCommunicationsStorage;
+  botIncidentNotificationsStorage: BotIncidentNotificationsStorage;
+  botNotificationsStorage: BotNotificationsStorage;
+  botUsersStorage: BotUsersStorage;
+  clusterStorage: ClusterStorage;
+  incidentStorage: IncidentStorage;
+  logger: Logger;
+  nativeTokenDecimals: number;
+  prisma: PrismaClient;
+  procedures: ApiProcedures;
+  systemConfigController: SystemConfigController;
+  tokenPriceApiUrl: string;
+  tokenPriceTokenName: string;
+  userStorage: UserStorage;
+  validatorController: ValidatorController;
+  validatorStorage: ValidatorStorage;
+  chain: 'ethereum' | 'gnosis';
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,23 +1,111 @@
-import { env } from './config/env.js';
+import { createAuthProcedures } from './auth/middleware.js';
+import { isOriginAllowed } from './auth/origin.js';
+import { createBotSignatureAuthenticator } from './auth/strategies/bot-signature.js';
+import { createTelegramAuthenticator } from './auth/strategies/telegram.js';
+import { createApiKeyAuthenticator } from './auth/strategies/token.js';
+import { loadEnv } from './config/env.js';
+import { SystemConfigController } from './controllers/systemConfig.js';
+import { ValidatorController } from './controllers/validator.js';
 import { startJobs, stopJobs } from './jobs/index.js';
-import { logger } from './lib/logger.js';
-import { disconnectPrisma, getPrisma } from './lib/prisma.js';
+import { createLogger } from './lib/logger.js';
+import { createPrisma, disconnectPrisma } from './lib/prisma.js';
+import { createRouter } from './routers/index.js';
 import { createHttpServer } from './server.js';
+import { AnalyticsStorage } from './storage/analytics.js';
+import { BlockStorage } from './storage/block.js';
+import { BotCommunicationsStorage } from './storage/bot-communications.js';
+import { BotIncidentNotificationsStorage } from './storage/bot-incident-notifications.js';
+import { BotNotificationsStorage } from './storage/bot-notifications.js';
+import { BotUsersStorage } from './storage/bot-users.js';
+import { ClusterStorage } from './storage/cluster.js';
+import { IncidentStorage } from './storage/incident.js';
+import { SystemConfigStorage } from './storage/systemConfig.js';
+import { UserStorage } from './storage/user.js';
+import { ValidatorStorage } from './storage/validator.js';
+import { createBeaconHelpers } from './utils/beaconTime.js';
 
-let server: ReturnType<typeof createHttpServer> | null = null;
+/**
+ * Bootstraps the API runtime.
+ */
+async function main() {
+  const env = loadEnv();
+  const logger = createLogger({
+    logLevel: env.LOG_LEVEL,
+    nodeEnv: env.NODE_ENV,
+  });
 
-// Cleanup function to ensure proper shutdown
-async function cleanup() {
-  logger.info('Starting graceful shutdown...');
+  const prisma = createPrisma(env.DATABASE_URL, logger);
 
-  try {
-    // Stop cron jobs
-    stopJobs();
+  const beaconHelpers = createBeaconHelpers({
+    chain: env.CHAIN,
+    lookbackSlot: env.CONSENSUS_LOOKBACK_SLOT,
+  });
 
-    // Close HTTP server
-    if (server) {
+  const userStorage = new UserStorage(prisma);
+  const validatorStorage = new ValidatorStorage(prisma);
+  const validatorController = new ValidatorController({
+    storage: validatorStorage,
+    beaconHelpers,
+    chain: env.CHAIN,
+  });
+  const systemConfigStorage = new SystemConfigStorage(prisma);
+  const systemConfigController = new SystemConfigController(systemConfigStorage);
+
+  const procedures = createAuthProcedures({
+    ...createApiKeyAuthenticator(env.API_TOKEN_SECRET),
+    ...createBotSignatureAuthenticator(env.TELEGRAM_BOT_TOKEN),
+    ...createTelegramAuthenticator({
+      maxAgeSeconds: env.TELEGRAM_INIT_DATA_MAX_AGE_SECONDS,
+      telegramBotToken: env.TELEGRAM_BOT_TOKEN,
+    }),
+    isOriginAllowed: (origin) =>
+      isOriginAllowed(origin, {
+        allowedOrigins: env.ALLOWED_ORIGINS,
+        logger,
+      }),
+    userStorage,
+  });
+
+  const router = createRouter({
+    analyticsStorage: new AnalyticsStorage(prisma),
+    beaconHelpers,
+    blockStorage: new BlockStorage(prisma),
+    botCommunicationsStorage: new BotCommunicationsStorage(prisma),
+    botIncidentNotificationsStorage: new BotIncidentNotificationsStorage(prisma),
+    botNotificationsStorage: new BotNotificationsStorage(prisma),
+    botUsersStorage: new BotUsersStorage(prisma),
+    chain: env.CHAIN,
+    clusterStorage: new ClusterStorage(prisma),
+    incidentStorage: new IncidentStorage(prisma),
+    logger,
+    nativeTokenDecimals: env.NATIVE_TOKEN_DECIMALS,
+    prisma,
+    procedures,
+    systemConfigController,
+    tokenPriceApiUrl: env.COINGECKO_TOKEN_PRICE_API_URL,
+    tokenPriceTokenName: env.COINGECKO_TOKEN_NAME,
+    userStorage,
+    validatorController,
+    validatorStorage,
+  });
+
+  const server = createHttpServer({
+    allowedOrigins: env.ALLOWED_ORIGINS,
+    logger,
+    router,
+  });
+
+  /**
+   * Shuts down the API process gracefully.
+   */
+  async function cleanup() {
+    logger.info('Starting graceful shutdown...');
+
+    try {
+      stopJobs(logger);
+
       await new Promise<void>((resolve, reject) => {
-        server!.close((err) => {
+        server.close((err) => {
           if (err) {
             reject(err);
           } else {
@@ -26,63 +114,59 @@ async function cleanup() {
         });
       });
       logger.info('HTTP server closed');
+
+      await disconnectPrisma(prisma, logger);
+    } catch (error) {
+      logger.error({ err: error }, 'Error during cleanup');
     }
 
-    // Disconnect Prisma
-    await disconnectPrisma();
-  } catch (error) {
-    logger.error({ err: error }, 'Error during cleanup');
+    logger.info('Shutdown complete');
   }
 
-  logger.info('Shutdown complete');
-}
+  /**
+   * Handles process shutdown signals.
+   */
+  const shutdown = async (signal: string) => {
+    logger.info(`Received ${signal}, shutting down gracefully...`);
+    await cleanup();
+    process.exit(0);
+  };
 
-// Handle graceful shutdown signals
-const shutdown = async (signal: string) => {
-  logger.info(`Received ${signal}, shutting down gracefully...`);
-  await cleanup();
-  process.exit(0);
-};
+  process.on('SIGINT', () => {
+    void shutdown('SIGINT');
+  });
+  process.on('SIGTERM', () => {
+    void shutdown('SIGTERM');
+  });
 
-process.on('SIGINT', () => shutdown('SIGINT'));
-process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('uncaughtException', async (error) => {
+    logger.error({ err: error }, 'Uncaught exception');
+    await cleanup();
+    process.exit(1);
+  });
 
-// Handle uncaught exceptions and unhandled rejections
-process.on('uncaughtException', async (error) => {
-  logger.error({ err: error }, 'Uncaught exception');
-  await cleanup();
-  process.exit(1);
-});
+  process.on('unhandledRejection', async (reason, promise) => {
+    logger.error({ promise, reason }, 'Unhandled rejection');
+    await cleanup();
+    process.exit(1);
+  });
 
-process.on('unhandledRejection', async (reason, promise) => {
-  logger.error({ promise, reason }, 'Unhandled rejection');
-  await cleanup();
-  process.exit(1);
-});
-
-async function main() {
   try {
-    // Connect to database
-    const prisma = getPrisma();
     await prisma.$connect();
     logger.info('Database connected successfully');
 
-    // Start HTTP server
-    server = createHttpServer();
     await new Promise<void>((resolve, reject) => {
-      server!.listen(env.PORT, '0.0.0.0', () => {
+      server.listen(env.PORT, '0.0.0.0', () => {
         logger.info(`HTTP server listening on port ${env.PORT}`);
         resolve();
       });
 
-      server!.on('error', (err) => {
+      server.on('error', (err) => {
         reject(err);
       });
     });
 
-    // Start cron jobs
-    startJobs();
-
+    startJobs({ logger, prisma });
     logger.info('API server started successfully');
   } catch (error) {
     logger.error({ err: error }, 'Failed to start server');
@@ -91,13 +175,7 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  logger.error({ err: error }, 'Fatal error');
-  cleanup()
-    .then(() => {
-      process.exit(1);
-    })
-    .catch(() => {
-      process.exit(1);
-    });
+void main().catch(async (error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/packages/api/src/jobs/daily.ts
+++ b/packages/api/src/jobs/daily.ts
@@ -1,17 +1,14 @@
 import cron from 'node-cron';
 
-import { logger } from '@/lib/logger.js';
+import type { Logger } from '@/lib/logger.js';
 
 /**
- * Register daily jobs
- * These jobs run once per day for daily aggregations
+ * Registers the daily jobs.
  */
-export function registerDailyJobs() {
-  // Run at midnight UTC (00:00)
+export function registerDailyJobs(logger: Logger) {
   cron.schedule('0 0 * * *', async () => {
     try {
       logger.info('Starting daily aggregation job');
-
       logger.info('Daily aggregation job completed');
     } catch (error) {
       logger.error({ err: error }, 'Error in daily aggregation job');

--- a/packages/api/src/jobs/hourly.ts
+++ b/packages/api/src/jobs/hourly.ts
@@ -1,21 +1,14 @@
 import cron from 'node-cron';
 
-import { logger } from '@/lib/logger.js';
+import type { Logger } from '@/lib/logger.js';
 
 /**
- * Register hourly jobs
- * These jobs run every hour for data aggregation
+ * Registers the hourly jobs.
  */
-export function registerHourlyJobs() {
-  // Run at the start of each hour (minute 0)
+export function registerHourlyJobs(logger: Logger) {
   cron.schedule('0 * * * *', async () => {
     try {
       logger.info('Starting hourly aggregation job');
-
-      // TODO: Implement hourly aggregation logic
-      // Previously used lastSummaryUpdate table which has been removed
-      // Hourly aggregations should now be computed from slot-level data
-
       logger.info('Hourly aggregation job completed');
     } catch (error) {
       logger.error({ err: error }, 'Error in hourly aggregation job');

--- a/packages/api/src/jobs/index.ts
+++ b/packages/api/src/jobs/index.ts
@@ -1,46 +1,41 @@
+import type { PrismaClient } from '@beacon-indexer/db';
+
 import { registerDailyJobs } from './daily.js';
 import { registerHourlyJobs } from './hourly.js';
 import { registerPerMinuteJobs } from './per-minute.js';
 import { registerPerSecondJobs } from './per-second.js';
 
-import { logger } from '@/lib/logger.js';
+import type { Logger } from '@/lib/logger.js';
 
 let jobsStarted = false;
 
 /**
- * Start all cron jobs
+ * Starts the API cron jobs.
  */
-export function startJobs() {
+export function startJobs(params: { logger: Logger; prisma: PrismaClient }) {
   if (jobsStarted) {
-    logger.warn('Jobs already started, skipping');
+    params.logger.warn('Jobs already started, skipping');
     return;
   }
 
-  logger.info('Starting cron jobs...');
-
-  // Register all job types
-  registerPerSecondJobs();
-  registerPerMinuteJobs();
-  registerHourlyJobs();
-  registerDailyJobs();
-
+  params.logger.info('Starting cron jobs...');
+  registerPerSecondJobs(params.logger);
+  registerPerMinuteJobs(params);
+  registerHourlyJobs(params.logger);
+  registerDailyJobs(params.logger);
   jobsStarted = true;
-  logger.info('All cron jobs started');
+  params.logger.info('All cron jobs started');
 }
 
 /**
- * Stop all cron jobs
- * Note: node-cron doesn't have a built-in way to stop all jobs,
- * but we can track this for graceful shutdown
+ * Stops the API cron jobs bookkeeping.
  */
-export function stopJobs() {
+export function stopJobs(logger: Logger) {
   if (!jobsStarted) {
     return;
   }
 
   logger.info('Stopping cron jobs...');
-  // In a real implementation, you might want to track cron instances
-  // and call .destroy() on them, but for now we just log
   jobsStarted = false;
   logger.info('Cron jobs stopped');
 }

--- a/packages/api/src/jobs/per-minute.ts
+++ b/packages/api/src/jobs/per-minute.ts
@@ -1,32 +1,27 @@
+import type { PrismaClient } from '@beacon-indexer/db';
 import cron from 'node-cron';
 
-import { logger } from '@/lib/logger.js';
-import { getPrisma } from '@/lib/prisma.js';
+import type { Logger } from '@/lib/logger.js';
 
 /**
- * Register per-minute jobs
- * These jobs run every minute for frequent checks
+ * Registers the per-minute jobs.
  */
-export function registerPerMinuteJobs() {
-  // Example: Check indexer health and log metrics
+export function registerPerMinuteJobs(params: { logger: Logger; prisma: PrismaClient }) {
   cron.schedule('* * * * *', async () => {
     try {
-      const prisma = getPrisma();
-
-      // Quick health check
-      const lastProcessedSlot = await prisma.slot.findFirst({
+      const lastProcessedSlot = await params.prisma.slot.findFirst({
         where: { processed: true },
         orderBy: { slot: 'desc' },
         select: { slot: true },
       });
 
       if (lastProcessedSlot) {
-        logger.debug({ lastProcessedSlot: lastProcessedSlot.slot }, 'Indexer status check');
+        params.logger.debug({ lastProcessedSlot: lastProcessedSlot.slot }, 'Indexer status check');
       }
     } catch (error) {
-      logger.error({ err: error }, 'Error in per-minute job');
+      params.logger.error({ err: error }, 'Error in per-minute job');
     }
   });
 
-  logger.info('Per-minute jobs registered');
+  params.logger.info('Per-minute jobs registered');
 }

--- a/packages/api/src/jobs/per-second.ts
+++ b/packages/api/src/jobs/per-second.ts
@@ -1,19 +1,14 @@
 import cron from 'node-cron';
 
-import { logger } from '@/lib/logger.js';
+import type { Logger } from '@/lib/logger.js';
 
 /**
- * Register per-second jobs
- * These are very light jobs that run every second
+ * Registers the per-second jobs.
  */
-export function registerPerSecondJobs() {
-  // Example: Update cached current slot/epoch
-  // This can be useful for real-time monitoring
+export function registerPerSecondJobs(logger: Logger) {
   cron.schedule('* * * * * *', async () => {
     try {
-      // Light operations only - avoid heavy DB queries here
-      // This is just a placeholder for future lightweight operations
-      // logger.debug('Per-second job executed');
+      // Placeholder for future lightweight background work.
     } catch (error) {
       logger.error({ err: error }, 'Error in per-second job');
     }

--- a/packages/api/src/lib/logger.ts
+++ b/packages/api/src/lib/logger.ts
@@ -1,20 +1,26 @@
 import pino from 'pino';
 
-import { env } from '@/config/env.js';
+export type Logger = pino.Logger;
 
-export const logger = pino({
-  level: env.LOG_LEVEL,
-  transport:
-    env.NODE_ENV === 'development'
-      ? {
-          target: 'pino-pretty',
-          options: {
-            colorize: true,
-            translateTime: 'HH:MM:ss Z',
-            ignore: 'pid,hostname',
-          },
-        }
-      : undefined,
-});
-
-export type Logger = typeof logger;
+/**
+ * Creates the API logger from plain parameters.
+ */
+export function createLogger(params: {
+  logLevel: 'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
+  nodeEnv: 'development' | 'production' | 'test';
+}): Logger {
+  return pino({
+    level: params.logLevel,
+    transport:
+      params.nodeEnv === 'development'
+        ? {
+            target: 'pino-pretty',
+            options: {
+              colorize: true,
+              translateTime: 'HH:MM:ss Z',
+              ignore: 'pid,hostname',
+            },
+          }
+        : undefined,
+  });
+}

--- a/packages/api/src/lib/orpc.ts
+++ b/packages/api/src/lib/orpc.ts
@@ -1,6 +1,7 @@
 import { os } from '@orpc/server';
 
 import { AuthStrategy } from '@/auth/types.js';
+import type { Logger } from '@/lib/logger.js';
 
 export interface DbUser {
   id: string;
@@ -12,7 +13,7 @@ export interface DbUser {
  * `user` is populated by auth middleware when Telegram auth succeeds.
  */
 export interface BaseContext {
-  logger: typeof import('./logger.js').logger;
+  logger: Logger;
   headers: Record<string, string | string[] | undefined>;
   user?: DbUser;
   authStrategy?: AuthStrategy;

--- a/packages/api/src/lib/prisma.ts
+++ b/packages/api/src/lib/prisma.ts
@@ -1,53 +1,49 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { logger } from './logger.js';
+import type { Logger } from '@/lib/logger.js';
 
-import { env } from '@/config/env.js';
+/**
+ * Builds the Prisma client with API-specific connection settings.
+ */
+export function createPrisma(databaseUrl: string, logger: Logger): PrismaClient {
+  const prismaUrl = databaseUrl.includes('?')
+    ? `${databaseUrl}&pool_timeout=30&connect_timeout=10`
+    : `${databaseUrl}?pool_timeout=30&connect_timeout=10`;
 
-// Singleton pattern for Prisma client
-let prisma: PrismaClient | null = null;
-
-export function getPrisma(): PrismaClient {
-  if (!prisma) {
-    const databaseUrl = env.DATABASE_URL.includes('?')
-      ? `${env.DATABASE_URL}&pool_timeout=30&connect_timeout=10`
-      : `${env.DATABASE_URL}?pool_timeout=30&connect_timeout=10`;
-
-    prisma = new PrismaClient({
-      datasources: {
-        db: {
-          url: databaseUrl,
-        },
+  const prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: prismaUrl,
       },
-      log: [
-        {
-          emit: 'event',
-          level: 'error',
-        },
-        {
-          emit: 'event',
-          level: 'warn',
-        },
-      ],
-    });
+    },
+    log: [
+      {
+        emit: 'event',
+        level: 'error',
+      },
+      {
+        emit: 'event',
+        level: 'warn',
+      },
+    ],
+  });
 
-    // Log Prisma errors
-    prisma.$on('error' as never, (e: { message: string; target?: string }) => {
-      logger.error({ err: e }, 'Prisma error');
-    });
+  // Hooks Prisma events into the API logger so callers only configure logging once.
+  prisma.$on('error' as never, (event: { message: string; target?: string }) => {
+    logger.error({ err: event }, 'Prisma error');
+  });
 
-    prisma.$on('warn' as never, (e: { message: string; target?: string }) => {
-      logger.warn({ warn: e }, 'Prisma warning');
-    });
-  }
+  prisma.$on('warn' as never, (event: { message: string; target?: string }) => {
+    logger.warn({ warn: event }, 'Prisma warning');
+  });
 
   return prisma;
 }
 
-export async function disconnectPrisma() {
-  if (prisma) {
-    await prisma.$disconnect();
-    prisma = null;
-    logger.info('Prisma disconnected');
-  }
+/**
+ * Disconnects Prisma and logs the shutdown result.
+ */
+export async function disconnectPrisma(prisma: PrismaClient, logger: Logger) {
+  await prisma.$disconnect();
+  logger.info('Prisma disconnected');
 }

--- a/packages/api/src/lib/procedures.ts
+++ b/packages/api/src/lib/procedures.ts
@@ -1,6 +1,0 @@
-/**
- * Canonical entry point for all oRPC procedures.
- * Import procedures from here in router files.
- */
-export { publicProcedure } from './orpc.js';
-export { apiKeyProcedure, securedProcedure, telegramAuthProcedure } from '@/auth/middleware.js';

--- a/packages/api/src/routers/blocks/index.ts
+++ b/packages/api/src/routers/blocks/index.ts
@@ -1,5 +1,10 @@
-import { listBlockProposals } from './list.js';
+import { createListBlockProposalsRoute } from './list.js';
 
-export const blocksRouter = {
-  list: listBlockProposals,
-};
+/**
+ * Creates the blocks router.
+ */
+export function createBlocksRouter(params: Parameters<typeof createListBlockProposalsRoute>[0]) {
+  return {
+    list: createListBlockProposalsRoute(params),
+  };
+}

--- a/packages/api/src/routers/blocks/list.ts
+++ b/packages/api/src/routers/blocks/list.ts
@@ -1,57 +1,77 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { BlockProposalsInputSchema, BlockProposalsOutputSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { BlockStorage } from '@/storage/block.js';
-import { beaconTime } from '@/utils/beaconTime.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance, formatWeiToToken } from '@/utils/tokenFormat.js';
 
 const PAGE_SIZE = 10;
 
 /**
- * Get paginated block proposals for a cluster or validator
- * GET /blocks
+ * Creates the block proposals route.
  */
-export const listBlockProposals = securedProcedure
-  .route({ method: 'GET', path: '/blocks' })
-  .input(BlockProposalsInputSchema)
-  .output(ApiResponseSchema(BlockProposalsOutputSchema))
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BlockStorage();
-      const { rows, totalCount } = await storage.getBlockProposals({
-        clusterId: input.clusterId,
-        validatorIndex: input.validatorIndex,
-        page: input.page,
-        pageSize: PAGE_SIZE,
-      });
+export function createListBlockProposalsRoute(params: {
+  beaconHelpers: {
+    beaconTime: { getTimestampFromSlotNumber: (slot: number) => number };
+  };
+  blockStorage: {
+    getBlockProposals: (input: {
+      clusterId?: string;
+      page: number;
+      pageSize: number;
+      validatorIndex?: number;
+    }) => Promise<{ rows: any[]; totalCount: number }>;
+  };
+  chain: 'ethereum' | 'gnosis';
+  nativeTokenDecimals: number;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      const blocks = rows.map((row) => ({
-        slot: row.slot,
-        blockNumber: row.block_number,
-        validatorIndex: row.proposer_index,
-        timestamp: beaconTime.getTimestampFromSlotNumber(row.slot),
-        consensusReward: row.consensus_reward !== null ? formatBalance(row.consensus_reward) : null,
-        executionReward:
-          row.execution_reward !== null ? formatWeiToToken(row.execution_reward) : null,
-      }));
-
-      return {
-        success: true,
-        data: {
-          blocks,
-          totalCount,
+  return securedProcedure
+    .route({ method: 'GET', path: '/blocks' })
+    .input(BlockProposalsInputSchema)
+    .output(ApiResponseSchema(BlockProposalsOutputSchema))
+    .handler(async ({ input }: any) => {
+      try {
+        const { rows, totalCount } = await params.blockStorage.getBlockProposals({
+          clusterId: input.clusterId,
+          validatorIndex: input.validatorIndex,
           page: input.page,
           pageSize: PAGE_SIZE,
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to fetch block proposals';
-      return {
-        success: false,
-        error: { code: 'BLOCK_PROPOSALS_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+        });
+
+        return {
+          success: true,
+          data: {
+            blocks: rows.map((row) => ({
+              slot: row.slot,
+              blockNumber: row.block_number,
+              validatorIndex: row.proposer_index,
+              timestamp: params.beaconHelpers.beaconTime.getTimestampFromSlotNumber(row.slot),
+              consensusReward:
+                row.consensus_reward !== null
+                  ? formatBalance(row.consensus_reward, params.chain)
+                  : null,
+              executionReward:
+                row.execution_reward !== null
+                  ? formatWeiToToken(row.execution_reward, params.nativeTokenDecimals)
+                  : null,
+            })),
+            totalCount,
+            page: input.page,
+            pageSize: PAGE_SIZE,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'BLOCK_PROPOSALS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to fetch block proposals',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+    });
+}

--- a/packages/api/src/routers/blocks/list.ts
+++ b/packages/api/src/routers/blocks/list.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { BlockProposalsInputSchema, BlockProposalsOutputSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance, formatWeiToToken } from '@/utils/tokenFormat.js';
 
@@ -23,7 +24,7 @@ export function createListBlockProposalsRoute(params: {
   };
   chain: 'ethereum' | 'gnosis';
   nativeTokenDecimals: number;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/bot/communications.ts
+++ b/packages/api/src/routers/bot/communications.ts
@@ -2,6 +2,7 @@
 import { ORPCError } from '@orpc/server';
 import { z } from 'zod';
 
+import type { ApiDependencies } from '@/dependencies.js';
 import { createBotProcedure } from '@/routers/bot/procedures.js';
 import {
   BotCommunicationDetailsSchema,
@@ -50,10 +51,9 @@ function mapCommunication(communication: {
 /**
  * Creates the bot communications routes.
  */
-export function createBotCommunicationsRoutes(params: {
-  botCommunicationsStorage: any;
-  procedures: any;
-}) {
+export function createBotCommunicationsRoutes(
+  params: Pick<ApiDependencies, 'botCommunicationsStorage' | 'procedures'>,
+) {
   const botProcedure = createBotProcedure(params.procedures);
   const { apiKeyProcedure } = params.procedures;
 

--- a/packages/api/src/routers/bot/communications.ts
+++ b/packages/api/src/routers/bot/communications.ts
@@ -1,8 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ORPCError } from '@orpc/server';
 import { z } from 'zod';
 
-import { apiKeyProcedure } from '@/lib/procedures.js';
-import { botProcedure } from '@/routers/bot/procedures.js';
+import { createBotProcedure } from '@/routers/bot/procedures.js';
 import {
   BotCommunicationDetailsSchema,
   BotCommunicationSchema,
@@ -11,7 +11,6 @@ import {
   CreateBotCommunicationSchema,
 } from '@/routers/bot/schemas.js';
 import { resolveCommunicationRecipients } from '@/storage/bot-communication-recipients.js';
-import { BotCommunicationsStorage } from '@/storage/bot-communications.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
 const BotCommunicationResponseSchema = ApiResponseSchema(BotCommunicationSchema);
@@ -49,90 +48,92 @@ function mapCommunication(communication: {
 }
 
 /**
- * Creates a new pending communication through API key authentication.
- * POST /bot/communications
+ * Creates the bot communications routes.
  */
-export const createBotCommunication = apiKeyProcedure
-  .route({ method: 'POST', path: '/bot/communications' })
-  .input(CreateBotCommunicationSchema)
-  .output(BotCommunicationResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotCommunicationsStorage();
-      const communication = await storage.create(input);
+export function createBotCommunicationsRoutes(params: {
+  botCommunicationsStorage: any;
+  procedures: any;
+}) {
+  const botProcedure = createBotProcedure(params.procedures);
+  const { apiKeyProcedure } = params.procedures;
 
-      return successResponse(mapCommunication(communication)) as BotCommunicationResponse;
-    } catch (error) {
-      return errorResponse(
-        'CREATE_COMMUNICATION_ERROR',
-        error instanceof Error ? error.message : 'Failed to create communication',
-      ) as BotCommunicationResponse;
-    }
-  });
-
-/**
- * Returns one communication plus the users that should receive it.
- * GET /bot/communications/{id}
- */
-export const getBotCommunication = botProcedure
-  .route({ method: 'GET', path: '/bot/communications/{id}' })
-  .input(CommunicationIdParamSchema)
-  .output(BotCommunicationDetailsResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotCommunicationsStorage();
-      const communication = await storage.findById(input.id);
-
-      if (!communication) {
-        throw new ORPCError('NOT_FOUND', {
-          message: `Communication ${input.id} was not found`,
-        });
+  const createBotCommunication = apiKeyProcedure
+    .route({ method: 'POST', path: '/bot/communications' })
+    .input(CreateBotCommunicationSchema)
+    .output(BotCommunicationResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        return successResponse(
+          mapCommunication(await params.botCommunicationsStorage.create(input)),
+        ) as BotCommunicationResponse;
+      } catch (error) {
+        return errorResponse(
+          'CREATE_COMMUNICATION_ERROR',
+          error instanceof Error ? error.message : 'Failed to create communication',
+        ) as BotCommunicationResponse;
       }
+    });
 
-      // Load broadcast recipients only when the communication does not target explicit telegram ids.
-      const broadcastTelegramIds =
-        communication.onlyTo.length > 0 ? [] : await storage.listBroadcastTelegramIds();
-      const recipients = resolveCommunicationRecipients(broadcastTelegramIds, communication);
+  const getBotCommunication = botProcedure
+    .route({ method: 'GET', path: '/bot/communications/{id}' })
+    .input(CommunicationIdParamSchema)
+    .output(BotCommunicationDetailsResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const communication = await params.botCommunicationsStorage.findById(input.id);
 
-      return successResponse({
-        ...mapCommunication(communication),
-        recipients,
-      }) as BotCommunicationDetailsResponse;
-    } catch (error) {
-      return errorResponse(
-        'GET_COMMUNICATION_ERROR',
-        error instanceof Error ? error.message : 'Failed to get communication',
-      ) as BotCommunicationDetailsResponse;
-    }
-  });
+        if (!communication) {
+          throw new ORPCError('NOT_FOUND', {
+            message: `Communication ${input.id} was not found`,
+          });
+        }
 
-/**
- * Marks a communication as sent after the bot finishes delivery attempts.
- * PUT /bot/communications/{id}/sent
- */
-export const markBotCommunicationSent = botProcedure
-  .route({ method: 'PUT', path: '/bot/communications/{id}/sent' })
-  .input(CommunicationIdParamSchema)
-  .output(BotCommunicationSentResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotCommunicationsStorage();
-      const updated = await storage.markSent(input.id);
+        const broadcastTelegramIds =
+          communication.onlyTo.length > 0
+            ? []
+            : await params.botCommunicationsStorage.listBroadcastTelegramIds();
 
-      if (!updated) {
-        throw new ORPCError('CONFLICT', {
-          message: `Communication ${input.id} was already sent`,
-        });
+        return successResponse({
+          ...mapCommunication(communication),
+          recipients: resolveCommunicationRecipients(broadcastTelegramIds, communication),
+        }) as BotCommunicationDetailsResponse;
+      } catch (error) {
+        return errorResponse(
+          'GET_COMMUNICATION_ERROR',
+          error instanceof Error ? error.message : 'Failed to get communication',
+        ) as BotCommunicationDetailsResponse;
       }
+    });
 
-      return successResponse({
-        id: input.id,
-        sent: true,
-      }) as BotCommunicationSentResponse;
-    } catch (error) {
-      return errorResponse(
-        'MARK_COMMUNICATION_SENT_ERROR',
-        error instanceof Error ? error.message : 'Failed to mark communication as sent',
-      ) as BotCommunicationSentResponse;
-    }
-  });
+  const markBotCommunicationSent = botProcedure
+    .route({ method: 'PUT', path: '/bot/communications/{id}/sent' })
+    .input(CommunicationIdParamSchema)
+    .output(BotCommunicationSentResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const updated = await params.botCommunicationsStorage.markSent(input.id);
+
+        if (!updated) {
+          throw new ORPCError('CONFLICT', {
+            message: `Communication ${input.id} was already sent`,
+          });
+        }
+
+        return successResponse({
+          id: input.id,
+          sent: true,
+        }) as BotCommunicationSentResponse;
+      } catch (error) {
+        return errorResponse(
+          'MARK_COMMUNICATION_SENT_ERROR',
+          error instanceof Error ? error.message : 'Failed to mark communication as sent',
+        ) as BotCommunicationSentResponse;
+      }
+    });
+
+  return {
+    createBotCommunication,
+    getBotCommunication,
+    markBotCommunicationSent,
+  };
+}

--- a/packages/api/src/routers/bot/incident-notifications.ts
+++ b/packages/api/src/routers/bot/incident-notifications.ts
@@ -1,6 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
-import { botProcedure } from './procedures.js';
 import {
   BotIncidentNotificationListSchema,
   BotNotificationDeliveredSchema,
@@ -8,7 +8,7 @@ import {
   IncidentNotificationIdParamSchema,
 } from './schemas.js';
 
-import { BotIncidentNotificationsStorage } from '@/storage/bot-incident-notifications.js';
+import { createBotProcedure } from '@/routers/bot/procedures.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
 const BotIncidentNotificationListResponseSchema = ApiResponseSchema(
@@ -26,82 +26,83 @@ type BotIncidentNotificationDeliveredResponse = z.infer<
 >;
 
 /**
- * List pending incident notifications.
- * GET /bot/incident-notifications
+ * Creates the bot incident notification routes.
  */
-export const listBotIncidentNotifications = botProcedure
-  .route({ method: 'GET', path: '/bot/incident-notifications' })
-  .input(BotNotificationListInputSchema)
-  .output(BotIncidentNotificationListResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotIncidentNotificationsStorage();
-      const notifications = await storage.listPending(input.limit);
+export function createBotIncidentNotificationRoutes(params: {
+  botIncidentNotificationsStorage: any;
+  procedures: any;
+}) {
+  const botProcedure = createBotProcedure(params.procedures);
 
-      return successResponse(
-        notifications.map((notification) => ({
-          id: notification.id,
-          userId: notification.userId,
-          telegramId: notification.user.telegramId.toString(),
-          type: notification.type,
-          payload: notification.payload,
-          createdAt: notification.createdAt.toISOString(),
-        })),
-      ) as BotIncidentNotificationListResponse;
-    } catch (error) {
-      return errorResponse(
-        'LIST_INCIDENT_NOTIFICATIONS_ERROR',
-        error instanceof Error ? error.message : 'Failed to list incident notifications',
-      ) as BotIncidentNotificationListResponse;
-    }
-  });
+  const listBotIncidentNotifications = botProcedure
+    .route({ method: 'GET', path: '/bot/incident-notifications' })
+    .input(BotNotificationListInputSchema)
+    .output(BotIncidentNotificationListResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const notifications = await params.botIncidentNotificationsStorage.listPending(input.limit);
 
-/**
- * Mark an open incident notification as sent.
- * PUT /bot/incident-notifications/{incidentId}/opened
- */
-export const markBotIncidentOpenedNotified = botProcedure
-  .route({ method: 'PUT', path: '/bot/incident-notifications/{incidentId}/opened' })
-  .input(IncidentNotificationIdParamSchema)
-  .output(BotIncidentNotificationDeliveredResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotIncidentNotificationsStorage();
-      await storage.markOpenedNotified(input.incidentId);
+        return successResponse(
+          notifications.map((notification: any) => ({
+            id: notification.id,
+            userId: notification.userId,
+            telegramId: notification.user.telegramId.toString(),
+            type: notification.type,
+            payload: notification.payload,
+            createdAt: notification.createdAt.toISOString(),
+          })),
+        ) as BotIncidentNotificationListResponse;
+      } catch (error) {
+        return errorResponse(
+          'LIST_INCIDENT_NOTIFICATIONS_ERROR',
+          error instanceof Error ? error.message : 'Failed to list incident notifications',
+        ) as BotIncidentNotificationListResponse;
+      }
+    });
 
-      return successResponse({
-        id: input.incidentId,
-        delivered: true,
-      }) as BotIncidentNotificationDeliveredResponse;
-    } catch (error) {
-      return errorResponse(
-        'MARK_INCIDENT_OPENED_NOTIFIED_ERROR',
-        error instanceof Error ? error.message : 'Failed to mark open incident notification',
-      ) as BotIncidentNotificationDeliveredResponse;
-    }
-  });
+  const markBotIncidentOpenedNotified = botProcedure
+    .route({ method: 'PUT', path: '/bot/incident-notifications/{incidentId}/opened' })
+    .input(IncidentNotificationIdParamSchema)
+    .output(BotIncidentNotificationDeliveredResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        await params.botIncidentNotificationsStorage.markOpenedNotified(input.incidentId);
 
-/**
- * Mark a closed incident notification as sent.
- * PUT /bot/incident-notifications/{incidentId}/closed
- */
-export const markBotIncidentClosedNotified = botProcedure
-  .route({ method: 'PUT', path: '/bot/incident-notifications/{incidentId}/closed' })
-  .input(IncidentNotificationIdParamSchema)
-  .output(BotIncidentNotificationDeliveredResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotIncidentNotificationsStorage();
-      await storage.markClosedNotified(input.incidentId);
+        return successResponse({
+          id: input.incidentId,
+          delivered: true,
+        }) as BotIncidentNotificationDeliveredResponse;
+      } catch (error) {
+        return errorResponse(
+          'MARK_INCIDENT_OPENED_NOTIFIED_ERROR',
+          error instanceof Error ? error.message : 'Failed to mark open incident notification',
+        ) as BotIncidentNotificationDeliveredResponse;
+      }
+    });
 
-      return successResponse({
-        id: input.incidentId,
-        delivered: true,
-      }) as BotIncidentNotificationDeliveredResponse;
-    } catch (error) {
-      return errorResponse(
-        'MARK_INCIDENT_CLOSED_NOTIFIED_ERROR',
-        error instanceof Error ? error.message : 'Failed to mark closed incident notification',
-      ) as BotIncidentNotificationDeliveredResponse;
-    }
-  });
+  const markBotIncidentClosedNotified = botProcedure
+    .route({ method: 'PUT', path: '/bot/incident-notifications/{incidentId}/closed' })
+    .input(IncidentNotificationIdParamSchema)
+    .output(BotIncidentNotificationDeliveredResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        await params.botIncidentNotificationsStorage.markClosedNotified(input.incidentId);
+
+        return successResponse({
+          id: input.incidentId,
+          delivered: true,
+        }) as BotIncidentNotificationDeliveredResponse;
+      } catch (error) {
+        return errorResponse(
+          'MARK_INCIDENT_CLOSED_NOTIFIED_ERROR',
+          error instanceof Error ? error.message : 'Failed to mark closed incident notification',
+        ) as BotIncidentNotificationDeliveredResponse;
+      }
+    });
+
+  return {
+    listBotIncidentNotifications,
+    markBotIncidentClosedNotified,
+    markBotIncidentOpenedNotified,
+  };
+}

--- a/packages/api/src/routers/bot/incident-notifications.ts
+++ b/packages/api/src/routers/bot/incident-notifications.ts
@@ -8,6 +8,7 @@ import {
   IncidentNotificationIdParamSchema,
 } from './schemas.js';
 
+import type { ApiDependencies } from '@/dependencies.js';
 import { createBotProcedure } from '@/routers/bot/procedures.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
@@ -30,7 +31,7 @@ type BotIncidentNotificationDeliveredResponse = z.infer<
  */
 export function createBotIncidentNotificationRoutes(params: {
   botIncidentNotificationsStorage: any;
-  procedures: any;
+  procedures: ApiDependencies['procedures'];
 }) {
   const botProcedure = createBotProcedure(params.procedures);
 

--- a/packages/api/src/routers/bot/incident-notifications.ts
+++ b/packages/api/src/routers/bot/incident-notifications.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import {
@@ -30,7 +29,7 @@ type BotIncidentNotificationDeliveredResponse = z.infer<
  * Creates the bot incident notification routes.
  */
 export function createBotIncidentNotificationRoutes(params: {
-  botIncidentNotificationsStorage: any;
+  botIncidentNotificationsStorage: ApiDependencies['botIncidentNotificationsStorage'];
   procedures: ApiDependencies['procedures'];
 }) {
   const botProcedure = createBotProcedure(params.procedures);
@@ -39,12 +38,12 @@ export function createBotIncidentNotificationRoutes(params: {
     .route({ method: 'GET', path: '/bot/incident-notifications' })
     .input(BotNotificationListInputSchema)
     .output(BotIncidentNotificationListResponseSchema)
-    .handler(async ({ input }: any) => {
+    .handler(async ({ input }) => {
       try {
         const notifications = await params.botIncidentNotificationsStorage.listPending(input.limit);
 
         return successResponse(
-          notifications.map((notification: any) => ({
+          notifications.map((notification) => ({
             id: notification.id,
             userId: notification.userId,
             telegramId: notification.user.telegramId.toString(),
@@ -65,7 +64,7 @@ export function createBotIncidentNotificationRoutes(params: {
     .route({ method: 'PUT', path: '/bot/incident-notifications/{incidentId}/opened' })
     .input(IncidentNotificationIdParamSchema)
     .output(BotIncidentNotificationDeliveredResponseSchema)
-    .handler(async ({ input }: any) => {
+    .handler(async ({ input }) => {
       try {
         await params.botIncidentNotificationsStorage.markOpenedNotified(input.incidentId);
 
@@ -85,7 +84,7 @@ export function createBotIncidentNotificationRoutes(params: {
     .route({ method: 'PUT', path: '/bot/incident-notifications/{incidentId}/closed' })
     .input(IncidentNotificationIdParamSchema)
     .output(BotIncidentNotificationDeliveredResponseSchema)
-    .handler(async ({ input }: any) => {
+    .handler(async ({ input }) => {
       try {
         await params.botIncidentNotificationsStorage.markClosedNotified(input.incidentId);
 

--- a/packages/api/src/routers/bot/index.ts
+++ b/packages/api/src/routers/bot/index.ts
@@ -1,37 +1,40 @@
-import {
-  createBotCommunication,
-  getBotCommunication,
-  markBotCommunicationSent,
-} from './communications.js';
-import {
-  listBotIncidentNotifications,
-  markBotIncidentClosedNotified,
-  markBotIncidentOpenedNotified,
-} from './incident-notifications.js';
-import {
-  deleteBotNotification,
-  listBotNotifications,
-  markBotNotificationDelivered,
-} from './notifications.js';
-import {
-  listBotUsers,
-  setBotUserBlocked,
-  setBotUserUnblocked,
-  updateBotUserMessageId,
-} from './users.js';
+import { createBotCommunicationsRoutes } from './communications.js';
+import { createBotIncidentNotificationRoutes } from './incident-notifications.js';
+import { createBotNotificationRoutes } from './notifications.js';
+import { createBotUsersRoutes } from './users.js';
+import type { ApiDependencies } from '@/dependencies.js';
 
-export const botRouter = {
-  createCommunication: createBotCommunication,
-  deleteNotification: deleteBotNotification,
-  getCommunication: getBotCommunication,
-  incidentNotifications: listBotIncidentNotifications,
-  notifications: listBotNotifications,
-  setIncidentClosedNotified: markBotIncidentClosedNotified,
-  setIncidentOpenedNotified: markBotIncidentOpenedNotified,
-  markCommunicationSent: markBotCommunicationSent,
-  setNotificationDelivered: markBotNotificationDelivered,
-  users: listBotUsers,
-  updateMessageId: updateBotUserMessageId,
-  setBlocked: setBotUserBlocked,
-  setUnblocked: setBotUserUnblocked,
-};
+/**
+ * Creates the bot router.
+ */
+export function createBotRouter(
+  deps: Pick<
+    ApiDependencies,
+    | 'botCommunicationsStorage'
+    | 'botIncidentNotificationsStorage'
+    | 'botNotificationsStorage'
+    | 'botUsersStorage'
+    | 'procedures'
+  >,
+) {
+  const communications = createBotCommunicationsRoutes(deps);
+  const incidentNotifications = createBotIncidentNotificationRoutes(deps);
+  const notifications = createBotNotificationRoutes(deps);
+  const users = createBotUsersRoutes(deps);
+
+  return {
+    createCommunication: communications.createBotCommunication,
+    deleteNotification: notifications.deleteBotNotification,
+    getCommunication: communications.getBotCommunication,
+    incidentNotifications: incidentNotifications.listBotIncidentNotifications,
+    notifications: notifications.listBotNotifications,
+    setIncidentClosedNotified: incidentNotifications.markBotIncidentClosedNotified,
+    setIncidentOpenedNotified: incidentNotifications.markBotIncidentOpenedNotified,
+    markCommunicationSent: communications.markBotCommunicationSent,
+    setNotificationDelivered: notifications.markBotNotificationDelivered,
+    users: users.listBotUsers,
+    updateMessageId: users.updateBotUserMessageId,
+    setBlocked: users.setBotUserBlocked,
+    setUnblocked: users.setBotUserUnblocked,
+  };
+}

--- a/packages/api/src/routers/bot/notifications.ts
+++ b/packages/api/src/routers/bot/notifications.ts
@@ -1,6 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
-import { botProcedure } from './procedures.js';
 import {
   BotNotificationDeletedSchema,
   BotNotificationDeliveredSchema,
@@ -9,7 +9,7 @@ import {
   NotificationIdParamSchema,
 } from './schemas.js';
 
-import { BotNotificationsStorage } from '@/storage/bot-notifications.js';
+import { createBotProcedure } from '@/routers/bot/procedures.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
 const BotNotificationListResponseSchema = ApiResponseSchema(BotNotificationListSchema);
@@ -22,82 +22,83 @@ const BotNotificationDeletedResponseSchema = ApiResponseSchema(BotNotificationDe
 type BotNotificationDeletedResponse = z.infer<typeof BotNotificationDeletedResponseSchema>;
 
 /**
- * List pending bot notifications.
- * GET /bot/notifications
+ * Creates the bot notification routes.
  */
-export const listBotNotifications = botProcedure
-  .route({ method: 'GET', path: '/bot/notifications' })
-  .input(BotNotificationListInputSchema)
-  .output(BotNotificationListResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotNotificationsStorage();
-      const notifications = await storage.listPending(input.limit);
+export function createBotNotificationRoutes(params: {
+  botNotificationsStorage: any;
+  procedures: any;
+}) {
+  const botProcedure = createBotProcedure(params.procedures);
 
-      return successResponse(
-        notifications.map((notification) => ({
-          id: notification.id,
-          userId: notification.userId,
-          telegramId: notification.user.telegramId!.toString(),
-          type: notification.type,
-          payload: notification.payload,
-          createdAt: notification.createdAt.toISOString(),
-        })),
-      ) as BotNotificationListResponse;
-    } catch (error) {
-      return errorResponse(
-        'LIST_NOTIFICATIONS_ERROR',
-        error instanceof Error ? error.message : 'Failed to list bot notifications',
-      ) as BotNotificationListResponse;
-    }
-  });
+  const listBotNotifications = botProcedure
+    .route({ method: 'GET', path: '/bot/notifications' })
+    .input(BotNotificationListInputSchema)
+    .output(BotNotificationListResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const notifications = await params.botNotificationsStorage.listPending(input.limit);
 
-/**
- * Mark a bot notification as delivered.
- * PUT /bot/notifications/{id}/delivered
- */
-export const markBotNotificationDelivered = botProcedure
-  .route({ method: 'PUT', path: '/bot/notifications/{id}/delivered' })
-  .input(NotificationIdParamSchema)
-  .output(BotNotificationDeliveredResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotNotificationsStorage();
-      await storage.markDelivered(input.id);
+        return successResponse(
+          notifications.map((notification: any) => ({
+            id: notification.id,
+            userId: notification.userId,
+            telegramId: notification.user.telegramId!.toString(),
+            type: notification.type,
+            payload: notification.payload,
+            createdAt: notification.createdAt.toISOString(),
+          })),
+        ) as BotNotificationListResponse;
+      } catch (error) {
+        return errorResponse(
+          'LIST_NOTIFICATIONS_ERROR',
+          error instanceof Error ? error.message : 'Failed to list bot notifications',
+        ) as BotNotificationListResponse;
+      }
+    });
 
-      return successResponse({
-        id: input.id,
-        delivered: true,
-      }) as BotNotificationDeliveredResponse;
-    } catch (error) {
-      return errorResponse(
-        'MARK_NOTIFICATION_DELIVERED_ERROR',
-        error instanceof Error ? error.message : 'Failed to mark notification as delivered',
-      ) as BotNotificationDeliveredResponse;
-    }
-  });
+  const markBotNotificationDelivered = botProcedure
+    .route({ method: 'PUT', path: '/bot/notifications/{id}/delivered' })
+    .input(NotificationIdParamSchema)
+    .output(BotNotificationDeliveredResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        await params.botNotificationsStorage.markDelivered(input.id);
 
-/**
- * Delete a bot notification.
- * DELETE /bot/notifications/{id}
- */
-export const deleteBotNotification = botProcedure
-  .route({ method: 'DELETE', path: '/bot/notifications/{id}' })
-  .input(NotificationIdParamSchema)
-  .output(BotNotificationDeletedResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotNotificationsStorage();
-      await storage.delete(input.id);
+        return successResponse({
+          id: input.id,
+          delivered: true,
+        }) as BotNotificationDeliveredResponse;
+      } catch (error) {
+        return errorResponse(
+          'MARK_NOTIFICATION_DELIVERED_ERROR',
+          error instanceof Error ? error.message : 'Failed to mark notification as delivered',
+        ) as BotNotificationDeliveredResponse;
+      }
+    });
 
-      return successResponse({
-        id: input.id,
-        deleted: true,
-      }) as BotNotificationDeletedResponse;
-    } catch (error) {
-      return errorResponse(
-        'DELETE_NOTIFICATION_ERROR',
-        error instanceof Error ? error.message : 'Failed to delete bot notification',
-      ) as BotNotificationDeletedResponse;
-    }
-  });
+  const deleteBotNotification = botProcedure
+    .route({ method: 'DELETE', path: '/bot/notifications/{id}' })
+    .input(NotificationIdParamSchema)
+    .output(BotNotificationDeletedResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        await params.botNotificationsStorage.delete(input.id);
+
+        return successResponse({
+          id: input.id,
+          deleted: true,
+        }) as BotNotificationDeletedResponse;
+      } catch (error) {
+        return errorResponse(
+          'DELETE_NOTIFICATION_ERROR',
+          error instanceof Error ? error.message : 'Failed to delete bot notification',
+        ) as BotNotificationDeletedResponse;
+      }
+    });
+
+  return {
+    deleteBotNotification,
+    listBotNotifications,
+    markBotNotificationDelivered,
+  };
+}

--- a/packages/api/src/routers/bot/notifications.ts
+++ b/packages/api/src/routers/bot/notifications.ts
@@ -9,6 +9,7 @@ import {
   NotificationIdParamSchema,
 } from './schemas.js';
 
+import type { ApiDependencies } from '@/dependencies.js';
 import { createBotProcedure } from '@/routers/bot/procedures.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
@@ -26,7 +27,7 @@ type BotNotificationDeletedResponse = z.infer<typeof BotNotificationDeletedRespo
  */
 export function createBotNotificationRoutes(params: {
   botNotificationsStorage: any;
-  procedures: any;
+  procedures: ApiDependencies['procedures'];
 }) {
   const botProcedure = createBotProcedure(params.procedures);
 

--- a/packages/api/src/routers/bot/procedures.ts
+++ b/packages/api/src/routers/bot/procedures.ts
@@ -1,20 +1,8 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ORPCError } from '@orpc/server';
-
 import type { ApiProcedures } from '@/auth/middleware.js';
-import { AuthStrategy } from '@/auth/types.js';
 
 /**
- * Builds the bot-specific secured procedure.
+ * Builds the bot-specific public procedure.
  */
 export function createBotProcedure(procedures: ApiProcedures) {
-  return procedures.securedProcedure.use(async ({ context, next }: any) => {
-    if (context.authStrategy !== AuthStrategy.BOT_SIGNATURE) {
-      throw new ORPCError('FORBIDDEN', {
-        message: 'This endpoint requires bot-signature authentication',
-      });
-    }
-
-    return next({ context });
-  });
+  return procedures.publicProcedure;
 }

--- a/packages/api/src/routers/bot/procedures.ts
+++ b/packages/api/src/routers/bot/procedures.ts
@@ -1,14 +1,20 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ORPCError } from '@orpc/server';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { AuthStrategy } from '@/auth/types.js';
-import { securedProcedure } from '@/lib/procedures.js';
 
-export const botProcedure = securedProcedure.use(async ({ context, next }) => {
-  if (context.authStrategy !== AuthStrategy.BOT_SIGNATURE) {
-    throw new ORPCError('FORBIDDEN', {
-      message: 'This endpoint requires bot-signature authentication',
-    });
-  }
+/**
+ * Builds the bot-specific secured procedure.
+ */
+export function createBotProcedure(procedures: ApiProcedures) {
+  return procedures.securedProcedure.use(async ({ context, next }: any) => {
+    if (context.authStrategy !== AuthStrategy.BOT_SIGNATURE) {
+      throw new ORPCError('FORBIDDEN', {
+        message: 'This endpoint requires bot-signature authentication',
+      });
+    }
 
-  return next({ context });
-});
+    return next({ context });
+  });
+}

--- a/packages/api/src/routers/bot/users.ts
+++ b/packages/api/src/routers/bot/users.ts
@@ -1,6 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
-import { botProcedure } from './procedures.js';
 import {
   BotUserListSchema,
   BotUserSchema,
@@ -8,7 +8,7 @@ import {
   UpdateMessageIdSchema,
 } from './schemas.js';
 
-import { BotUsersStorage } from '@/storage/bot-users.js';
+import { createBotProcedure } from '@/routers/bot/procedures.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
 const BotUserListResponseSchema = ApiResponseSchema(BotUserListSchema);
@@ -18,110 +18,105 @@ const BotUserResponseSchema = ApiResponseSchema(BotUserSchema);
 type BotUserResponse = z.infer<typeof BotUserResponseSchema>;
 
 /**
- * List all notifiable bot users — users with a telegramId, not blocked, and having validators.
- * GET /bot/users
+ * Creates the bot users routes.
  */
-export const listBotUsers = botProcedure
-  .route({ method: 'GET', path: '/bot/users' })
-  .output(BotUserListResponseSchema)
-  .handler(async () => {
-    try {
-      const storage = new BotUsersStorage();
-      const users = await storage.listNotifiableUsers();
+export function createBotUsersRoutes(params: { botUsersStorage: any; procedures: any }) {
+  const botProcedure = createBotProcedure(params.procedures);
 
-      const mapped = users.map((u) => ({
-        id: u.id,
-        telegramId: u.telegramId!.toString(),
-        username: u.username,
-        messageId: u.messageId?.toString() ?? null,
-      }));
+  const listBotUsers = botProcedure
+    .route({ method: 'GET', path: '/bot/users' })
+    .output(BotUserListResponseSchema)
+    .handler(async () => {
+      try {
+        return successResponse(
+          (await params.botUsersStorage.listNotifiableUsers()).map((user: any) => ({
+            id: user.id,
+            telegramId: user.telegramId!.toString(),
+            username: user.username,
+            messageId: user.messageId?.toString() ?? null,
+          })),
+        ) as BotUserListResponse;
+      } catch (error) {
+        return errorResponse(
+          'LIST_USERS_ERROR',
+          error instanceof Error ? error.message : 'Failed to list bot users',
+        ) as BotUserListResponse;
+      }
+    });
 
-      return successResponse(mapped) as BotUserListResponse;
-    } catch (error) {
-      return errorResponse(
-        'LIST_USERS_ERROR',
-        error instanceof Error ? error.message : 'Failed to list bot users',
-      ) as BotUserListResponse;
-    }
-  });
+  const updateBotUserMessageId = botProcedure
+    .route({ method: 'PUT', path: '/bot/users/{telegramId}/message-id' })
+    .input(UpdateMessageIdSchema)
+    .output(BotUserResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const user = await params.botUsersStorage.updateMessageId(
+          BigInt(input.telegramId),
+          input.messageId,
+        );
 
-/**
- * Update the pinned message ID for a bot user.
- * PUT /bot/users/{telegramId}/message-id
- */
-export const updateBotUserMessageId = botProcedure
-  .route({ method: 'PUT', path: '/bot/users/{telegramId}/message-id' })
-  .input(UpdateMessageIdSchema)
-  .output(BotUserResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotUsersStorage();
-      const user = await storage.updateMessageId(BigInt(input.telegramId), input.messageId);
+        return successResponse({
+          id: user.id,
+          telegramId: input.telegramId,
+          username: user.username,
+          messageId: input.messageId ? input.messageId.toString() : null,
+        }) as BotUserResponse;
+      } catch (error) {
+        return errorResponse(
+          'UPDATE_MESSAGE_ID_ERROR',
+          error instanceof Error ? error.message : 'Failed to update message ID',
+        ) as BotUserResponse;
+      }
+    });
 
-      return successResponse({
-        id: user.id,
-        telegramId: input.telegramId,
-        username: user.username,
-        messageId: input.messageId ? input.messageId.toString() : null,
-      }) as BotUserResponse;
-    } catch (error) {
-      return errorResponse(
-        'UPDATE_MESSAGE_ID_ERROR',
-        error instanceof Error ? error.message : 'Failed to update message ID',
-      ) as BotUserResponse;
-    }
-  });
+  const setBotUserBlocked = botProcedure
+    .route({ method: 'PUT', path: '/bot/users/{telegramId}/blocked' })
+    .input(TelegramIdParamSchema)
+    .output(BotUserResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const user = await params.botUsersStorage.setBlocked(BigInt(input.telegramId));
 
-/**
- * Mark a bot user as blocked (they blocked the bot on Telegram).
- * PUT /bot/users/{telegramId}/blocked
- */
-export const setBotUserBlocked = botProcedure
-  .route({ method: 'PUT', path: '/bot/users/{telegramId}/blocked' })
-  .input(TelegramIdParamSchema)
-  .output(BotUserResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotUsersStorage();
-      const user = await storage.setBlocked(BigInt(input.telegramId));
+        return successResponse({
+          id: user.id,
+          telegramId: input.telegramId,
+          username: user.username,
+          messageId: user.messageId?.toString() ?? null,
+        }) as BotUserResponse;
+      } catch (error) {
+        return errorResponse(
+          'SET_BLOCKED_ERROR',
+          error instanceof Error ? error.message : 'Failed to set user as blocked',
+        ) as BotUserResponse;
+      }
+    });
 
-      return successResponse({
-        id: user.id,
-        telegramId: input.telegramId,
-        username: user.username,
-        messageId: user.messageId?.toString() ?? null,
-      }) as BotUserResponse;
-    } catch (error) {
-      return errorResponse(
-        'SET_BLOCKED_ERROR',
-        error instanceof Error ? error.message : 'Failed to set user as blocked',
-      ) as BotUserResponse;
-    }
-  });
+  const setBotUserUnblocked = botProcedure
+    .route({ method: 'PUT', path: '/bot/users/{telegramId}/unblocked' })
+    .input(TelegramIdParamSchema)
+    .output(BotUserResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const user = await params.botUsersStorage.setUnblocked(BigInt(input.telegramId));
 
-/**
- * Mark a bot user as unblocked.
- * PUT /bot/users/{telegramId}/unblocked
- */
-export const setBotUserUnblocked = botProcedure
-  .route({ method: 'PUT', path: '/bot/users/{telegramId}/unblocked' })
-  .input(TelegramIdParamSchema)
-  .output(BotUserResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      const storage = new BotUsersStorage();
-      const user = await storage.setUnblocked(BigInt(input.telegramId));
+        return successResponse({
+          id: user.id,
+          telegramId: input.telegramId,
+          username: user.username,
+          messageId: user.messageId?.toString() ?? null,
+        }) as BotUserResponse;
+      } catch (error) {
+        return errorResponse(
+          'SET_UNBLOCKED_ERROR',
+          error instanceof Error ? error.message : 'Failed to set user as unblocked',
+        ) as BotUserResponse;
+      }
+    });
 
-      return successResponse({
-        id: user.id,
-        telegramId: input.telegramId,
-        username: user.username,
-        messageId: user.messageId?.toString() ?? null,
-      }) as BotUserResponse;
-    } catch (error) {
-      return errorResponse(
-        'SET_UNBLOCKED_ERROR',
-        error instanceof Error ? error.message : 'Failed to set user as unblocked',
-      ) as BotUserResponse;
-    }
-  });
+  return {
+    listBotUsers,
+    setBotUserBlocked,
+    setBotUserUnblocked,
+    updateBotUserMessageId,
+  };
+}

--- a/packages/api/src/routers/bot/users.ts
+++ b/packages/api/src/routers/bot/users.ts
@@ -8,6 +8,7 @@ import {
   UpdateMessageIdSchema,
 } from './schemas.js';
 
+import type { ApiDependencies } from '@/dependencies.js';
 import { createBotProcedure } from '@/routers/bot/procedures.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
@@ -20,7 +21,9 @@ type BotUserResponse = z.infer<typeof BotUserResponseSchema>;
 /**
  * Creates the bot users routes.
  */
-export function createBotUsersRoutes(params: { botUsersStorage: any; procedures: any }) {
+export function createBotUsersRoutes(
+  params: Pick<ApiDependencies, 'botUsersStorage' | 'procedures'>,
+) {
   const botProcedure = createBotProcedure(params.procedures);
 
   const listBotUsers = botProcedure

--- a/packages/api/src/routers/bot/users.ts
+++ b/packages/api/src/routers/bot/users.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import {
@@ -32,7 +31,7 @@ export function createBotUsersRoutes(
     .handler(async () => {
       try {
         return successResponse(
-          (await params.botUsersStorage.listNotifiableUsers()).map((user: any) => ({
+          (await params.botUsersStorage.listNotifiableUsers()).map((user) => ({
             id: user.id,
             telegramId: user.telegramId!.toString(),
             username: user.username,
@@ -51,7 +50,7 @@ export function createBotUsersRoutes(
     .route({ method: 'PUT', path: '/bot/users/{telegramId}/message-id' })
     .input(UpdateMessageIdSchema)
     .output(BotUserResponseSchema)
-    .handler(async ({ input }: any) => {
+    .handler(async ({ input }) => {
       try {
         const user = await params.botUsersStorage.updateMessageId(
           BigInt(input.telegramId),
@@ -76,7 +75,7 @@ export function createBotUsersRoutes(
     .route({ method: 'PUT', path: '/bot/users/{telegramId}/blocked' })
     .input(TelegramIdParamSchema)
     .output(BotUserResponseSchema)
-    .handler(async ({ input }: any) => {
+    .handler(async ({ input }) => {
       try {
         const user = await params.botUsersStorage.setBlocked(BigInt(input.telegramId));
 
@@ -98,7 +97,7 @@ export function createBotUsersRoutes(
     .route({ method: 'PUT', path: '/bot/users/{telegramId}/unblocked' })
     .input(TelegramIdParamSchema)
     .output(BotUserResponseSchema)
-    .handler(async ({ input }: any) => {
+    .handler(async ({ input }) => {
       try {
         const user = await params.botUsersStorage.setUnblocked(BigInt(input.telegramId));
 

--- a/packages/api/src/routers/chain.ts
+++ b/packages/api/src/routers/chain.ts
@@ -1,8 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
-import { getPrisma } from '@/lib/prisma.js';
-import { securedProcedure } from '@/lib/procedures.js';
-import { beaconTime, chainConfig } from '@/utils/beaconTime.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 import { getTokenPrice } from '@/utils/tokenPrice.js';
@@ -20,54 +18,6 @@ const ChainStatsDataSchema = z.object({
 
 const ChainStatsResponseSchema = ApiResponseSchema(ChainStatsDataSchema);
 
-const getStats = securedProcedure
-  .route({ method: 'GET', path: '/chain/stats' })
-  .output(ChainStatsResponseSchema)
-  .handler(async () => {
-    const prisma = getPrisma();
-
-    const latestStats = await prisma.chainEpochStats.findFirst({
-      orderBy: { epoch: 'desc' },
-    });
-
-    if (!latestStats) {
-      return {
-        success: false,
-        error: {
-          code: 'NOT_FOUND',
-          message: 'No chain statistics available yet',
-        },
-        meta: {
-          timestamp: new Date().toISOString(),
-        },
-      };
-    }
-
-    let tokenPrice = 0;
-    try {
-      tokenPrice = await getTokenPrice();
-    } catch {
-      // tokenPrice stays 0 if fetch fails
-    }
-
-    return {
-      success: true,
-      data: {
-        epoch: latestStats.epoch,
-        totalActiveValidators: latestStats.totalActiveValidators,
-        totalStaked: formatBalance(latestStats.totalStaked),
-        validatorsEntering: latestStats.validatorsEntering,
-        enteringStaked: formatBalance(latestStats.enteringStaked),
-        validatorsExiting: latestStats.validatorsExiting,
-        validatorsConsolidating: latestStats.validatorsConsolidating,
-        tokenPrice,
-      },
-      meta: {
-        timestamp: new Date().toISOString(),
-      },
-    };
-  });
-
 const SyncStatusDataSchema = z.object({
   currentSlot: z.number().int(),
   processingSlot: z.number().int(),
@@ -76,35 +26,105 @@ const SyncStatusDataSchema = z.object({
 
 const SyncStatusResponseSchema = ApiResponseSchema(SyncStatusDataSchema);
 
-const getSyncStatus = securedProcedure
-  .route({ method: 'GET', path: '/chain/sync-status' })
-  .output(SyncStatusResponseSchema)
-  .handler(async () => {
-    const prisma = getPrisma();
-    const currentSlot = beaconTime.getSlotNumberFromTimestamp(Date.now());
+/**
+ * Creates the chain router.
+ */
+export function createChainRouter(params: {
+  beaconHelpers: {
+    beaconTime: { getSlotNumberFromTimestamp: (timestamp: number) => number };
+    chainConfig: { beacon: { slotDuration: number } };
+  };
+  chain: 'ethereum' | 'gnosis';
+  logger: import('@/lib/logger.js').Logger;
+  prisma: {
+    chainEpochStats: {
+      findFirst: typeof import('@beacon-indexer/db').PrismaClient.prototype.chainEpochStats.findFirst;
+    };
+    slot: { findFirst: typeof import('@beacon-indexer/db').PrismaClient.prototype.slot.findFirst };
+  };
+  procedures: { securedProcedure: any };
+  tokenPriceApiUrl: string;
+  tokenPriceTokenName: string;
+}) {
+  const { securedProcedure } = params.procedures;
 
-    const lastProcessedSlot = await prisma.slot.findFirst({
-      where: { processed: true },
-      orderBy: { slot: 'desc' },
-      select: { slot: true },
+  const getStats = securedProcedure
+    .route({ method: 'GET', path: '/chain/stats' })
+    .output(ChainStatsResponseSchema)
+    .handler(async () => {
+      const latestStats = await params.prisma.chainEpochStats.findFirst({
+        orderBy: { epoch: 'desc' },
+      });
+
+      if (!latestStats) {
+        return {
+          success: false,
+          error: {
+            code: 'NOT_FOUND',
+            message: 'No chain statistics available yet',
+          },
+          meta: {
+            timestamp: new Date().toISOString(),
+          },
+        };
+      }
+
+      let tokenPrice = 0;
+      try {
+        tokenPrice = await getTokenPrice(
+          params.tokenPriceApiUrl,
+          params.tokenPriceTokenName,
+          params.logger,
+        );
+      } catch {
+        // Keeps the endpoint available even when the price feed fails.
+      }
+
+      return {
+        success: true,
+        data: {
+          epoch: latestStats.epoch,
+          totalActiveValidators: latestStats.totalActiveValidators,
+          totalStaked: formatBalance(latestStats.totalStaked, params.chain),
+          validatorsEntering: latestStats.validatorsEntering,
+          enteringStaked: formatBalance(latestStats.enteringStaked, params.chain),
+          validatorsExiting: latestStats.validatorsExiting,
+          validatorsConsolidating: latestStats.validatorsConsolidating,
+          tokenPrice,
+        },
+        meta: {
+          timestamp: new Date().toISOString(),
+        },
+      };
     });
 
-    const processingSlot = lastProcessedSlot ? lastProcessedSlot.slot + 1 : 0;
+  const getSyncStatus = securedProcedure
+    .route({ method: 'GET', path: '/chain/sync-status' })
+    .output(SyncStatusResponseSchema)
+    .handler(async () => {
+      const currentSlot = params.beaconHelpers.beaconTime.getSlotNumberFromTimestamp(Date.now());
 
-    return {
-      success: true,
-      data: {
-        currentSlot,
-        processingSlot,
-        slotDurationMs: chainConfig.beacon.slotDuration,
-      },
-      meta: {
-        timestamp: new Date().toISOString(),
-      },
-    };
-  });
+      const lastProcessedSlot = await params.prisma.slot.findFirst({
+        where: { processed: true },
+        orderBy: { slot: 'desc' },
+        select: { slot: true },
+      });
 
-export const chainRouter = {
-  stats: getStats,
-  syncStatus: getSyncStatus,
-};
+      return {
+        success: true,
+        data: {
+          currentSlot,
+          processingSlot: lastProcessedSlot ? lastProcessedSlot.slot + 1 : 0,
+          slotDurationMs: params.beaconHelpers.chainConfig.beacon.slotDuration,
+        },
+        meta: {
+          timestamp: new Date().toISOString(),
+        },
+      };
+    });
+
+  return {
+    stats: getStats,
+    syncStatus: getSyncStatus,
+  };
+}

--- a/packages/api/src/routers/chain.ts
+++ b/packages/api/src/routers/chain.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 import { getTokenPrice } from '@/utils/tokenPrice.js';
@@ -42,7 +43,7 @@ export function createChainRouter(params: {
     };
     slot: { findFirst: typeof import('@beacon-indexer/db').PrismaClient.prototype.slot.findFirst };
   };
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
   tokenPriceApiUrl: string;
   tokenPriceTokenName: string;
 }) {

--- a/packages/api/src/routers/cluster/addValidators.ts
+++ b/packages/api/src/routers/cluster/addValidators.ts
@@ -6,6 +6,7 @@ import {
   ClusterIdParamSchema,
 } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
@@ -13,7 +14,7 @@ import { ApiResponseSchema } from '@/utils/response.js';
  */
 export function createAddValidatorsRoute(params: {
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/addValidators.ts
+++ b/packages/api/src/routers/cluster/addValidators.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { requireOwnedCluster } from './ownership.js';
 import {
   AddValidatorsInputSchema,
@@ -5,100 +6,103 @@ import {
   ClusterIdParamSchema,
 } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Add validators to cluster
- * POST /clusters/:id/validators
- *
- * Accepts either:
- * - validatorIndexes: array of validator indexes to add
- * - withdrawalAddress: adds all validators with this withdrawal address (case-insensitive)
+ * Creates the add-validators route.
  */
-export const addValidators = securedProcedure
-  .route({ method: 'POST', path: '/clusters/{id}/validators' })
-  .input(ClusterIdParamSchema.merge(AddValidatorsInputSchema))
-  .output(ApiResponseSchema(AddValidatorsResponseSchema))
-  .handler(async ({ context, input }) => {
-    try {
-      const storage = new ClusterStorage();
-      let validatorIndexes: number[];
+export function createAddValidatorsRoute(params: {
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      const ownershipError = await requireOwnedCluster(storage, input.id, context.user);
-      if (ownershipError) {
-        return ownershipError;
-      }
-
-      // Validate that exactly one input type is provided
-      if (input.withdrawalAddress && input.validatorIndexes) {
-        return {
-          success: false,
-          error: {
-            code: 'INVALID_INPUT',
-            message: 'Only one of validatorIndexes or withdrawalAddress can be provided, not both',
-          },
-          meta: { timestamp: new Date().toISOString() },
-        };
-      }
-
-      if (input.withdrawalAddress) {
-        // Find all validators with this withdrawal address
-        validatorIndexes = await storage.findValidatorIndexesByWithdrawalAddress(
-          input.withdrawalAddress,
+  return securedProcedure
+    .route({ method: 'POST', path: '/clusters/{id}/validators' })
+    .input(ClusterIdParamSchema.merge(AddValidatorsInputSchema))
+    .output(ApiResponseSchema(AddValidatorsResponseSchema))
+    .handler(async ({ context, input }: any) => {
+      try {
+        const ownershipError = await requireOwnedCluster(
+          params.clusterStorage,
+          input.id,
+          context.user,
         );
-
-        if (validatorIndexes.length === 0) {
-          return {
-            success: false,
-            error: {
-              code: 'VALIDATORS_NOT_FOUND',
-              message: `No validators found with withdrawal address ${input.withdrawalAddress}`,
-            },
-            meta: { timestamp: new Date().toISOString() },
-          };
+        if (ownershipError) {
+          return ownershipError;
         }
-      } else if (input.validatorIndexes) {
-        // Verify all validator indexes exist
-        const { existing, notFound } = await storage.verifyValidatorIndexes(input.validatorIndexes);
 
-        if (notFound.length > 0) {
+        let validatorIndexes: number[];
+
+        if (input.withdrawalAddress && input.validatorIndexes) {
           return {
             success: false,
             error: {
-              code: 'VALIDATORS_NOT_FOUND',
-              message: `Validators not found: ${notFound.join(', ')}`,
+              code: 'INVALID_INPUT',
+              message:
+                'Only one of validatorIndexes or withdrawalAddress can be provided, not both',
             },
             meta: { timestamp: new Date().toISOString() },
           };
         }
 
-        validatorIndexes = existing;
-      } else {
+        if (input.withdrawalAddress) {
+          validatorIndexes = await params.clusterStorage.findValidatorIndexesByWithdrawalAddress(
+            input.withdrawalAddress,
+          );
+
+          if (validatorIndexes.length === 0) {
+            return {
+              success: false,
+              error: {
+                code: 'VALIDATORS_NOT_FOUND',
+                message: `No validators found with withdrawal address ${input.withdrawalAddress}`,
+              },
+              meta: { timestamp: new Date().toISOString() },
+            };
+          }
+        } else if (input.validatorIndexes) {
+          const { existing, notFound } = await params.clusterStorage.verifyValidatorIndexes(
+            input.validatorIndexes,
+          );
+
+          if (notFound.length > 0) {
+            return {
+              success: false,
+              error: {
+                code: 'VALIDATORS_NOT_FOUND',
+                message: `Validators not found: ${notFound.join(', ')}`,
+              },
+              meta: { timestamp: new Date().toISOString() },
+            };
+          }
+
+          validatorIndexes = existing;
+        } else {
+          return {
+            success: false,
+            error: {
+              code: 'INVALID_INPUT',
+              message: 'Either validatorIndexes or withdrawalAddress must be provided',
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+
+        return {
+          success: true,
+          data: { added: await params.clusterStorage.addValidators(input.id, validatorIndexes) },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
         return {
           success: false,
           error: {
-            code: 'INVALID_INPUT',
-            message: 'Either validatorIndexes or withdrawalAddress must be provided',
+            code: 'CLUSTER_ADD_VALIDATORS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to add validators',
           },
           meta: { timestamp: new Date().toISOString() },
         };
       }
-
-      const added = await storage.addValidators(input.id, validatorIndexes);
-
-      return {
-        success: true,
-        data: { added },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to add validators';
-      return {
-        success: false,
-        error: { code: 'CLUSTER_ADD_VALIDATORS_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+    });
+}

--- a/packages/api/src/routers/cluster/create.ts
+++ b/packages/api/src/routers/cluster/create.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ClusterWithCountSchema, CreateClusterInputSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
@@ -8,7 +9,7 @@ import { ApiResponseSchema } from '@/utils/response.js';
  */
 export function createCreateClusterRoute(params: {
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/create.ts
+++ b/packages/api/src/routers/cluster/create.ts
@@ -1,47 +1,53 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ClusterWithCountSchema, CreateClusterInputSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Create a new cluster
- * POST /clusters
+ * Creates the cluster creation route.
  */
-export const createCluster = securedProcedure
-  .route({ method: 'POST', path: '/clusters' })
-  .input(CreateClusterInputSchema)
-  .output(ApiResponseSchema(ClusterWithCountSchema))
-  .handler(async ({ context, input }) => {
-    try {
-      const storage = new ClusterStorage();
-      const cluster = await storage.create({
-        name: input.name,
-        ownerId: context.user!.id,
-        visibility: input.visibility,
-        feeRecipientAddress: input.feeRecipientAddress ?? null,
-        validatorIndexes: input.validatorIndexes,
-      });
+export function createCreateClusterRoute(params: {
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      return {
-        success: true,
-        data: {
-          id: cluster.id,
-          name: cluster.name,
-          visibility: cluster.visibility,
-          feeRecipientAddress: cluster.feeRecipientAddress,
-          ownerId: cluster.ownerId,
-          createdAt: cluster.createdAt.toISOString(),
-          validatorCount: cluster.validatorCount,
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to create cluster';
-      return {
-        success: false,
-        error: { code: 'CLUSTER_CREATE_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+  return securedProcedure
+    .route({ method: 'POST', path: '/clusters' })
+    .input(CreateClusterInputSchema)
+    .output(ApiResponseSchema(ClusterWithCountSchema))
+    .handler(async ({ context, input }: any) => {
+      try {
+        const cluster = await params.clusterStorage.create({
+          name: input.name,
+          ownerId: context.user!.id,
+          visibility: input.visibility,
+          feeRecipientAddress: input.feeRecipientAddress ?? null,
+          validatorIndexes: input.validatorIndexes,
+        });
+
+        return {
+          success: true,
+          data: {
+            id: cluster.id,
+            name: cluster.name,
+            visibility: cluster.visibility,
+            feeRecipientAddress: cluster.feeRecipientAddress,
+            ownerId: cluster.ownerId,
+            createdAt: cluster.createdAt.toISOString(),
+            validatorCount: cluster.validatorCount,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'CLUSTER_CREATE_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to create cluster',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+    });
+}

--- a/packages/api/src/routers/cluster/delete.ts
+++ b/packages/api/src/routers/cluster/delete.ts
@@ -1,41 +1,51 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterIdParamSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Delete cluster
- * DELETE /clusters/:id
+ * Creates the cluster deletion route.
  */
-export const deleteCluster = securedProcedure
-  .route({ method: 'DELETE', path: '/clusters/{id}' })
-  .input(ClusterIdParamSchema)
-  .output(ApiResponseSchema(z.object({ deleted: z.boolean() })))
-  .handler(async ({ context, input }) => {
-    try {
-      const storage = new ClusterStorage();
-      const ownershipError = await requireOwnedCluster(storage, input.id, context.user);
-      if (ownershipError) {
-        return ownershipError;
+export function createDeleteClusterRoute(params: {
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
+
+  return securedProcedure
+    .route({ method: 'DELETE', path: '/clusters/{id}' })
+    .input(ClusterIdParamSchema)
+    .output(ApiResponseSchema(z.object({ deleted: z.boolean() })))
+    .handler(async ({ context, input }: any) => {
+      try {
+        const ownershipError = await requireOwnedCluster(
+          params.clusterStorage,
+          input.id,
+          context.user,
+        );
+        if (ownershipError) {
+          return ownershipError;
+        }
+
+        await params.clusterStorage.delete(input.id);
+
+        return {
+          success: true,
+          data: { deleted: true },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'CLUSTER_DELETE_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to delete cluster',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
       }
-
-      await storage.delete(input.id);
-
-      return {
-        success: true,
-        data: { deleted: true },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to delete cluster';
-      return {
-        success: false,
-        error: { code: 'CLUSTER_DELETE_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+    });
+}

--- a/packages/api/src/routers/cluster/delete.ts
+++ b/packages/api/src/routers/cluster/delete.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterIdParamSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
@@ -11,7 +12,7 @@ import { ApiResponseSchema } from '@/utils/response.js';
  */
 export function createDeleteClusterRoute(params: {
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/get.ts
+++ b/packages/api/src/routers/cluster/get.ts
@@ -1,84 +1,99 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterDetailSchema, ClusterIdParamSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 
 /**
- * Get cluster details with validators
- * GET /clusters/:id
+ * Creates the cluster detail route.
  */
-export const getCluster = securedProcedure
-  .route({ method: 'GET', path: '/clusters/{id}' })
-  .input(ClusterIdParamSchema)
-  .output(ApiResponseSchema(ClusterDetailSchema))
-  .handler(async ({ context, input }) => {
-    try {
-      const storage = new ClusterStorage();
-      const ownershipError = await requireOwnedCluster(storage, input.id, context.user);
-      if (ownershipError) {
-        return ownershipError;
-      }
+export function createGetClusterRoute(params: {
+  chain: 'ethereum' | 'gnosis';
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      const cluster = await storage.findByIdWithValidatorsAndSnapshot(input.id);
+  return securedProcedure
+    .route({ method: 'GET', path: '/clusters/{id}' })
+    .input(ClusterIdParamSchema)
+    .output(ApiResponseSchema(ClusterDetailSchema))
+    .handler(async ({ context, input }: any) => {
+      try {
+        const ownershipError = await requireOwnedCluster(
+          params.clusterStorage,
+          input.id,
+          context.user,
+        );
+        if (ownershipError) {
+          return ownershipError;
+        }
 
-      if (!cluster) {
+        const cluster = await params.clusterStorage.findByIdWithValidatorsAndSnapshot(input.id);
+
+        if (!cluster) {
+          return {
+            success: false,
+            error: { code: 'CLUSTER_NOT_FOUND', message: `Cluster with id ${input.id} not found` },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+
+        const withdrawalAddresses = Array.from(
+          new Set(
+            cluster.validators.flatMap((validator: any) =>
+              validator.withdrawalAddress ? [validator.withdrawalAddress] : [],
+            ),
+          ),
+        );
+
+        let totalBalance = BigInt(0);
+        let totalEffectiveBalance = BigInt(0);
+
+        for (const validator of cluster.validators) {
+          totalBalance += validator.balance;
+          if (validator.effectiveBalance) {
+            totalEffectiveBalance += validator.effectiveBalance;
+          }
+        }
+
+        return {
+          success: true,
+          data: {
+            id: cluster.id,
+            name: cluster.name,
+            visibility: cluster.visibility as 'private' | 'shared',
+            feeRecipientAddress: cluster.feeRecipientAddress,
+            ownerId: cluster.ownerId,
+            createdAt: cluster.createdAt.toISOString(),
+            validators: cluster.validators.map((validator: any) => ({
+              validatorIndex: validator.validatorIndex,
+              withdrawalAddress: validator.withdrawalAddress,
+              status: validator.beaconStatus,
+              isInactive: validator.isInactive,
+              performanceH: validator.performanceH,
+              balance: formatBalance(validator.balance, params.chain),
+              effectiveBalance: validator.effectiveBalance
+                ? formatBalance(validator.effectiveBalance, params.chain)
+                : null,
+              pubkey: validator.pubkey,
+            })),
+            withdrawalAddresses,
+            totalBalance: formatBalance(totalBalance, params.chain),
+            totalEffectiveBalance: formatBalance(totalEffectiveBalance, params.chain),
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
         return {
           success: false,
-          error: { code: 'CLUSTER_NOT_FOUND', message: `Cluster with id ${input.id} not found` },
+          error: {
+            code: 'CLUSTER_GET_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to get cluster',
+          },
           meta: { timestamp: new Date().toISOString() },
         };
       }
-
-      const withdrawalAddresses = Array.from(
-        new Set(
-          cluster.validators.flatMap((v) => (v.withdrawalAddress ? [v.withdrawalAddress] : [])),
-        ),
-      );
-
-      let totalBalance = BigInt(0);
-      let totalEffectiveBalance = BigInt(0);
-
-      for (const v of cluster.validators) {
-        totalBalance += v.balance;
-        if (v.effectiveBalance) {
-          totalEffectiveBalance += v.effectiveBalance;
-        }
-      }
-
-      return {
-        success: true,
-        data: {
-          id: cluster.id,
-          name: cluster.name,
-          visibility: cluster.visibility as 'private' | 'shared',
-          feeRecipientAddress: cluster.feeRecipientAddress,
-          ownerId: cluster.ownerId,
-          createdAt: cluster.createdAt.toISOString(),
-          validators: cluster.validators.map((v) => ({
-            validatorIndex: v.validatorIndex,
-            withdrawalAddress: v.withdrawalAddress,
-            status: v.beaconStatus,
-            isInactive: v.isInactive,
-            performanceH: v.performanceH,
-            balance: formatBalance(v.balance),
-            effectiveBalance: v.effectiveBalance ? formatBalance(v.effectiveBalance) : null,
-            pubkey: v.pubkey,
-          })),
-          withdrawalAddresses,
-          totalBalance: formatBalance(totalBalance),
-          totalEffectiveBalance: formatBalance(totalEffectiveBalance),
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to get cluster';
-      return {
-        success: false,
-        error: { code: 'CLUSTER_GET_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+    });
+}

--- a/packages/api/src/routers/cluster/get.ts
+++ b/packages/api/src/routers/cluster/get.ts
@@ -2,6 +2,7 @@
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterDetailSchema, ClusterIdParamSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 
@@ -11,7 +12,7 @@ import { formatBalance } from '@/utils/tokenFormat.js';
 export function createGetClusterRoute(params: {
   chain: 'ethereum' | 'gnosis';
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 
@@ -41,7 +42,7 @@ export function createGetClusterRoute(params: {
         }
 
         const withdrawalAddresses = Array.from(
-          new Set(
+          new Set<string>(
             cluster.validators.flatMap((validator: any) =>
               validator.withdrawalAddress ? [validator.withdrawalAddress] : [],
             ),

--- a/packages/api/src/routers/cluster/incidents.ts
+++ b/packages/api/src/routers/cluster/incidents.ts
@@ -10,6 +10,7 @@ import {
   ClusterIncidentsResponseSchema,
 } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 
@@ -77,7 +78,7 @@ function missingValidatorsUserResponse(): ClusterIncidentAffectedValidatorsApiRe
 export function createClusterIncidentRoutes(params: {
   chain: 'ethereum' | 'gnosis';
   incidentStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/incidents.ts
+++ b/packages/api/src/routers/cluster/incidents.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import {
@@ -10,7 +9,7 @@ import {
   ClusterIncidentsResponseSchema,
 } from './schemas.js';
 
-import type { ApiProcedures } from '@/auth/middleware.js';
+import type { ApiDependencies } from '@/dependencies.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 
@@ -75,18 +74,16 @@ function missingValidatorsUserResponse(): ClusterIncidentAffectedValidatorsApiRe
 /**
  * Creates the cluster incidents routes.
  */
-export function createClusterIncidentRoutes(params: {
-  chain: 'ethereum' | 'gnosis';
-  incidentStorage: any;
-  procedures: ApiProcedures;
-}) {
+export function createClusterIncidentRoutes(
+  params: Pick<ApiDependencies, 'chain' | 'incidentStorage' | 'procedures'>,
+) {
   const { securedProcedure } = params.procedures;
 
   const listClusterIncidents = securedProcedure
     .route({ method: 'GET', path: '/clusters/{id}/incidents' })
     .input(ClusterIncidentsInputSchema)
     .output(ClusterIncidentsApiResponseSchema)
-    .handler(async ({ context, input }: any) => {
+    .handler(async ({ context, input }) => {
       if (!context.user) {
         return missingUserResponse();
       }
@@ -120,7 +117,7 @@ export function createClusterIncidentRoutes(params: {
         return {
           success: true,
           data: {
-            incidents: rows.map((row: any) => ({
+            incidents: rows.map((row) => ({
               id: row.id,
               status: row.status,
               openedAt: row.opened_at.toISOString(),
@@ -168,7 +165,7 @@ export function createClusterIncidentRoutes(params: {
     .route({ method: 'POST', path: '/clusters/{id}/incidents/opened-notified' })
     .input(ClusterIncidentsInputSchema.pick({ id: true }))
     .output(ClusterIncidentNotificationApiResponseSchema)
-    .handler(async ({ context, input }: any) => {
+    .handler(async ({ context, input }) => {
       if (!context.user) {
         return missingNotificationUserResponse();
       }
@@ -218,7 +215,7 @@ export function createClusterIncidentRoutes(params: {
     .route({ method: 'POST', path: '/clusters/incidents/{incidentId}/closed-notified' })
     .input(ClusterIncidentIdParamSchema)
     .output(ClusterIncidentNotificationApiResponseSchema)
-    .handler(async ({ context, input }: any) => {
+    .handler(async ({ context, input }) => {
       if (!context.user) {
         return missingNotificationUserResponse();
       }
@@ -284,7 +281,7 @@ export function createClusterIncidentRoutes(params: {
     .route({ method: 'GET', path: '/clusters/incidents/{incidentId}/affected-validators' })
     .input(ClusterIncidentAffectedValidatorsInputSchema)
     .output(ClusterIncidentAffectedValidatorsApiResponseSchema)
-    .handler(async ({ context, input }: any) => {
+    .handler(async ({ context, input }) => {
       if (!context.user) {
         return missingValidatorsUserResponse();
       }
@@ -318,7 +315,7 @@ export function createClusterIncidentRoutes(params: {
         return {
           success: true,
           data: {
-            validators: rows.map((row: any) => ({
+            validators: rows.map((row) => ({
               validatorIndex: row.validator_index,
               inactiveFromSlot: row.inactive_from_slot,
               inactiveToSlot: row.inactive_to_slot,

--- a/packages/api/src/routers/cluster/incidents.ts
+++ b/packages/api/src/routers/cluster/incidents.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import {
@@ -9,12 +10,9 @@ import {
   ClusterIncidentsResponseSchema,
 } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { IncidentStorage } from '@/storage/incident.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 
-const incidentStorage = new IncidentStorage();
 const ClusterIncidentsApiResponseSchema = ApiResponseSchema(ClusterIncidentsResponseSchema);
 const ClusterIncidentNotificationApiResponseSchema = ApiResponseSchema(
   ClusterIncidentNotificationSchema,
@@ -32,7 +30,7 @@ type ClusterIncidentAffectedValidatorsApiResponse = z.infer<
 >;
 
 /**
- * Returns a success response for a missing authenticated user.
+ * Builds the missing-user response for incidents routes.
  */
 function missingUserResponse(): ClusterIncidentsApiResponse {
   return {
@@ -46,7 +44,7 @@ function missingUserResponse(): ClusterIncidentsApiResponse {
 }
 
 /**
- * Returns a success response for a missing authenticated user on notification routes.
+ * Builds the missing-user response for incident notification routes.
  */
 function missingNotificationUserResponse(): ClusterIncidentNotificationApiResponse {
   return {
@@ -60,7 +58,7 @@ function missingNotificationUserResponse(): ClusterIncidentNotificationApiRespon
 }
 
 /**
- * Returns a success response for a missing authenticated user on validator routes.
+ * Builds the missing-user response for affected-validator routes.
  */
 function missingValidatorsUserResponse(): ClusterIncidentAffectedValidatorsApiResponse {
   return {
@@ -74,276 +72,282 @@ function missingValidatorsUserResponse(): ClusterIncidentAffectedValidatorsApiRe
 }
 
 /**
- * Lists incidents for one owned cluster.
+ * Creates the cluster incidents routes.
  */
-export const listClusterIncidents = securedProcedure
-  .route({ method: 'GET', path: '/clusters/{id}/incidents' })
-  .input(ClusterIncidentsInputSchema)
-  .output(ClusterIncidentsApiResponseSchema)
-  .handler(async ({ context, input }) => {
-    if (!context.user) {
-      return missingUserResponse();
-    }
+export function createClusterIncidentRoutes(params: {
+  chain: 'ethereum' | 'gnosis';
+  incidentStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-    try {
-      const { rows, totalCount } = await incidentStorage.listClusterIncidents({
-        ownerId: context.user.id,
-        clusterId: input.id,
-        page: input.page,
-        pageSize: input.pageSize,
-      });
+  const listClusterIncidents = securedProcedure
+    .route({ method: 'GET', path: '/clusters/{id}/incidents' })
+    .input(ClusterIncidentsInputSchema)
+    .output(ClusterIncidentsApiResponseSchema)
+    .handler(async ({ context, input }: any) => {
+      if (!context.user) {
+        return missingUserResponse();
+      }
 
-      // This fallback distinguishes an empty page from an unknown or foreign cluster.
-      if (rows.length === 0) {
-        const isOwnedCluster = await incidentStorage.isOwnedCluster({
+      try {
+        const { rows, totalCount } = await params.incidentStorage.listClusterIncidents({
           ownerId: context.user.id,
           clusterId: input.id,
-        });
-
-        if (!isOwnedCluster) {
-          return {
-            success: false,
-            error: {
-              code: 'CLUSTER_NOT_FOUND',
-              message: `Cluster with id ${input.id} not found`,
-            },
-            meta: { timestamp: new Date().toISOString() },
-          };
-        }
-      }
-
-      return {
-        success: true,
-        data: {
-          incidents: rows.map((row) => ({
-            id: row.id,
-            status: row.status,
-            openedAt: row.opened_at.toISOString(),
-            openedSlot: row.opened_slot,
-            closedAt: row.closed_at?.toISOString() ?? null,
-            closedSlot: row.closed_slot,
-            durationSlots: row.duration_slots,
-            durationSeconds: row.duration_seconds,
-            missedAttestationRewards:
-              row.missed_attestation_rewards !== null
-                ? formatBalance(row.missed_attestation_rewards)
-                : null,
-            missedSyncRewards:
-              row.missed_sync_rewards !== null ? formatBalance(row.missed_sync_rewards) : null,
-            missedConsensusRewards:
-              row.missed_consensus_rewards !== null
-                ? formatBalance(row.missed_consensus_rewards)
-                : null,
-            rewardsFinalized: row.rewards_finalized,
-            rewardsFinalizedAt: row.rewards_finalized_at?.toISOString() ?? null,
-            openedNotificationQueuedAt: row.opened_notification_queued_at?.toISOString() ?? null,
-            closedNotificationQueuedAt: row.closed_notification_queued_at?.toISOString() ?? null,
-          })),
-          totalCount,
           page: input.page,
           pageSize: input.pageSize,
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: {
-          code: 'CLUSTER_INCIDENTS_ERROR',
-          message: error instanceof Error ? error.message : 'Failed to fetch cluster incidents',
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+        });
 
-/**
- * Updates the send timestamp for the current open incident in a cluster.
- */
-export const markClusterIncidentOpenedNotified = securedProcedure
-  .route({ method: 'POST', path: '/clusters/{id}/incidents/opened-notified' })
-  .input(ClusterIncidentsInputSchema.pick({ id: true }))
-  .output(ClusterIncidentNotificationApiResponseSchema)
-  .handler(async ({ context, input }) => {
-    if (!context.user) {
-      return missingNotificationUserResponse();
-    }
+        if (rows.length === 0) {
+          const isOwnedCluster = await params.incidentStorage.isOwnedCluster({
+            ownerId: context.user.id,
+            clusterId: input.id,
+          });
 
-    try {
-      const notifiedAt = new Date();
-      const updatedIncident = await incidentStorage.markOpenIncidentNotified({
-        ownerId: context.user.id,
-        clusterId: input.id,
-        notifiedAt,
-      });
+          if (!isOwnedCluster) {
+            return {
+              success: false,
+              error: {
+                code: 'CLUSTER_NOT_FOUND',
+                message: `Cluster with id ${input.id} not found`,
+              },
+              meta: { timestamp: new Date().toISOString() },
+            };
+          }
+        }
 
-      if (!updatedIncident) {
+        return {
+          success: true,
+          data: {
+            incidents: rows.map((row: any) => ({
+              id: row.id,
+              status: row.status,
+              openedAt: row.opened_at.toISOString(),
+              openedSlot: row.opened_slot,
+              closedAt: row.closed_at?.toISOString() ?? null,
+              closedSlot: row.closed_slot,
+              durationSlots: row.duration_slots,
+              durationSeconds: row.duration_seconds,
+              missedAttestationRewards:
+                row.missed_attestation_rewards !== null
+                  ? formatBalance(row.missed_attestation_rewards, params.chain)
+                  : null,
+              missedSyncRewards:
+                row.missed_sync_rewards !== null
+                  ? formatBalance(row.missed_sync_rewards, params.chain)
+                  : null,
+              missedConsensusRewards:
+                row.missed_consensus_rewards !== null
+                  ? formatBalance(row.missed_consensus_rewards, params.chain)
+                  : null,
+              rewardsFinalized: row.rewards_finalized,
+              rewardsFinalizedAt: row.rewards_finalized_at?.toISOString() ?? null,
+              openedNotificationQueuedAt: row.opened_notification_queued_at?.toISOString() ?? null,
+              closedNotificationQueuedAt: row.closed_notification_queued_at?.toISOString() ?? null,
+            })),
+            totalCount,
+            page: input.page,
+            pageSize: input.pageSize,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
         return {
           success: false,
           error: {
-            code: 'OPEN_INCIDENT_NOT_FOUND',
-            message: `No open incident found for cluster ${input.id}`,
+            code: 'CLUSTER_INCIDENTS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to fetch cluster incidents',
           },
           meta: { timestamp: new Date().toISOString() },
         };
       }
+    });
 
-      return {
-        success: true,
-        data: {
-          incidentId: updatedIncident.incident_id,
-          notifiedAt: updatedIncident.opened_notification_queued_at.toISOString(),
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: {
-          code: 'MARK_OPEN_INCIDENT_NOTIFIED_ERROR',
-          message:
-            error instanceof Error ? error.message : 'Failed to update open incident notification',
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+  const markClusterIncidentOpenedNotified = securedProcedure
+    .route({ method: 'POST', path: '/clusters/{id}/incidents/opened-notified' })
+    .input(ClusterIncidentsInputSchema.pick({ id: true }))
+    .output(ClusterIncidentNotificationApiResponseSchema)
+    .handler(async ({ context, input }: any) => {
+      if (!context.user) {
+        return missingNotificationUserResponse();
+      }
 
-/**
- * Updates the send timestamp for a closed incident.
- */
-export const markClusterIncidentClosedNotified = securedProcedure
-  .route({ method: 'POST', path: '/clusters/incidents/{incidentId}/closed-notified' })
-  .input(ClusterIncidentIdParamSchema)
-  .output(ClusterIncidentNotificationApiResponseSchema)
-  .handler(async ({ context, input }) => {
-    if (!context.user) {
-      return missingNotificationUserResponse();
-    }
-
-    try {
-      const notifiedAt = new Date();
-      const updatedIncident = await incidentStorage.markClosedIncidentNotified({
-        ownerId: context.user.id,
-        incidentId: input.incidentId,
-        notifiedAt,
-      });
-
-      if (!updatedIncident) {
-        const incidentStatus = await incidentStorage.getOwnedIncidentStatus({
+      try {
+        const updatedIncident = await params.incidentStorage.markOpenIncidentNotified({
           ownerId: context.user.id,
-          incidentId: input.incidentId,
+          clusterId: input.id,
+          notifiedAt: new Date(),
         });
 
-        if (!incidentStatus) {
+        if (!updatedIncident) {
           return {
             success: false,
             error: {
-              code: 'INCIDENT_NOT_FOUND',
-              message: `Incident with id ${input.incidentId} not found`,
+              code: 'OPEN_INCIDENT_NOT_FOUND',
+              message: `No open incident found for cluster ${input.id}`,
             },
             meta: { timestamp: new Date().toISOString() },
           };
         }
 
         return {
+          success: true,
+          data: {
+            incidentId: updatedIncident.incident_id,
+            notifiedAt: updatedIncident.opened_notification_queued_at.toISOString(),
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
           success: false,
           error: {
-            code: 'INCIDENT_NOT_CLOSED',
-            message: `Incident with id ${input.incidentId} is not closed`,
+            code: 'MARK_OPEN_INCIDENT_NOTIFIED_ERROR',
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Failed to update open incident notification',
           },
           meta: { timestamp: new Date().toISOString() },
         };
       }
+    });
 
-      return {
-        success: true,
-        data: {
-          incidentId: updatedIncident.incident_id,
-          notifiedAt: updatedIncident.closed_notification_queued_at.toISOString(),
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: {
-          code: 'MARK_CLOSED_INCIDENT_NOTIFIED_ERROR',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'Failed to update closed incident notification',
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+  const markClusterIncidentClosedNotified = securedProcedure
+    .route({ method: 'POST', path: '/clusters/incidents/{incidentId}/closed-notified' })
+    .input(ClusterIncidentIdParamSchema)
+    .output(ClusterIncidentNotificationApiResponseSchema)
+    .handler(async ({ context, input }: any) => {
+      if (!context.user) {
+        return missingNotificationUserResponse();
+      }
 
-/**
- * Lists affected validators for one owned incident.
- */
-export const listIncidentAffectedValidators = securedProcedure
-  .route({ method: 'GET', path: '/clusters/incidents/{incidentId}/affected-validators' })
-  .input(ClusterIncidentAffectedValidatorsInputSchema)
-  .output(ClusterIncidentAffectedValidatorsApiResponseSchema)
-  .handler(async ({ context, input }) => {
-    if (!context.user) {
-      return missingValidatorsUserResponse();
-    }
-
-    try {
-      const { rows, totalCount } = await incidentStorage.listIncidentAffectedValidators({
-        ownerId: context.user.id,
-        incidentId: input.incidentId,
-        page: input.page,
-        pageSize: input.pageSize,
-      });
-
-      // This fallback distinguishes an empty page from an unknown or foreign incident.
-      if (rows.length === 0) {
-        const isOwnedIncident = await incidentStorage.isOwnedIncident({
+      try {
+        const updatedIncident = await params.incidentStorage.markClosedIncidentNotified({
           ownerId: context.user.id,
           incidentId: input.incidentId,
+          notifiedAt: new Date(),
         });
 
-        if (!isOwnedIncident) {
+        if (!updatedIncident) {
+          const incidentStatus = await params.incidentStorage.getOwnedIncidentStatus({
+            ownerId: context.user.id,
+            incidentId: input.incidentId,
+          });
+
+          if (!incidentStatus) {
+            return {
+              success: false,
+              error: {
+                code: 'INCIDENT_NOT_FOUND',
+                message: `Incident with id ${input.incidentId} not found`,
+              },
+              meta: { timestamp: new Date().toISOString() },
+            };
+          }
+
           return {
             success: false,
             error: {
-              code: 'INCIDENT_NOT_FOUND',
-              message: `Incident with id ${input.incidentId} not found`,
+              code: 'INCIDENT_NOT_CLOSED',
+              message: `Incident with id ${input.incidentId} is not closed`,
             },
             meta: { timestamp: new Date().toISOString() },
           };
         }
+
+        return {
+          success: true,
+          data: {
+            incidentId: updatedIncident.incident_id,
+            notifiedAt: updatedIncident.closed_notification_queued_at.toISOString(),
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'MARK_CLOSED_INCIDENT_NOTIFIED_ERROR',
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Failed to update closed incident notification',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+    });
+
+  const listIncidentAffectedValidators = securedProcedure
+    .route({ method: 'GET', path: '/clusters/incidents/{incidentId}/affected-validators' })
+    .input(ClusterIncidentAffectedValidatorsInputSchema)
+    .output(ClusterIncidentAffectedValidatorsApiResponseSchema)
+    .handler(async ({ context, input }: any) => {
+      if (!context.user) {
+        return missingValidatorsUserResponse();
       }
 
-      return {
-        success: true,
-        data: {
-          validators: rows.map((row) => ({
-            validatorIndex: row.validator_index,
-            inactiveFromSlot: row.inactive_from_slot,
-            inactiveToSlot: row.inactive_to_slot,
-            rewardsProcessedThroughSlot: row.rewards_processed_through_slot,
-            missedAttestationRewards: formatBalance(row.missed_attestation_rewards),
-            missedSyncRewards: formatBalance(row.missed_sync_rewards),
-            missedConsensusRewards: formatBalance(row.missed_consensus_rewards),
-          })),
-          totalCount,
+      try {
+        const { rows, totalCount } = await params.incidentStorage.listIncidentAffectedValidators({
+          ownerId: context.user.id,
+          incidentId: input.incidentId,
           page: input.page,
           pageSize: input.pageSize,
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: {
-          code: 'INCIDENT_AFFECTED_VALIDATORS_ERROR',
-          message: error instanceof Error ? error.message : 'Failed to fetch affected validators',
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+        });
+
+        if (rows.length === 0) {
+          const isOwnedIncident = await params.incidentStorage.isOwnedIncident({
+            ownerId: context.user.id,
+            incidentId: input.incidentId,
+          });
+
+          if (!isOwnedIncident) {
+            return {
+              success: false,
+              error: {
+                code: 'INCIDENT_NOT_FOUND',
+                message: `Incident with id ${input.incidentId} not found`,
+              },
+              meta: { timestamp: new Date().toISOString() },
+            };
+          }
+        }
+
+        return {
+          success: true,
+          data: {
+            validators: rows.map((row: any) => ({
+              validatorIndex: row.validator_index,
+              inactiveFromSlot: row.inactive_from_slot,
+              inactiveToSlot: row.inactive_to_slot,
+              rewardsProcessedThroughSlot: row.rewards_processed_through_slot,
+              missedAttestationRewards: formatBalance(row.missed_attestation_rewards, params.chain),
+              missedSyncRewards: formatBalance(row.missed_sync_rewards, params.chain),
+              missedConsensusRewards: formatBalance(row.missed_consensus_rewards, params.chain),
+            })),
+            totalCount,
+            page: input.page,
+            pageSize: input.pageSize,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'INCIDENT_AFFECTED_VALIDATORS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to fetch affected validators',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+    });
+
+  return {
+    listClusterIncidents,
+    listIncidentAffectedValidators,
+    markClusterIncidentClosedNotified,
+    markClusterIncidentOpenedNotified,
+  };
+}

--- a/packages/api/src/routers/cluster/index.ts
+++ b/packages/api/src/routers/cluster/index.ts
@@ -1,40 +1,57 @@
-import { addValidators } from './addValidators.js';
-import { createCluster } from './create.js';
-import { deleteCluster } from './delete.js';
-import { getCluster } from './get.js';
+import { createAddValidatorsRoute } from './addValidators.js';
+import { createCreateClusterRoute } from './create.js';
+import { createDeleteClusterRoute } from './delete.js';
+import { createGetClusterRoute } from './get.js';
+import { createClusterIncidentRoutes } from './incidents.js';
+import { createListClustersRoute } from './list.js';
 import {
-  listClusterIncidents,
-  listIncidentAffectedValidators,
-  markClusterIncidentClosedNotified,
-  markClusterIncidentOpenedNotified,
-} from './incidents.js';
-import { listClusters } from './list.js';
-import {
-  getAllClustersMissedAttestations,
-  getClusterMissedAttestations,
+  createAllClustersMissedAttestationsRoute,
+  createClusterMissedAttestationsRoute,
 } from './missed-attestations.js';
-import { removeValidators } from './removeValidators.js';
-import { getAllClustersRewards, getClusterRewards } from './rewards.js';
-import { getClusterSnapshot } from './snapshot.js';
-import { getClusterSummary } from './summary.js';
-import { updateCluster } from './update.js';
+import { createRemoveValidatorsRoute } from './removeValidators.js';
+import { createAllClustersRewardsRoute, createClusterRewardsRoute } from './rewards.js';
+import { createClusterSnapshotRoute } from './snapshot.js';
+import { createClusterSummaryRoute } from './summary.js';
+import { createUpdateClusterRoute } from './update.js';
+import type { ApiDependencies } from '@/dependencies.js';
 
-export const clusterRouter = {
-  create: createCluster,
-  list: listClusters,
-  summary: getClusterSummary,
-  get: getCluster,
-  update: updateCluster,
-  delete: deleteCluster,
-  addValidators,
-  removeValidators,
-  incidents: listClusterIncidents,
-  incidentAffectedValidators: listIncidentAffectedValidators,
-  setIncidentClosedNotified: markClusterIncidentClosedNotified,
-  setIncidentOpenedNotified: markClusterIncidentOpenedNotified,
-  snapshot: getClusterSnapshot,
-  missedAttestations: getClusterMissedAttestations,
-  allMissedAttestations: getAllClustersMissedAttestations,
-  rewards: getClusterRewards,
-  allRewards: getAllClustersRewards,
-};
+/**
+ * Creates the cluster router.
+ */
+export function createClusterRouter(
+  deps: Pick<
+    ApiDependencies,
+    | 'analyticsStorage'
+    | 'beaconHelpers'
+    | 'clusterStorage'
+    | 'incidentStorage'
+    | 'procedures'
+    | 'chain'
+    | 'logger'
+    | 'nativeTokenDecimals'
+    | 'tokenPriceApiUrl'
+    | 'tokenPriceTokenName'
+  >,
+) {
+  const incidents = createClusterIncidentRoutes(deps);
+
+  return {
+    create: createCreateClusterRoute(deps),
+    list: createListClustersRoute(deps),
+    summary: createClusterSummaryRoute(deps),
+    get: createGetClusterRoute(deps),
+    update: createUpdateClusterRoute(deps),
+    delete: createDeleteClusterRoute(deps),
+    addValidators: createAddValidatorsRoute(deps),
+    removeValidators: createRemoveValidatorsRoute(deps),
+    incidents: incidents.listClusterIncidents,
+    incidentAffectedValidators: incidents.listIncidentAffectedValidators,
+    setIncidentClosedNotified: incidents.markClusterIncidentClosedNotified,
+    setIncidentOpenedNotified: incidents.markClusterIncidentOpenedNotified,
+    snapshot: createClusterSnapshotRoute(deps),
+    missedAttestations: createClusterMissedAttestationsRoute(deps),
+    allMissedAttestations: createAllClustersMissedAttestationsRoute(deps),
+    rewards: createClusterRewardsRoute(deps),
+    allRewards: createAllClustersRewardsRoute(deps),
+  };
+}

--- a/packages/api/src/routers/cluster/list.ts
+++ b/packages/api/src/routers/cluster/list.ts
@@ -1,42 +1,48 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import { ClusterWithCountSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * List clusters for the current authenticated user
- * GET /clusters
+ * Creates the cluster listing route.
  */
-export const listClusters = securedProcedure
-  .route({ method: 'GET', path: '/clusters' })
-  .output(ApiResponseSchema(z.array(ClusterWithCountSchema)))
-  .handler(async ({ context }) => {
-    try {
-      const storage = new ClusterStorage();
-      const clusters = await storage.listByOwner(context.user!.id);
+export function createListClustersRoute(params: {
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      return {
-        success: true,
-        data: clusters.map((cluster) => ({
-          id: cluster.id,
-          name: cluster.name,
-          visibility: cluster.visibility,
-          feeRecipientAddress: cluster.feeRecipientAddress,
-          ownerId: cluster.ownerId,
-          createdAt: cluster.createdAt.toISOString(),
-          validatorCount: cluster._count.validators,
-        })),
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to list clusters';
-      return {
-        success: false,
-        error: { code: 'CLUSTER_LIST_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+  return securedProcedure
+    .route({ method: 'GET', path: '/clusters' })
+    .output(ApiResponseSchema(z.array(ClusterWithCountSchema)))
+    .handler(async ({ context }: any) => {
+      try {
+        const clusters = await params.clusterStorage.listByOwner(context.user!.id);
+
+        return {
+          success: true,
+          data: clusters.map((cluster: any) => ({
+            id: cluster.id,
+            name: cluster.name,
+            visibility: cluster.visibility,
+            feeRecipientAddress: cluster.feeRecipientAddress,
+            ownerId: cluster.ownerId,
+            createdAt: cluster.createdAt.toISOString(),
+            validatorCount: cluster._count.validators,
+          })),
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'CLUSTER_LIST_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to list clusters',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+    });
+}

--- a/packages/api/src/routers/cluster/list.ts
+++ b/packages/api/src/routers/cluster/list.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { ClusterWithCountSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
@@ -10,7 +11,7 @@ import { ApiResponseSchema } from '@/utils/response.js';
  */
 export function createListClustersRoute(params: {
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/missed-attestations.ts
+++ b/packages/api/src/routers/cluster/missed-attestations.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   MissedAttestationsAllInputSchema,
   MissedAttestationsInputSchema,
@@ -6,58 +7,54 @@ import {
 } from './analytics-schemas.js';
 import { requireOwnedCluster } from './ownership.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { AnalyticsStorage } from '@/storage/analytics.js';
-import { ClusterStorage } from '@/storage/cluster.js';
-import { beaconTime, chainConfig } from '@/utils/beaconTime.js';
 import { ApiResponseSchema } from '@/utils/response.js';
-
-const clusterStorage = new ClusterStorage();
-const analyticsStorage = new AnalyticsStorage();
 
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Get validator indexes for a single cluster
+ * Loads validator indexes for one cluster.
  */
-async function getValidatorIndexesForCluster(clusterId: string): Promise<number[]> {
-  const cluster = await clusterStorage.findByIdWithValidators(clusterId);
-  if (!cluster) {
-    return [];
-  }
-  return cluster.validators.map((v) => v.validatorIndex);
+async function getValidatorIndexesForCluster(
+  params: { clusterStorage: any },
+  clusterId: string,
+): Promise<number[]> {
+  const cluster = await params.clusterStorage.findByIdWithValidators(clusterId);
+  return cluster ? cluster.validators.map((validator: any) => validator.validatorIndex) : [];
 }
 
 /**
- * Fetch missed attestations for a set of validators within a time range.
- * '1h' reads pre-computed data from the snapshot table (consistent with performance_h).
- * '24h' uses the validator_hourly_archive table (historical hourly data).
+ * Loads missed attestation rows for the requested range.
  */
 async function fetchMissedAttestations(
+  params: {
+    analyticsStorage: any;
+    beaconHelpers: any;
+    clusterStorage: any;
+  },
   validatorIndexes: number[],
   range: '1h' | '24h',
 ): Promise<Array<{ timestamp: string; count: number; validatorCount: number }>> {
   if (range === '1h') {
-    const rows = await analyticsStorage.getMissedAttestationsFromSnapshot(
+    const rows = await params.analyticsStorage.getMissedAttestationsFromSnapshot(
       validatorIndexes,
-      chainConfig.beacon.slotsPerEpoch,
+      params.beaconHelpers.chainConfig.beacon.slotsPerEpoch,
     );
 
-    return rows.map((row) => ({
-      timestamp: new Date(beaconTime.getTimestampFromEpochNumber(row.epoch)).toISOString(),
+    return rows.map((row: any) => ({
+      timestamp: new Date(
+        params.beaconHelpers.beaconTime.getTimestampFromEpochNumber(row.epoch),
+      ).toISOString(),
       count: Number(row.count),
       validatorCount: Number(row.validator_count),
     }));
   }
 
-  // 24h range
-  const fromTimestamp = new Date(Date.now() - TWENTY_FOUR_HOURS_MS);
-  const rows = await analyticsStorage.getMissedAttestationsFromArchive(
+  const rows = await params.analyticsStorage.getMissedAttestationsFromArchive(
     validatorIndexes,
-    fromTimestamp,
+    new Date(Date.now() - TWENTY_FOUR_HOURS_MS),
   );
 
-  return rows.map((row) => ({
+  return rows.map((row: any) => ({
     timestamp: row.timestamp.toISOString(),
     count: Number(row.count),
     validatorCount: Number(row.validator_count),
@@ -65,56 +62,96 @@ async function fetchMissedAttestations(
 }
 
 /**
- * GET /clusters/{id}/analytics/missed-attestations?range=1h|24h
- * Returns missed attestation data for a single cluster
+ * Creates the cluster missed-attestations route.
  */
-export const getClusterMissedAttestations = securedProcedure
-  .route({ method: 'GET', path: '/clusters/{id}/analytics/missed-attestations' })
-  .input(MissedAttestationsInputSchema)
-  .output(ApiResponseSchema(MissedAttestationsResponseSchema))
-  .handler(async ({ context, input }) => {
-    const ownershipError = await requireOwnedCluster(clusterStorage, input.id, context.user);
-    if (ownershipError) {
-      return ownershipError;
-    }
+export function createClusterMissedAttestationsRoute(params: {
+  analyticsStorage: any;
+  beaconHelpers: any;
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-    const validatorIndexes = await getValidatorIndexesForCluster(input.id);
-    const data = await fetchMissedAttestations(validatorIndexes, input.range);
-    return { success: true, data, meta: { timestamp: new Date().toISOString() } };
-  });
+  return securedProcedure
+    .route({ method: 'GET', path: '/clusters/{id}/analytics/missed-attestations' })
+    .input(MissedAttestationsInputSchema)
+    .output(ApiResponseSchema(MissedAttestationsResponseSchema))
+    .handler(async ({ context, input }: any) => {
+      const ownershipError = await requireOwnedCluster(
+        params.clusterStorage,
+        input.id,
+        context.user,
+      );
+      if (ownershipError) {
+        return ownershipError;
+      }
 
-/**
- * GET /clusters/all/analytics/missed-attestations?ownerId=X&range=1h|24h
- * Returns missed attestation data aggregated across all clusters for an owner
- */
-export const getAllClustersMissedAttestations = securedProcedure
-  .route({ method: 'GET', path: '/clusters/all/analytics/missed-attestations' })
-  .input(MissedAttestationsAllInputSchema)
-  .output(ApiResponseSchema(MissedAttestationsResponseSchema))
-  .handler(async ({ context, input }) => {
-    // Require a resolved user so missed attestation aggregation stays scoped to one owner.
-    if (!context.user) {
       return {
-        success: false,
-        error: { code: 'UNAUTHORIZED', message: 'User authentication required' },
+        success: true,
+        data: await fetchMissedAttestations(
+          params,
+          await getValidatorIndexesForCluster(params, input.id),
+          input.range,
+        ),
         meta: { timestamp: new Date().toISOString() },
       };
-    }
-
-    const validatorIndexes = await clusterStorage.findAllValidatorIndexesByOwner(context.user!.id);
-    const data = await fetchMissedAttestations(validatorIndexes, input.range);
-    return { success: true, data, meta: { timestamp: new Date().toISOString() } };
-  });
+    });
+}
 
 /**
- * GET /validators/{index}/analytics/missed-attestations?range=1h|24h
- * Returns missed attestation data for a single validator
+ * Creates the all-clusters missed-attestations route.
  */
-export const getValidatorMissedAttestations = securedProcedure
-  .route({ method: 'GET', path: '/validators/{index}/analytics/missed-attestations' })
-  .input(MissedAttestationsValidatorInputSchema)
-  .output(ApiResponseSchema(MissedAttestationsResponseSchema))
-  .handler(async ({ input }) => {
-    const data = await fetchMissedAttestations([input.index], input.range);
-    return { success: true, data, meta: { timestamp: new Date().toISOString() } };
-  });
+export function createAllClustersMissedAttestationsRoute(params: {
+  analyticsStorage: any;
+  beaconHelpers: any;
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
+
+  return securedProcedure
+    .route({ method: 'GET', path: '/clusters/all/analytics/missed-attestations' })
+    .input(MissedAttestationsAllInputSchema)
+    .output(ApiResponseSchema(MissedAttestationsResponseSchema))
+    .handler(async ({ context, input }: any) => {
+      if (!context.user) {
+        return {
+          success: false,
+          error: { code: 'UNAUTHORIZED', message: 'User authentication required' },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+
+      return {
+        success: true,
+        data: await fetchMissedAttestations(
+          params,
+          await params.clusterStorage.findAllValidatorIndexesByOwner(context.user.id),
+          input.range,
+        ),
+        meta: { timestamp: new Date().toISOString() },
+      };
+    });
+}
+
+/**
+ * Creates the validator missed-attestations route.
+ */
+export function createValidatorMissedAttestationsRoute(params: {
+  analyticsStorage: any;
+  beaconHelpers: any;
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
+
+  return securedProcedure
+    .route({ method: 'GET', path: '/validators/{index}/analytics/missed-attestations' })
+    .input(MissedAttestationsValidatorInputSchema)
+    .output(ApiResponseSchema(MissedAttestationsResponseSchema))
+    .handler(async ({ input }: any) => ({
+      success: true,
+      data: await fetchMissedAttestations(params, [input.index], input.range),
+      meta: { timestamp: new Date().toISOString() },
+    }));
+}

--- a/packages/api/src/routers/cluster/missed-attestations.ts
+++ b/packages/api/src/routers/cluster/missed-attestations.ts
@@ -7,6 +7,7 @@ import {
 } from './analytics-schemas.js';
 import { requireOwnedCluster } from './ownership.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
@@ -68,7 +69,7 @@ export function createClusterMissedAttestationsRoute(params: {
   analyticsStorage: any;
   beaconHelpers: any;
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 
@@ -105,7 +106,7 @@ export function createAllClustersMissedAttestationsRoute(params: {
   analyticsStorage: any;
   beaconHelpers: any;
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 
@@ -141,7 +142,7 @@ export function createValidatorMissedAttestationsRoute(params: {
   analyticsStorage: any;
   beaconHelpers: any;
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/removeValidators.ts
+++ b/packages/api/src/routers/cluster/removeValidators.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { requireOwnedCluster } from './ownership.js';
 import {
   ClusterIdParamSchema,
@@ -5,75 +6,80 @@ import {
   RemoveValidatorsResponseSchema,
 } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Remove validators from cluster
- * DELETE /clusters/:id/validators
- *
- * Accepts either:
- * - validatorIndexes: array of validator indexes to remove
- * - withdrawalAddress: removes all validators with this withdrawal address (case-insensitive)
+ * Creates the remove-validators route.
  */
-export const removeValidators = securedProcedure
-  .route({ method: 'DELETE', path: '/clusters/{id}/validators' })
-  .input(ClusterIdParamSchema.merge(RemoveValidatorsInputSchema))
-  .output(ApiResponseSchema(RemoveValidatorsResponseSchema))
-  .handler(async ({ context, input }) => {
-    try {
-      const storage = new ClusterStorage();
-      const ownershipError = await requireOwnedCluster(storage, input.id, context.user);
-      if (ownershipError) {
-        return ownershipError;
-      }
+export function createRemoveValidatorsRoute(params: {
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      // Validate that exactly one input type is provided
-      if (input.withdrawalAddress && input.validatorIndexes) {
-        return {
-          success: false,
-          error: {
-            code: 'INVALID_INPUT',
-            message: 'Only one of validatorIndexes or withdrawalAddress can be provided, not both',
-          },
-          meta: { timestamp: new Date().toISOString() },
-        };
-      }
-
-      let removed: number;
-
-      if (input.withdrawalAddress) {
-        // Remove all validators with this withdrawal address
-        removed = await storage.removeValidatorsByWithdrawalAddress(
+  return securedProcedure
+    .route({ method: 'DELETE', path: '/clusters/{id}/validators' })
+    .input(ClusterIdParamSchema.merge(RemoveValidatorsInputSchema))
+    .output(ApiResponseSchema(RemoveValidatorsResponseSchema))
+    .handler(async ({ context, input }: any) => {
+      try {
+        const ownershipError = await requireOwnedCluster(
+          params.clusterStorage,
           input.id,
-          input.withdrawalAddress,
+          context.user,
         );
-      } else if (input.validatorIndexes) {
-        // Remove specific validators by index
-        removed = await storage.removeValidatorsByIndexes(input.id, input.validatorIndexes);
-      } else {
+        if (ownershipError) {
+          return ownershipError;
+        }
+
+        if (input.withdrawalAddress && input.validatorIndexes) {
+          return {
+            success: false,
+            error: {
+              code: 'INVALID_INPUT',
+              message:
+                'Only one of validatorIndexes or withdrawalAddress can be provided, not both',
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+
+        let removed: number;
+        if (input.withdrawalAddress) {
+          removed = await params.clusterStorage.removeValidatorsByWithdrawalAddress(
+            input.id,
+            input.withdrawalAddress,
+          );
+        } else if (input.validatorIndexes) {
+          removed = await params.clusterStorage.removeValidatorsByIndexes(
+            input.id,
+            input.validatorIndexes,
+          );
+        } else {
+          return {
+            success: false,
+            error: {
+              code: 'INVALID_INPUT',
+              message: 'Either validatorIndexes or withdrawalAddress must be provided',
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+
+        return {
+          success: true,
+          data: { removed },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
         return {
           success: false,
           error: {
-            code: 'INVALID_INPUT',
-            message: 'Either validatorIndexes or withdrawalAddress must be provided',
+            code: 'CLUSTER_REMOVE_VALIDATORS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to remove validators',
           },
           meta: { timestamp: new Date().toISOString() },
         };
       }
-
-      return {
-        success: true,
-        data: { removed },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to remove validators';
-      return {
-        success: false,
-        error: { code: 'CLUSTER_REMOVE_VALIDATORS_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+    });
+}

--- a/packages/api/src/routers/cluster/removeValidators.ts
+++ b/packages/api/src/routers/cluster/removeValidators.ts
@@ -6,6 +6,7 @@ import {
   RemoveValidatorsResponseSchema,
 } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
@@ -13,7 +14,7 @@ import { ApiResponseSchema } from '@/utils/response.js';
  */
 export function createRemoveValidatorsRoute(params: {
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/rewards.ts
+++ b/packages/api/src/routers/cluster/rewards.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   AnalyticsAllClustersInputSchema,
   AnalyticsClusterInputSchema,
@@ -6,16 +7,10 @@ import {
 } from './analytics-schemas.js';
 import { requireOwnedCluster } from './ownership.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { AnalyticsStorage } from '@/storage/analytics.js';
-import { ClusterStorage } from '@/storage/cluster.js';
-import { beaconTime, chainConfig } from '@/utils/beaconTime.js';
+import type { ApiDependencies } from '@/dependencies.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance, formatWeiToToken } from '@/utils/tokenFormat.js';
 import { getTokenPrice } from '@/utils/tokenPrice.js';
-
-const clusterStorage = new ClusterStorage();
-const analyticsStorage = new AnalyticsStorage();
 
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 
@@ -34,27 +29,27 @@ type RewardItem = {
 };
 
 /**
- * Fetch rewards for a set of validators within a time range.
- * All CL rewards are returned in token units (GNO or ETH) via formatBalance.
- * Execution rewards are returned in native EL token (xDAI or ETH) via formatWeiToToken.
+ * Loads reward rows for the requested range.
  */
 async function fetchRewards(
+  deps: Pick<
+    ApiDependencies,
+    'analyticsStorage' | 'beaconHelpers' | 'clusterStorage' | 'chain' | 'nativeTokenDecimals'
+  >,
   validatorIndexes: number[],
   range: '1h' | '24h',
 ): Promise<RewardItem[]> {
   if (range === '1h') {
-    const currentEpoch = beaconTime.getEpochNumberFromTimestamp(Date.now());
-    const { slotsPerEpoch } = chainConfig.beacon;
-    const epochsPerHour = Math.ceil(
-      (60 * 60 * 1000) / (slotsPerEpoch * chainConfig.beacon.slotDuration),
-    );
+    const currentEpoch = deps.beaconHelpers.beaconTime.getEpochNumberFromTimestamp(Date.now());
+    const { slotDuration, slotsPerEpoch } = deps.beaconHelpers.chainConfig.beacon;
+    const epochsPerHour = Math.ceil((60 * 60 * 1000) / (slotsPerEpoch * slotDuration));
     const fromEpoch = currentEpoch - epochsPerHour;
     const fromSlot = fromEpoch * slotsPerEpoch;
 
     const [epochRows, syncRows, blockRows] = await Promise.all([
-      analyticsStorage.getRewardsFromEpochRewards(validatorIndexes, fromEpoch),
-      analyticsStorage.getSyncRewardsFromSlots(validatorIndexes, fromSlot, slotsPerEpoch),
-      analyticsStorage.getBlockRewardsFromSlots(validatorIndexes, fromSlot, slotsPerEpoch),
+      deps.analyticsStorage.getRewardsFromEpochRewards(validatorIndexes, fromEpoch),
+      deps.analyticsStorage.getSyncRewardsFromSlots(validatorIndexes, fromSlot, slotsPerEpoch),
+      deps.analyticsStorage.getBlockRewardsFromSlots(validatorIndexes, fromSlot, slotsPerEpoch),
     ]);
 
     const syncByEpoch = new Map<number, bigint>();
@@ -63,6 +58,7 @@ async function fetchRewards(
       syncByEpoch.set(row.epoch, row.sync_reward);
       syncMissedByEpoch.set(row.epoch, row.sync_missed);
     }
+
     const blockByEpoch = new Map<number, { consensus: bigint; execution: bigint }>();
     for (const row of blockRows) {
       blockByEpoch.set(row.epoch, {
@@ -71,139 +67,215 @@ async function fetchRewards(
       });
     }
 
-    const epochByEpoch = new Map(epochRows.map((r) => [r.epoch, r]));
-
+    const epochByEpoch = new Map(epochRows.map((row) => [row.epoch, row]));
     const allEpochs = new Set([
-      ...epochRows.map((r) => r.epoch),
-      ...syncRows.map((r) => r.epoch),
-      ...blockRows.map((r) => r.epoch),
+      ...epochRows.map((row) => row.epoch),
+      ...syncRows.map((row) => row.epoch),
+      ...blockRows.map((row) => row.epoch),
     ]);
 
     return Array.from(allEpochs)
-      .sort((a, b) => a - b)
+      .sort((left, right) => left - right)
       .map((epoch) => {
-        const er = epochByEpoch.get(epoch);
+        const epochReward = epochByEpoch.get(epoch);
         const syncReward = syncByEpoch.get(epoch) ?? BigInt(0);
         const syncMissed = syncMissedByEpoch.get(epoch) ?? BigInt(0);
         const block = blockByEpoch.get(epoch);
-        const timestamp = new Date(beaconTime.getTimestampFromEpochNumber(epoch)).toISOString();
 
         return {
-          timestamp,
-          head: formatBalance(er?.head),
-          target: formatBalance(er?.target),
-          source: formatBalance(er?.source),
-          inactivity: formatBalance(er?.inactivity),
-          sync: formatBalance(syncReward),
-          missed: formatBalance((er?.missed ?? BigInt(0)) + syncMissed),
-          clMissed: formatBalance(er?.missed),
-          syncMissed: formatBalance(syncMissed),
-          blockConsensus: formatBalance(block?.consensus),
-          // execution_reward is in wei of native EL token (xDAI/ETH)
-          blockExecution: formatWeiToToken(block?.execution ?? BigInt(0)),
+          timestamp: new Date(
+            deps.beaconHelpers.beaconTime.getTimestampFromEpochNumber(epoch),
+          ).toISOString(),
+          head: formatBalance(epochReward?.head, deps.chain),
+          target: formatBalance(epochReward?.target, deps.chain),
+          source: formatBalance(epochReward?.source, deps.chain),
+          inactivity: formatBalance(epochReward?.inactivity, deps.chain),
+          sync: formatBalance(syncReward, deps.chain),
+          missed: formatBalance((epochReward?.missed ?? BigInt(0)) + syncMissed, deps.chain),
+          clMissed: formatBalance(epochReward?.missed, deps.chain),
+          syncMissed: formatBalance(syncMissed, deps.chain),
+          blockConsensus: formatBalance(block?.consensus, deps.chain),
+          blockExecution: formatWeiToToken(block?.execution ?? BigInt(0), deps.nativeTokenDecimals),
         };
       });
   }
 
-  // 24h range — use archive aggregate columns
-  const fromTimestamp = new Date(Date.now() - TWENTY_FOUR_HOURS_MS);
-  const rows = await analyticsStorage.getRewardsFromArchive(validatorIndexes, fromTimestamp);
+  const rows = await deps.analyticsStorage.getRewardsFromArchive(
+    validatorIndexes,
+    new Date(Date.now() - TWENTY_FOUR_HOURS_MS),
+  );
 
   return rows.map((row) => ({
     timestamp: row.timestamp.toISOString(),
-    // Archive has aggregate CL reward (head+target+source+inactivity combined)
     head: '0',
     target: '0',
-    source: formatBalance(row.cl_reward),
+    source: formatBalance(row.cl_reward, deps.chain),
     inactivity: '0',
-    sync: formatBalance(row.sync_reward),
-    missed: formatBalance(row.cl_missed + row.sync_missed),
-    clMissed: formatBalance(row.cl_missed),
-    syncMissed: formatBalance(row.sync_missed),
-    blockConsensus: formatBalance(row.block_reward),
-    blockExecution: formatWeiToToken(row.exec_reward ?? BigInt(0)),
+    sync: formatBalance(row.sync_reward, deps.chain),
+    missed: formatBalance(row.cl_missed + row.sync_missed, deps.chain),
+    clMissed: formatBalance(row.cl_missed, deps.chain),
+    syncMissed: formatBalance(row.sync_missed, deps.chain),
+    blockConsensus: formatBalance(row.block_reward, deps.chain),
+    blockExecution: formatWeiToToken(row.exec_reward ?? BigInt(0), deps.nativeTokenDecimals),
   }));
 }
 
 /**
- * GET /clusters/{id}/analytics/rewards?range=1h|24h
+ * Creates the cluster rewards route.
  */
-export const getClusterRewards = securedProcedure
-  .route({ method: 'GET', path: '/clusters/{id}/analytics/rewards' })
-  .input(AnalyticsClusterInputSchema)
-  .output(ApiResponseSchema(RewardsResponseSchema))
-  .handler(async ({ context, input }) => {
-    const ownershipError = await requireOwnedCluster(clusterStorage, input.id, context.user);
-    if (ownershipError) {
-      return ownershipError;
-    }
+export function createClusterRewardsRoute(
+  deps: Pick<
+    ApiDependencies,
+    | 'analyticsStorage'
+    | 'beaconHelpers'
+    | 'clusterStorage'
+    | 'procedures'
+    | 'chain'
+    | 'logger'
+    | 'nativeTokenDecimals'
+    | 'tokenPriceApiUrl'
+    | 'tokenPriceTokenName'
+  >,
+) {
+  const { securedProcedure } = deps.procedures;
 
-    const cluster = await clusterStorage.findByIdWithValidators(input.id);
-    const validatorIndexes = cluster ? cluster.validators.map((v) => v.validatorIndex) : [];
-    const items = await fetchRewards(validatorIndexes, input.range);
-    let tokenPrice = 0;
-    try {
-      tokenPrice = await getTokenPrice();
-    } catch {
-      // tokenPrice stays 0 if fetch fails
-    }
-    return {
-      success: true,
-      data: { items, tokenPrice },
-      meta: { timestamp: new Date().toISOString() },
-    };
-  });
+  return securedProcedure
+    .route({ method: 'GET', path: '/clusters/{id}/analytics/rewards' })
+    .input(AnalyticsClusterInputSchema)
+    .output(ApiResponseSchema(RewardsResponseSchema))
+    .handler(async ({ context, input }: any) => {
+      const ownershipError = await requireOwnedCluster(deps.clusterStorage, input.id, context.user);
+      if (ownershipError) {
+        return ownershipError;
+      }
 
-/**
- * GET /clusters/all/analytics/rewards?ownerId=X&range=1h|24h
- */
-export const getAllClustersRewards = securedProcedure
-  .route({ method: 'GET', path: '/clusters/all/analytics/rewards' })
-  .input(AnalyticsAllClustersInputSchema)
-  .output(ApiResponseSchema(RewardsResponseSchema))
-  .handler(async ({ context, input }) => {
-    // Require a resolved user so reward aggregation stays scoped to one owner.
-    if (!context.user) {
+      const cluster = await deps.clusterStorage.findByIdWithValidators(input.id);
+      const validatorIndexes = cluster
+        ? cluster.validators.map((validator) => validator.validatorIndex)
+        : [];
+
+      let tokenPrice = 0;
+      try {
+        tokenPrice = await getTokenPrice(
+          deps.tokenPriceApiUrl,
+          deps.tokenPriceTokenName,
+          deps.logger,
+        );
+      } catch {
+        // Leaves price at zero when the remote source fails.
+      }
+
       return {
-        success: false,
-        error: { code: 'UNAUTHORIZED', message: 'User authentication required' },
+        success: true,
+        data: {
+          items: await fetchRewards(deps, validatorIndexes, input.range),
+          tokenPrice,
+        },
         meta: { timestamp: new Date().toISOString() },
       };
-    }
-
-    const validatorIndexes = await clusterStorage.findAllValidatorIndexesByOwner(context.user!.id);
-    const items = await fetchRewards(validatorIndexes, input.range);
-    let tokenPrice = 0;
-    try {
-      tokenPrice = await getTokenPrice();
-    } catch {
-      // tokenPrice stays 0 if fetch fails
-    }
-    return {
-      success: true,
-      data: { items, tokenPrice },
-      meta: { timestamp: new Date().toISOString() },
-    };
-  });
+    });
+}
 
 /**
- * GET /validators/{index}/analytics/rewards?range=1h|24h
+ * Creates the all-clusters rewards route.
  */
-export const getValidatorRewards = securedProcedure
-  .route({ method: 'GET', path: '/validators/{index}/analytics/rewards' })
-  .input(AnalyticsValidatorInputSchema)
-  .output(ApiResponseSchema(RewardsResponseSchema))
-  .handler(async ({ input }) => {
-    const items = await fetchRewards([input.index], input.range);
-    let tokenPrice = 0;
-    try {
-      tokenPrice = await getTokenPrice();
-    } catch {
-      // tokenPrice stays 0 if fetch fails
-    }
-    return {
-      success: true,
-      data: { items, tokenPrice },
-      meta: { timestamp: new Date().toISOString() },
-    };
-  });
+export function createAllClustersRewardsRoute(
+  deps: Pick<
+    ApiDependencies,
+    | 'analyticsStorage'
+    | 'beaconHelpers'
+    | 'clusterStorage'
+    | 'procedures'
+    | 'chain'
+    | 'logger'
+    | 'nativeTokenDecimals'
+    | 'tokenPriceApiUrl'
+    | 'tokenPriceTokenName'
+  >,
+) {
+  const { securedProcedure } = deps.procedures;
+
+  return securedProcedure
+    .route({ method: 'GET', path: '/clusters/all/analytics/rewards' })
+    .input(AnalyticsAllClustersInputSchema)
+    .output(ApiResponseSchema(RewardsResponseSchema))
+    .handler(async ({ context, input }: any) => {
+      if (!context.user) {
+        return {
+          success: false,
+          error: { code: 'UNAUTHORIZED', message: 'User authentication required' },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+
+      let tokenPrice = 0;
+      try {
+        tokenPrice = await getTokenPrice(
+          deps.tokenPriceApiUrl,
+          deps.tokenPriceTokenName,
+          deps.logger,
+        );
+      } catch {
+        // Leaves price at zero when the remote source fails.
+      }
+
+      return {
+        success: true,
+        data: {
+          items: await fetchRewards(
+            deps,
+            await deps.clusterStorage.findAllValidatorIndexesByOwner(context.user.id),
+            input.range,
+          ),
+          tokenPrice,
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    });
+}
+
+/**
+ * Creates the validator rewards route.
+ */
+export function createValidatorRewardsRoute(
+  deps: Pick<
+    ApiDependencies,
+    | 'analyticsStorage'
+    | 'beaconHelpers'
+    | 'clusterStorage'
+    | 'procedures'
+    | 'chain'
+    | 'logger'
+    | 'nativeTokenDecimals'
+    | 'tokenPriceApiUrl'
+    | 'tokenPriceTokenName'
+  >,
+) {
+  const { securedProcedure } = deps.procedures;
+
+  return securedProcedure
+    .route({ method: 'GET', path: '/validators/{index}/analytics/rewards' })
+    .input(AnalyticsValidatorInputSchema)
+    .output(ApiResponseSchema(RewardsResponseSchema))
+    .handler(async ({ input }: any) => {
+      let tokenPrice = 0;
+      try {
+        tokenPrice = await getTokenPrice(
+          deps.tokenPriceApiUrl,
+          deps.tokenPriceTokenName,
+          deps.logger,
+        );
+      } catch {
+        // Leaves price at zero when the remote source fails.
+      }
+
+      return {
+        success: true,
+        data: {
+          items: await fetchRewards(deps, [input.index], input.range),
+          tokenPrice,
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    });
+}

--- a/packages/api/src/routers/cluster/snapshot.ts
+++ b/packages/api/src/routers/cluster/snapshot.ts
@@ -2,6 +2,7 @@
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterIdParamSchema, ClusterSnapshotSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance, formatWeiToToken } from '@/utils/tokenFormat.js';
 import { getTokenPrice } from '@/utils/tokenPrice.js';
@@ -14,7 +15,7 @@ export function createClusterSnapshotRoute(params: {
   clusterStorage: any;
   logger: import('@/lib/logger.js').Logger;
   nativeTokenDecimals: number;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
   tokenPriceApiUrl: string;
   tokenPriceTokenName: string;
 }) {

--- a/packages/api/src/routers/cluster/snapshot.ts
+++ b/packages/api/src/routers/cluster/snapshot.ts
@@ -1,106 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterIdParamSchema, ClusterSnapshotSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance, formatWeiToToken } from '@/utils/tokenFormat.js';
 import { getTokenPrice } from '@/utils/tokenPrice.js';
 
 /**
- * Get cluster snapshot with aggregated performance metrics
- * GET /clusters/:id/snapshot
+ * Creates the cluster snapshot route.
  */
-export const getClusterSnapshot = securedProcedure
-  .route({ method: 'GET', path: '/clusters/{id}/snapshot' })
-  .input(ClusterIdParamSchema)
-  .output(ApiResponseSchema(ClusterSnapshotSchema))
-  .handler(async ({ context, input }) => {
-    try {
-      const storage = new ClusterStorage();
-      const ownershipError = await requireOwnedCluster(storage, input.id, context.user);
-      if (ownershipError) {
-        return ownershipError;
-      }
+export function createClusterSnapshotRoute(params: {
+  chain: 'ethereum' | 'gnosis';
+  clusterStorage: any;
+  logger: import('@/lib/logger.js').Logger;
+  nativeTokenDecimals: number;
+  procedures: { securedProcedure: any };
+  tokenPriceApiUrl: string;
+  tokenPriceTokenName: string;
+}) {
+  const { securedProcedure } = params.procedures;
 
-      const row = await storage.getClusterSnapshot(input.id);
+  return securedProcedure
+    .route({ method: 'GET', path: '/clusters/{id}/snapshot' })
+    .input(ClusterIdParamSchema)
+    .output(ApiResponseSchema(ClusterSnapshotSchema))
+    .handler(async ({ context, input }: any) => {
+      try {
+        const ownershipError = await requireOwnedCluster(
+          params.clusterStorage,
+          input.id,
+          context.user,
+        );
+        if (ownershipError) {
+          return ownershipError;
+        }
 
-      if (!row) {
+        const row = await params.clusterStorage.getClusterSnapshot(input.id);
+        if (!row) {
+          return {
+            success: false,
+            error: {
+              code: 'SNAPSHOT_NOT_FOUND',
+              message: `No snapshot data for cluster ${input.id}`,
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
+        }
+
+        let tokenPrice = 0;
+        try {
+          tokenPrice = await getTokenPrice(
+            params.tokenPriceApiUrl,
+            params.tokenPriceTokenName,
+            params.logger,
+          );
+        } catch {
+          // Keeps the route working when the price feed is temporarily unavailable.
+        }
+
+        const toNum = (value: string | null) => (value !== null ? Number(value) : null);
+        const toBigStr = (value: bigint | null) =>
+          value !== null ? formatBalance(value, params.chain) : null;
+        const toExecReward = (value: string | null) =>
+          value !== null
+            ? { wei: value, token: formatWeiToToken(value, params.nativeTokenDecimals) }
+            : null;
+
+        return {
+          success: true,
+          data: {
+            activeCount: Number(row.active_count),
+            inactiveCount: Number(row.inactive_count),
+            statusBreakdown: JSON.parse(row.beacon_status_breakdown),
+            totalBalance: formatBalance(row.total_balance ?? BigInt(0), params.chain),
+            totalEffectiveBalance: formatBalance(
+              row.total_effective_balance ?? BigInt(0),
+              params.chain,
+            ),
+            performanceH: toNum(row.performance_h),
+            performanceD: toNum(row.performance_d),
+            performanceW: toNum(row.performance_w),
+            performanceM: toNum(row.performance_m),
+            apyH: toNum(row.apy_h),
+            apyD: toNum(row.apy_d),
+            apyW: toNum(row.apy_w),
+            apyM: toNum(row.apy_m),
+            consensusRewardH: toBigStr(row.consensus_reward_h),
+            consensusRewardD: toBigStr(row.consensus_reward_d),
+            consensusRewardW: toBigStr(row.consensus_reward_w),
+            consensusRewardM: toBigStr(row.consensus_reward_m),
+            missedRewardH: toBigStr(row.missed_reward_h),
+            missedRewardD: toBigStr(row.missed_reward_d),
+            missedRewardW: toBigStr(row.missed_reward_w),
+            missedRewardM: toBigStr(row.missed_reward_m),
+            executionRewardH: toExecReward(row.execution_reward_h),
+            executionRewardD: toExecReward(row.execution_reward_d),
+            executionRewardW: toExecReward(row.execution_reward_w),
+            executionRewardM: toExecReward(row.execution_reward_m),
+            attestationEfficiencyD: toNum(row.attestation_efficiency_d),
+            attestationEfficiencyW: toNum(row.attestation_efficiency_w),
+            attestationEfficiencyM: toNum(row.attestation_efficiency_m),
+            avgAttestationDelayD: toNum(row.avg_attestation_delay_d),
+            avgAttestationDelayW: toNum(row.avg_attestation_delay_w),
+            avgAttestationDelayM: toNum(row.avg_attestation_delay_m),
+            tokenPrice,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
         return {
           success: false,
           error: {
-            code: 'SNAPSHOT_NOT_FOUND',
-            message: `No snapshot data for cluster ${input.id}`,
+            code: 'SNAPSHOT_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to get cluster snapshot',
           },
           meta: { timestamp: new Date().toISOString() },
         };
       }
-
-      let tokenPrice = 0;
-      try {
-        tokenPrice = await getTokenPrice();
-      } catch {
-        // tokenPrice stays 0 if fetch fails
-      }
-
-      const toNum = (v: string | null) => (v !== null ? Number(v) : null);
-      const toBigStr = (v: bigint | null) => (v !== null ? formatBalance(v) : null);
-      const toExecReward = (v: string | null) =>
-        v !== null ? { wei: v, token: formatWeiToToken(v) } : null;
-
-      return {
-        success: true,
-        data: {
-          activeCount: Number(row.active_count),
-          inactiveCount: Number(row.inactive_count),
-          statusBreakdown: JSON.parse(row.beacon_status_breakdown),
-
-          totalBalance: formatBalance(row.total_balance ?? BigInt(0)),
-          totalEffectiveBalance: formatBalance(row.total_effective_balance ?? BigInt(0)),
-
-          performanceH: toNum(row.performance_h),
-          performanceD: toNum(row.performance_d),
-          performanceW: toNum(row.performance_w),
-          performanceM: toNum(row.performance_m),
-
-          apyH: toNum(row.apy_h),
-          apyD: toNum(row.apy_d),
-          apyW: toNum(row.apy_w),
-          apyM: toNum(row.apy_m),
-
-          consensusRewardH: toBigStr(row.consensus_reward_h),
-          consensusRewardD: toBigStr(row.consensus_reward_d),
-          consensusRewardW: toBigStr(row.consensus_reward_w),
-          consensusRewardM: toBigStr(row.consensus_reward_m),
-
-          missedRewardH: toBigStr(row.missed_reward_h),
-          missedRewardD: toBigStr(row.missed_reward_d),
-          missedRewardW: toBigStr(row.missed_reward_w),
-          missedRewardM: toBigStr(row.missed_reward_m),
-
-          executionRewardH: toExecReward(row.execution_reward_h),
-          executionRewardD: toExecReward(row.execution_reward_d),
-          executionRewardW: toExecReward(row.execution_reward_w),
-          executionRewardM: toExecReward(row.execution_reward_m),
-
-          attestationEfficiencyD: toNum(row.attestation_efficiency_d),
-          attestationEfficiencyW: toNum(row.attestation_efficiency_w),
-          attestationEfficiencyM: toNum(row.attestation_efficiency_m),
-
-          avgAttestationDelayD: toNum(row.avg_attestation_delay_d),
-          avgAttestationDelayW: toNum(row.avg_attestation_delay_w),
-          avgAttestationDelayM: toNum(row.avg_attestation_delay_m),
-
-          tokenPrice,
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to get cluster snapshot';
-      return {
-        success: false,
-        error: { code: 'SNAPSHOT_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+    });
+}

--- a/packages/api/src/routers/cluster/summary.ts
+++ b/packages/api/src/routers/cluster/summary.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { ClusterSummarySchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
 const ClusterSummaryResponseSchema = ApiResponseSchema(ClusterSummarySchema);
@@ -13,7 +14,7 @@ type ClusterSummaryResponse = z.infer<typeof ClusterSummaryResponseSchema>;
  */
 export function createClusterSummaryRoute(params: {
   clusterStorage: any;
-  procedures: { apiKeyProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { apiKeyProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/summary.ts
+++ b/packages/api/src/routers/cluster/summary.ts
@@ -1,31 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import { ClusterSummarySchema } from './schemas.js';
 
-import { apiKeyProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
 const ClusterSummaryResponseSchema = ApiResponseSchema(ClusterSummarySchema);
 type ClusterSummaryResponse = z.infer<typeof ClusterSummaryResponseSchema>;
 
 /**
- * Returns a cross-user summary of clusters and validator counts.
- * GET /clusters/summary
+ * Creates the cluster summary route.
  */
-export const getClusterSummary = apiKeyProcedure
-  .route({ method: 'GET', path: '/clusters/summary' })
-  .output(ClusterSummaryResponseSchema)
-  .handler(async () => {
-    try {
-      const storage = new ClusterStorage();
-      const summary = await storage.getSummary();
+export function createClusterSummaryRoute(params: {
+  clusterStorage: any;
+  procedures: { apiKeyProcedure: any };
+}) {
+  const { apiKeyProcedure } = params.procedures;
 
-      return successResponse(summary) as ClusterSummaryResponse;
-    } catch (error) {
-      return errorResponse(
-        'CLUSTER_SUMMARY_ERROR',
-        error instanceof Error ? error.message : 'Failed to get cluster summary',
-      ) as ClusterSummaryResponse;
-    }
-  });
+  return apiKeyProcedure
+    .route({ method: 'GET', path: '/clusters/summary' })
+    .output(ClusterSummaryResponseSchema)
+    .handler(async () => {
+      try {
+        return successResponse(await params.clusterStorage.getSummary()) as ClusterSummaryResponse;
+      } catch (error) {
+        return errorResponse(
+          'CLUSTER_SUMMARY_ERROR',
+          error instanceof Error ? error.message : 'Failed to get cluster summary',
+        ) as ClusterSummaryResponse;
+      }
+    });
+}

--- a/packages/api/src/routers/cluster/update.ts
+++ b/packages/api/src/routers/cluster/update.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterIdParamSchema, ClusterSchema, UpdateClusterInputSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
@@ -11,7 +12,7 @@ import { ApiResponseSchema } from '@/utils/response.js';
  */
 export function createUpdateClusterRoute(params: {
   clusterStorage: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/cluster/update.ts
+++ b/packages/api/src/routers/cluster/update.ts
@@ -1,73 +1,85 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import { requireOwnedCluster } from './ownership.js';
 import { ClusterIdParamSchema, ClusterSchema, UpdateClusterInputSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ClusterStorage } from '@/storage/cluster.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Update cluster
- * PUT /clusters/:id
+ * Creates the cluster update route.
  */
-export const updateCluster = securedProcedure
-  .route({ method: 'PUT', path: '/clusters/{id}' })
-  .input(ClusterIdParamSchema.merge(UpdateClusterInputSchema))
-  .output(ApiResponseSchema(ClusterSchema))
-  .handler(async ({ context, input }) => {
-    try {
-      const storage = new ClusterStorage();
-      const ownershipError = await requireOwnedCluster(storage, input.id, context.user);
-      if (ownershipError) {
-        return ownershipError;
-      }
+export function createUpdateClusterRoute(params: {
+  clusterStorage: any;
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      // Build update data (only include provided fields)
-      const updateData: z.infer<typeof UpdateClusterInputSchema> = {};
-      if (input.name !== undefined) updateData.name = input.name;
-      if (input.visibility !== undefined) updateData.visibility = input.visibility;
-      if (input.feeRecipientAddress !== undefined)
-        updateData.feeRecipientAddress = input.feeRecipientAddress;
-      if (input.validatorIndexes !== undefined) {
-        // Verifies the full saved validator set before applying the transactional sync.
-        const { notFound } = await storage.verifyValidatorIndexes(input.validatorIndexes);
-
-        if (notFound.length > 0) {
-          return {
-            success: false,
-            error: {
-              code: 'VALIDATORS_NOT_FOUND',
-              message: `Validators not found: ${notFound.join(', ')}`,
-            },
-            meta: { timestamp: new Date().toISOString() },
-          };
+  return securedProcedure
+    .route({ method: 'PUT', path: '/clusters/{id}' })
+    .input(ClusterIdParamSchema.merge(UpdateClusterInputSchema))
+    .output(ApiResponseSchema(ClusterSchema))
+    .handler(async ({ context, input }: any) => {
+      try {
+        const ownershipError = await requireOwnedCluster(
+          params.clusterStorage,
+          input.id,
+          context.user,
+        );
+        if (ownershipError) {
+          return ownershipError;
         }
+
+        const updateData: z.infer<typeof UpdateClusterInputSchema> = {};
+        if (input.name !== undefined) updateData.name = input.name;
+        if (input.visibility !== undefined) updateData.visibility = input.visibility;
+        if (input.feeRecipientAddress !== undefined) {
+          updateData.feeRecipientAddress = input.feeRecipientAddress;
+        }
+
+        if (input.validatorIndexes !== undefined) {
+          const { notFound } = await params.clusterStorage.verifyValidatorIndexes(
+            input.validatorIndexes,
+          );
+
+          if (notFound.length > 0) {
+            return {
+              success: false,
+              error: {
+                code: 'VALIDATORS_NOT_FOUND',
+                message: `Validators not found: ${notFound.join(', ')}`,
+              },
+              meta: { timestamp: new Date().toISOString() },
+            };
+          }
+        }
+
+        const cluster = await params.clusterStorage.updateWithValidators(input.id, {
+          ...updateData,
+          validatorIndexes: input.validatorIndexes,
+        });
+
+        return {
+          success: true,
+          data: {
+            id: cluster.id,
+            name: cluster.name,
+            visibility: cluster.visibility,
+            feeRecipientAddress: cluster.feeRecipientAddress,
+            ownerId: cluster.ownerId,
+            createdAt: cluster.createdAt.toISOString(),
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'CLUSTER_UPDATE_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to update cluster',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
       }
-
-      const cluster = await storage.updateWithValidators(input.id, {
-        ...updateData,
-        validatorIndexes: input.validatorIndexes,
-      });
-
-      return {
-        success: true,
-        data: {
-          id: cluster.id,
-          name: cluster.name,
-          visibility: cluster.visibility,
-          feeRecipientAddress: cluster.feeRecipientAddress,
-          ownerId: cluster.ownerId,
-          createdAt: cluster.createdAt.toISOString(),
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to update cluster';
-      return {
-        success: false,
-        error: { code: 'CLUSTER_UPDATE_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+    });
+}

--- a/packages/api/src/routers/health.ts
+++ b/packages/api/src/routers/health.ts
@@ -1,7 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
-import { getPrisma } from '@/lib/prisma.js';
-import { publicProcedure } from '@/lib/procedures.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 const HealthResponseSchema = ApiResponseSchema(
@@ -18,49 +17,49 @@ const HealthResponseSchema = ApiResponseSchema(
 );
 
 /**
- * Health check endpoint
- * Public endpoint - no authentication required
+ * Creates the health router.
  */
-export const healthCheck = publicProcedure
-  .route({ method: 'GET', path: '/health/check' })
-  .output(HealthResponseSchema)
-  .handler(async () => {
-    const prisma = getPrisma();
-    const startTime = Date.now();
+export function createHealthRouter(params: {
+  prisma: { $queryRaw: typeof import('@beacon-indexer/db').PrismaClient.prototype.$queryRaw };
+  procedures: { publicProcedure: any };
+}) {
+  const { publicProcedure } = params.procedures;
 
-    let dbStatus: 'connected' | 'disconnected' = 'disconnected';
-    let dbLatency: number | undefined;
+  const healthCheck = publicProcedure
+    .route({ method: 'GET', path: '/health/check' })
+    .output(HealthResponseSchema)
+    .handler(async () => {
+      const startTime = Date.now();
+      let dbStatus: 'connected' | 'disconnected' = 'disconnected';
+      let dbLatency: number | undefined;
 
-    try {
-      // Simple database health check
-      await prisma.$queryRaw`SELECT 1`;
-      dbStatus = 'connected';
-      dbLatency = Date.now() - startTime;
-    } catch (error) {
-      console.error(`Database health check failed: ${error}`);
-      dbStatus = 'disconnected';
-    }
+      try {
+        await params.prisma.$queryRaw`SELECT 1`;
+        dbStatus = 'connected';
+        dbLatency = Date.now() - startTime;
+      } catch (error) {
+        console.error(`Database health check failed: ${error}`);
+      }
 
-    const overallStatus = dbStatus === 'connected' ? 'healthy' : 'unhealthy';
-
-    return {
-      success: true,
-      data: {
-        status: overallStatus,
-        timestamp: new Date().toISOString(),
-        services: {
-          database: {
-            status: dbStatus,
-            latencyMs: dbLatency,
+      return {
+        success: true,
+        data: {
+          status: dbStatus === 'connected' ? 'healthy' : 'unhealthy',
+          timestamp: new Date().toISOString(),
+          services: {
+            database: {
+              status: dbStatus,
+              latencyMs: dbLatency,
+            },
           },
         },
-      },
-      meta: {
-        timestamp: new Date().toISOString(),
-      },
-    };
-  });
+        meta: {
+          timestamp: new Date().toISOString(),
+        },
+      };
+    });
 
-export const healthRouter = {
-  check: healthCheck,
-};
+  return {
+    check: healthCheck,
+  };
+}

--- a/packages/api/src/routers/health.ts
+++ b/packages/api/src/routers/health.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 const HealthResponseSchema = ApiResponseSchema(
@@ -21,7 +22,7 @@ const HealthResponseSchema = ApiResponseSchema(
  */
 export function createHealthRouter(params: {
   prisma: { $queryRaw: typeof import('@beacon-indexer/db').PrismaClient.prototype.$queryRaw };
-  procedures: { publicProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { publicProcedure } = params.procedures;
 

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -9,6 +9,9 @@ import { createUtilsRouter } from './utils.js';
 import { createValidatorRouter } from './validator/index.js';
 import type { ApiDependencies } from '@/dependencies.js';
 
+export type Router = ReturnType<typeof createRouter>;
+export declare const router: Router;
+
 /**
  * Creates the top-level API router tree.
  */

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -1,21 +1,27 @@
-import { blocksRouter } from './blocks/index.js';
-import { botRouter } from './bot/index.js';
-import { chainRouter } from './chain.js';
-import { clusterRouter } from './cluster/index.js';
-import { healthRouter } from './health.js';
-import { indexerRouter } from './indexer/index.js';
-import { userRouter } from './user/index.js';
-import { utilsRouter } from './utils.js';
-import { validatorRouter } from './validator/index.js';
+import { createBlocksRouter } from './blocks/index.js';
+import { createBotRouter } from './bot/index.js';
+import { createChainRouter } from './chain.js';
+import { createClusterRouter } from './cluster/index.js';
+import { createHealthRouter } from './health.js';
+import { createIndexerRouter } from './indexer/index.js';
+import { createUserRouter } from './user/index.js';
+import { createUtilsRouter } from './utils.js';
+import { createValidatorRouter } from './validator/index.js';
+import type { ApiDependencies } from '@/dependencies.js';
 
-export const router = {
-  blocks: blocksRouter,
-  bot: botRouter,
-  chain: chainRouter,
-  cluster: clusterRouter,
-  health: healthRouter,
-  indexer: indexerRouter,
-  user: userRouter,
-  utils: utilsRouter,
-  validator: validatorRouter,
-};
+/**
+ * Creates the top-level API router tree.
+ */
+export function createRouter(deps: ApiDependencies) {
+  return {
+    blocks: createBlocksRouter(deps),
+    bot: createBotRouter(deps),
+    chain: createChainRouter(deps),
+    cluster: createClusterRouter(deps),
+    health: createHealthRouter(deps),
+    indexer: createIndexerRouter(deps),
+    user: createUserRouter(deps),
+    utils: createUtilsRouter(deps),
+    validator: createValidatorRouter(deps),
+  };
+}

--- a/packages/api/src/routers/indexer/index.ts
+++ b/packages/api/src/routers/indexer/index.ts
@@ -1,5 +1,10 @@
-import { getStatus } from './status.js';
+import { createIndexerStatusRoute } from './status.js';
 
-export const indexerRouter = {
-  status: getStatus,
-};
+/**
+ * Creates the indexer router.
+ */
+export function createIndexerRouter(params: Parameters<typeof createIndexerStatusRoute>[0]) {
+  return {
+    status: createIndexerStatusRoute(params),
+  };
+}

--- a/packages/api/src/routers/indexer/status.ts
+++ b/packages/api/src/routers/indexer/status.ts
@@ -1,112 +1,109 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { format } from 'date-fns';
 
 import { IndexerStatusSchema } from './schemas.js';
 
-import { SystemConfigController } from '@/controllers/systemConfig.js';
-import { getPrisma } from '@/lib/prisma.js';
-import { securedProcedure } from '@/lib/procedures.js';
-import { beaconTime, chainConfig } from '@/utils/beaconTime.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Format milliseconds to hh:mm:ss format using date-fns format
- * @param ms - Milliseconds to format
- * @returns Formatted string in hh:mm:ss format
+ * Formats a lag duration for the API response.
  */
 function formatTimeDistance(ms: number): string {
-  const durationDate = new Date(ms);
-  return format(durationDate, 'HH:mm:ss');
+  return format(new Date(ms), 'HH:mm:ss');
 }
 
 /**
- * Format timestamp to yyyy-MM-dd HH:mm:ss format using date-fns
- * @param timestamp - Timestamp in milliseconds
- * @returns Formatted string in yyyy-MM-dd HH:mm:ss format
+ * Formats a slot timestamp for the API response.
  */
 function formatTimestamp(timestamp: number): string {
-  const date = new Date(timestamp);
-  return format(date, 'yyyy-MM-dd HH:mm:ss');
+  return format(new Date(timestamp), 'yyyy-MM-dd HH:mm:ss');
 }
 
 /**
- * Get indexer status
- * Returns information about the current state of the indexer
+ * Creates the indexer status route.
  */
-export const getStatus = securedProcedure
-  .route({ method: 'GET', path: '/indexer/status' })
-  .output(ApiResponseSchema(IndexerStatusSchema))
-  .handler(async () => {
-    const prisma = getPrisma();
-    const systemConfigController = new SystemConfigController();
-
-    // Get current chain state
-    const now = Date.now();
-    const currentSlot = beaconTime.getSlotNumberFromTimestamp(now);
-
-    // Get last processed epoch
-    const lastProcessedEpochRecord = await prisma.epoch.findFirst({
-      where: { processed: true },
-      orderBy: { epoch: 'desc' },
-      select: { epoch: true },
-    });
-
-    // Get last processed slot
-    const lastProcessedSlotRecord = await prisma.slot.findFirst({
-      where: { processed: true },
-      orderBy: { slot: 'desc' },
-      select: { slot: true },
-    });
-
-    // Get system configuration data
-    const [archive, indexerConfig] = await Promise.all([
-      systemConfigController.getArchive(),
-      systemConfigController.getIndexerConfig(),
-    ]);
-
-    // Calculate distance to head
-    let distanceToHead = {
-      headSlot: currentSlot,
-      lagSlots: 0,
-      lagTimeMs: 0,
-      lagTimeFormatted: '00:00:00',
+export function createIndexerStatusRoute(params: {
+  beaconHelpers: {
+    beaconTime: {
+      getSlotNumberFromTimestamp: (timestamp: number) => number;
+      getTimestampFromSlotNumber: (slot: number) => number;
     };
+    chainConfig: { beacon: { slotDuration: number } };
+  };
+  prisma: any;
+  procedures: { securedProcedure: any };
+  systemConfigController: {
+    getArchive: () => Promise<any>;
+    getIndexerConfig: () => Promise<any>;
+  };
+}) {
+  const { securedProcedure } = params.procedures;
 
-    if (lastProcessedSlotRecord) {
-      const slotLag = currentSlot - lastProcessedSlotRecord.slot;
-      const timeLagMs = slotLag * chainConfig.beacon.slotDuration;
-      distanceToHead = {
+  return securedProcedure
+    .route({ method: 'GET', path: '/indexer/status' })
+    .output(ApiResponseSchema(IndexerStatusSchema))
+    .handler(async () => {
+      const now = Date.now();
+      const currentSlot = params.beaconHelpers.beaconTime.getSlotNumberFromTimestamp(now);
+
+      const lastProcessedEpochRecord = await params.prisma.epoch.findFirst({
+        where: { processed: true },
+        orderBy: { epoch: 'desc' },
+        select: { epoch: true },
+      });
+
+      const lastProcessedSlotRecord = await params.prisma.slot.findFirst({
+        where: { processed: true },
+        orderBy: { slot: 'desc' },
+        select: { slot: true },
+      });
+
+      const [archive, indexerConfig] = await Promise.all([
+        params.systemConfigController.getArchive(),
+        params.systemConfigController.getIndexerConfig(),
+      ]);
+
+      let distanceToHead = {
         headSlot: currentSlot,
-        lagSlots: slotLag,
-        lagTimeMs: timeLagMs,
-        lagTimeFormatted: formatTimeDistance(timeLagMs),
+        lagSlots: 0,
+        lagTimeMs: 0,
+        lagTimeFormatted: '00:00:00',
       };
-    }
 
-    // Build response
-    const lastProcessedSlotTimestamp = lastProcessedSlotRecord
-      ? beaconTime.getTimestampFromSlotNumber(lastProcessedSlotRecord.slot)
-      : null;
+      if (lastProcessedSlotRecord) {
+        const slotLag = currentSlot - lastProcessedSlotRecord.slot;
+        const timeLagMs = slotLag * params.beaconHelpers.chainConfig.beacon.slotDuration;
+        distanceToHead = {
+          headSlot: currentSlot,
+          lagSlots: slotLag,
+          lagTimeMs: timeLagMs,
+          lagTimeFormatted: formatTimeDistance(timeLagMs),
+        };
+      }
 
-    const status = {
-      lastProcessedEpoch: lastProcessedEpochRecord?.epoch ?? null,
-      lastProcessedSlot:
-        lastProcessedSlotRecord && lastProcessedSlotTimestamp
-          ? {
-              slot: lastProcessedSlotRecord.slot,
-              timestamp: lastProcessedSlotTimestamp,
-              timeFormatted: formatTimestamp(lastProcessedSlotTimestamp),
-            }
-          : null,
-      distanceToHead,
-      archive,
-      indexerConfig,
-    };
+      const lastProcessedSlotTimestamp = lastProcessedSlotRecord
+        ? params.beaconHelpers.beaconTime.getTimestampFromSlotNumber(lastProcessedSlotRecord.slot)
+        : null;
 
-    return {
-      success: true,
-      data: status,
-      meta: {
-        timestamp: new Date().toISOString(),
-      },
-    };
-  });
+      return {
+        success: true,
+        data: {
+          lastProcessedEpoch: lastProcessedEpochRecord?.epoch ?? null,
+          lastProcessedSlot:
+            lastProcessedSlotRecord && lastProcessedSlotTimestamp
+              ? {
+                  slot: lastProcessedSlotRecord.slot,
+                  timestamp: lastProcessedSlotTimestamp,
+                  timeFormatted: formatTimestamp(lastProcessedSlotTimestamp),
+                }
+              : null,
+          distanceToHead,
+          archive,
+          indexerConfig,
+        },
+        meta: {
+          timestamp: new Date().toISOString(),
+        },
+      };
+    });
+}

--- a/packages/api/src/routers/indexer/status.ts
+++ b/packages/api/src/routers/indexer/status.ts
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 
 import { IndexerStatusSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
@@ -31,7 +32,7 @@ export function createIndexerStatusRoute(params: {
     chainConfig: { beacon: { slotDuration: number } };
   };
   prisma: any;
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
   systemConfigController: {
     getArchive: () => Promise<any>;
     getIndexerConfig: () => Promise<any>;

--- a/packages/api/src/routers/user/anonymous.ts
+++ b/packages/api/src/routers/user/anonymous.ts
@@ -1,40 +1,44 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { AnonymousUserInputSchema, UserResponseSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { UserStorage } from '@/storage/user.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Get or create an anonymous user
- * POST /users/anonymous
- *
- * This allows the frontend to work without login.
- * The sessionId (UUID from localStorage) is used to identify the user.
- * In the future, this anonymous user can be linked to a real account.
+ * Creates the anonymous user route.
  */
-export const anonymousUser = securedProcedure
-  .route({ method: 'POST', path: '/users/anonymous' })
-  .input(AnonymousUserInputSchema)
-  .output(ApiResponseSchema(UserResponseSchema))
-  .handler(async ({ input }) => {
-    try {
-      const storage = new UserStorage();
-      const user = await storage.getOrCreateAnonymous(input.sessionId);
+export function createAnonymousUserRoute(params: {
+  procedures: { securedProcedure: any };
+  userStorage: {
+    getOrCreateAnonymous: (sessionId: string) => Promise<{ id: string; username: string }>;
+  };
+}) {
+  const { securedProcedure } = params.procedures;
 
-      return {
-        success: true,
-        data: {
-          id: user.id,
-          username: user.username,
-        },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to create anonymous user';
-      return {
-        success: false,
-        error: { code: 'USER_ANONYMOUS_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+  return securedProcedure
+    .route({ method: 'POST', path: '/users/anonymous' })
+    .input(AnonymousUserInputSchema)
+    .output(ApiResponseSchema(UserResponseSchema))
+    .handler(async ({ input }: any) => {
+      try {
+        const user = await params.userStorage.getOrCreateAnonymous(input.sessionId);
+
+        return {
+          success: true,
+          data: {
+            id: user.id,
+            username: user.username,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'USER_ANONYMOUS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to create anonymous user',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+    });
+}

--- a/packages/api/src/routers/user/anonymous.ts
+++ b/packages/api/src/routers/user/anonymous.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { AnonymousUserInputSchema, UserResponseSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
  * Creates the anonymous user route.
  */
 export function createAnonymousUserRoute(params: {
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
   userStorage: {
     getOrCreateAnonymous: (sessionId: string) => Promise<{ id: string; username: string }>;
   };

--- a/packages/api/src/routers/user/index.ts
+++ b/packages/api/src/routers/user/index.ts
@@ -1,7 +1,15 @@
-import { anonymousUser } from './anonymous.js';
-import { me } from './me.js';
+import { createAnonymousUserRoute } from './anonymous.js';
+import { createMeRoute } from './me.js';
 
-export const userRouter = {
-  anonymous: anonymousUser,
-  me,
-};
+/**
+ * Creates the user router.
+ */
+export function createUserRouter(params: {
+  procedures: Parameters<typeof createAnonymousUserRoute>[0]['procedures'];
+  userStorage: Parameters<typeof createAnonymousUserRoute>[0]['userStorage'];
+}) {
+  return {
+    anonymous: createAnonymousUserRoute(params),
+    me: createMeRoute(params),
+  };
+}

--- a/packages/api/src/routers/user/me.ts
+++ b/packages/api/src/routers/user/me.ts
@@ -3,12 +3,13 @@ import { ORPCError } from '@orpc/server';
 
 import { UserResponseSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
  * Creates the current-user route.
  */
-export function createMeRoute(params: { procedures: { securedProcedure: any } }) {
+export function createMeRoute(params: { procedures: ApiProcedures }) {
   const { securedProcedure } = params.procedures;
 
   return securedProcedure

--- a/packages/api/src/routers/user/me.ts
+++ b/packages/api/src/routers/user/me.ts
@@ -1,33 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ORPCError } from '@orpc/server';
 
 import { UserResponseSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Get the current authenticated user
- * GET /users/me
- *
- * Works for both Telegram and anonymous users — returns the DB user
- * resolved by the middleware. Returns 401 if no user in context (API key auth).
+ * Creates the current-user route.
  */
-export const me = securedProcedure
-  .route({ method: 'GET', path: '/users/me' })
-  .output(ApiResponseSchema(UserResponseSchema))
-  .handler(async ({ context }) => {
-    if (!context.user) {
-      throw new ORPCError('UNAUTHORIZED', {
-        message: 'No user in context',
-      });
-    }
+export function createMeRoute(params: { procedures: { securedProcedure: any } }) {
+  const { securedProcedure } = params.procedures;
 
-    return {
-      success: true,
-      data: {
-        id: context.user.id,
-        username: context.user.username,
-      },
-      meta: { timestamp: new Date().toISOString() },
-    };
-  });
+  return securedProcedure
+    .route({ method: 'GET', path: '/users/me' })
+    .output(ApiResponseSchema(UserResponseSchema))
+    .handler(async ({ context }: any) => {
+      if (!context.user) {
+        throw new ORPCError('UNAUTHORIZED', {
+          message: 'No user in context',
+        });
+      }
+
+      return {
+        success: true,
+        data: {
+          id: context.user.id,
+          username: context.user.username,
+        },
+        meta: { timestamp: new Date().toISOString() },
+      };
+    });
+}

--- a/packages/api/src/routers/utils.ts
+++ b/packages/api/src/routers/utils.ts
@@ -1,29 +1,26 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { beaconTime } from '@/utils/beaconTime.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
-// Schema for date string input: accepts both yyyy/mm/dd hh:mm:ss and ISO format yyyy-mm-ddThh:mm:ssZ
 const DateStringSchema = z.string().refine(
-  (val) => {
-    const isCustomFormat = /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}$/.test(val);
-    const isISOFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(val);
+  (value) => {
+    const isCustomFormat = /^\d{4}\/\d{2}\/\d{2} \d{2}:\d{2}:\d{2}$/.test(value);
+    const isISOFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(value);
 
     if (!isCustomFormat && !isISOFormat) {
       return false;
     }
 
-    const dateStr = isCustomFormat
-      ? val.replace(/(\d{4})\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):(\d{2})/, '$1-$2-$3T$4:$5:$6Z')
-      : val;
+    const dateString = isCustomFormat
+      ? value.replace(/(\d{4})\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):(\d{2})/, '$1-$2-$3T$4:$5:$6Z')
+      : value;
 
-    return !isNaN(new Date(dateStr).getTime());
+    return !isNaN(new Date(dateString).getTime());
   },
   { message: 'Date must be a valid date in format yyyy/mm/dd hh:mm:ss or yyyy-mm-ddThh:mm:ssZ' },
 );
 
-// Unified response schema for slot/date conversions
 const SlotDateResponseSchema = ApiResponseSchema(
   z.object({
     slot: z.number(),
@@ -35,93 +32,82 @@ const SlotDateResponseSchema = ApiResponseSchema(
 type SlotDateResponse = z.infer<typeof SlotDateResponseSchema>;
 
 /**
- * Convert UTC date string to slot number
- * @param date - Date string in format yyyy/mm/dd hh:mm:ss
- * @returns Slot number and original date
+ * Creates the utility conversion router.
  */
-export const dateToSlot = securedProcedure
-  .route({ method: 'GET', path: '/utils/date-to-slot' })
-  .input(
-    z.object({
-      date: DateStringSchema,
-    }),
-  )
-  .output(SlotDateResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      // The Zod schema has already validated the date format and its value.
-      // We just need to normalize it for the `Date` constructor.
-      let dateStr: string;
-      if (input.date.includes('/')) {
-        // Convert yyyy/mm/dd hh:mm:ss to ISO format
-        dateStr = input.date.replace(
-          /(\d{4})\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):(\d{2})/,
-          '$1-$2-$3T$4:$5:$6Z',
-        );
-      } else {
-        // Already in ISO format
-        dateStr = input.date;
+export function createUtilsRouter(params: {
+  beaconHelpers: {
+    beaconTime: {
+      getSlotNumberFromTimestamp: (timestamp: number) => number;
+      getTimestampFromSlotNumber: (slot: number) => number;
+    };
+  };
+  procedures: { securedProcedure: any };
+}) {
+  const { securedProcedure } = params.procedures;
+
+  const dateToSlot = securedProcedure
+    .route({ method: 'GET', path: '/utils/date-to-slot' })
+    .input(
+      z.object({
+        date: DateStringSchema,
+      }),
+    )
+    .output(SlotDateResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const dateString = input.date.includes('/')
+          ? input.date.replace(
+              /(\d{4})\/(\d{2})\/(\d{2}) (\d{2}):(\d{2}):(\d{2})/,
+              '$1-$2-$3T$4:$5:$6Z',
+            )
+          : input.date;
+        const timestamp = new Date(dateString).getTime();
+
+        return successResponse({
+          slot: params.beaconHelpers.beaconTime.getSlotNumberFromTimestamp(timestamp),
+          date: input.date,
+          timestamp,
+        }) as SlotDateResponse;
+      } catch (error) {
+        return errorResponse(
+          'CONVERSION_ERROR',
+          error instanceof Error ? error.message : 'Failed to convert date to slot',
+        ) as SlotDateResponse;
       }
-      const date = new Date(dateStr);
+    });
 
-      // Convert to timestamp (milliseconds)
-      const timestamp = date.getTime();
+  const slotToDate = securedProcedure
+    .route({ method: 'GET', path: '/utils/slot-to-date' })
+    .input(
+      z.object({
+        slot: z.coerce.number().int().nonnegative(),
+      }),
+    )
+    .output(SlotDateResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const timestamp = params.beaconHelpers.beaconTime.getTimestampFromSlotNumber(input.slot);
+        const date = new Date(timestamp);
+        const pad = (num: number) => String(num).padStart(2, '0');
+        const dateString = `${date.getUTCFullYear()}/${pad(date.getUTCMonth() + 1)}/${pad(
+          date.getUTCDate(),
+        )} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`;
 
-      // Get slot number from timestamp
-      const slot = beaconTime.getSlotNumberFromTimestamp(timestamp);
+        return successResponse({
+          slot: input.slot,
+          date: dateString,
+          timestamp,
+        }) as SlotDateResponse;
+      } catch (error) {
+        return errorResponse(
+          'CONVERSION_ERROR',
+          error instanceof Error ? error.message : 'Failed to convert slot to date',
+        ) as SlotDateResponse;
+      }
+    });
 
-      return successResponse({
-        slot,
-        date: input.date,
-        timestamp,
-      }) as SlotDateResponse;
-    } catch (error) {
-      return errorResponse(
-        'CONVERSION_ERROR',
-        error instanceof Error ? error.message : 'Failed to convert date to slot',
-      ) as SlotDateResponse;
-    }
-  });
-
-/**
- * Convert slot number to UTC date string
- * @param slot - Slot number
- * @returns UTC date string in format yyyy/mm/dd hh:mm:ss, timestamp, and slot
- */
-export const slotToDate = securedProcedure
-  .route({ method: 'GET', path: '/utils/slot-to-date' })
-  .input(
-    z.object({
-      slot: z.coerce.number().int().nonnegative(), // coerce converts string query params to number
-    }),
-  )
-  .output(SlotDateResponseSchema)
-  .handler(async ({ input }) => {
-    try {
-      // Get timestamp from slot number
-      const timestamp = beaconTime.getTimestampFromSlotNumber(input.slot);
-
-      // Convert timestamp to Date and format as yyyy/mm/dd hh:mm:ss in UTC
-      const date = new Date(timestamp);
-      const pad = (num: number) => String(num).padStart(2, '0');
-      const dateString = `${date.getUTCFullYear()}/${pad(date.getUTCMonth() + 1)}/${pad(
-        date.getUTCDate(),
-      )} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`;
-
-      return successResponse({
-        slot: input.slot,
-        date: dateString,
-        timestamp,
-      }) as SlotDateResponse;
-    } catch (error) {
-      return errorResponse(
-        'CONVERSION_ERROR',
-        error instanceof Error ? error.message : 'Failed to convert slot to date',
-      ) as SlotDateResponse;
-    }
-  });
-
-export const utilsRouter = {
-  dateToSlot,
-  slotToDate,
-};
+  return {
+    dateToSlot,
+    slotToDate,
+  };
+}

--- a/packages/api/src/routers/utils.ts
+++ b/packages/api/src/routers/utils.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
 
 const DateStringSchema = z.string().refine(
@@ -41,7 +42,7 @@ export function createUtilsRouter(params: {
       getTimestampFromSlotNumber: (slot: number) => number;
     };
   };
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
 }) {
   const { securedProcedure } = params.procedures;
 

--- a/packages/api/src/routers/validator/index.ts
+++ b/packages/api/src/routers/validator/index.ts
@@ -1,68 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod';
 
 import { ValidatorDetailsSchema } from './schemas.js';
-import { searchValidators } from './search.js';
+import { createSearchValidatorsRoute } from './search.js';
 
-import { ValidatorController } from '@/controllers/validator.js';
-import { securedProcedure } from '@/lib/procedures.js';
-import { getValidatorMissedAttestations } from '@/routers/cluster/missed-attestations.js';
-import { getValidatorRewards } from '@/routers/cluster/rewards.js';
+import type { ApiDependencies } from '@/dependencies.js';
+import { createValidatorMissedAttestationsRoute } from '@/routers/cluster/missed-attestations.js';
+import { createValidatorRewardsRoute } from '@/routers/cluster/rewards.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Get validator details with timeline grouped by epoch → slot
- * Accepts id as path parameter - can be validatorIndex (number) or pubkey (string, 98 chars)
- * Determines type by checking if id is a number or string length
+ * Creates the validator router.
  */
-export const getValidator = securedProcedure
-  .route({ method: 'GET', path: '/validator/{id}' })
-  .input(
-    z.object({
-      id: z.string(), // Path params come as strings
-    }),
-  )
-  .output(ApiResponseSchema(ValidatorDetailsSchema))
-  .handler(async ({ input }) => {
-    try {
-      const controller = new ValidatorController();
+export function createValidatorRouter(
+  deps: Pick<
+    ApiDependencies,
+    | 'analyticsStorage'
+    | 'beaconHelpers'
+    | 'chain'
+    | 'clusterStorage'
+    | 'logger'
+    | 'nativeTokenDecimals'
+    | 'procedures'
+    | 'tokenPriceApiUrl'
+    | 'tokenPriceTokenName'
+    | 'validatorController'
+    | 'validatorStorage'
+  >,
+) {
+  const { securedProcedure } = deps.procedures;
 
-      // Determine if id is number or pubkey by checking if it's a valid number
-      let id: number | string;
-      const parsed = Number(input.id);
-      if (!isNaN(parsed) && parsed > 0 && Number.isInteger(parsed)) {
-        id = parsed;
-      } else {
-        // Otherwise treat as pubkey
-        id = input.id;
+  const getValidator = securedProcedure
+    .route({ method: 'GET', path: '/validator/{id}' })
+    .input(
+      z.object({
+        id: z.string(),
+      }),
+    )
+    .output(ApiResponseSchema(ValidatorDetailsSchema))
+    .handler(async ({ input }: any) => {
+      try {
+        let id: number | string;
+        const parsed = Number(input.id);
+
+        if (!isNaN(parsed) && parsed > 0 && Number.isInteger(parsed)) {
+          id = parsed;
+        } else {
+          id = input.id;
+        }
+
+        const details = await deps.validatorController.getDetails(id);
+
+        return {
+          success: true,
+          data: details,
+          meta: {
+            timestamp: new Date().toISOString(),
+          },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'VALIDATOR_DETAILS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to get validator details',
+          },
+          meta: {
+            timestamp: new Date().toISOString(),
+          },
+        };
       }
+    });
 
-      const details = await controller.getDetails(id);
-
-      return {
-        success: true,
-        data: details,
-        meta: {
-          timestamp: new Date().toISOString(),
-        },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to get validator details';
-      return {
-        success: false,
-        error: {
-          code: 'VALIDATOR_DETAILS_ERROR',
-          message,
-        },
-        meta: {
-          timestamp: new Date().toISOString(),
-        },
-      };
-    }
-  });
-
-export const validatorRouter = {
-  getValidator,
-  search: searchValidators,
-  missedAttestations: getValidatorMissedAttestations,
-  rewards: getValidatorRewards,
-};
+  return {
+    getValidator,
+    missedAttestations: createValidatorMissedAttestationsRoute(deps),
+    rewards: createValidatorRewardsRoute(deps),
+    search: createSearchValidatorsRoute(deps),
+  };
+}

--- a/packages/api/src/routers/validator/search.ts
+++ b/packages/api/src/routers/validator/search.ts
@@ -1,71 +1,76 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ValidatorSearchInputSchema, ValidatorSearchResponseSchema } from './schemas.js';
 
-import { securedProcedure } from '@/lib/procedures.js';
-import { ValidatorStorage } from '@/storage/validator.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
- * Search validators by index, pubkey, or withdrawal address (single or bulk)
- * GET /validators/search?index=123 or ?indexes=1,2,3 or ?pubkey=0x... or ?pubkeys=0x...,0x...
- * or ?withdrawalAddress=0x... or ?withdrawalAddresses=0x...,0x...
+ * Creates the validator search route.
  */
-export const searchValidators = securedProcedure
-  .route({ method: 'GET', path: '/validators/search' })
-  .input(ValidatorSearchInputSchema)
-  .output(ApiResponseSchema(ValidatorSearchResponseSchema))
-  .handler(async ({ input }) => {
-    try {
-      const storage = new ValidatorStorage();
-      const validators: Array<{
-        index: number;
-        pubkey: string | null;
-        withdrawalAddress: string | null;
-      }> = [];
+export function createSearchValidatorsRoute(params: {
+  procedures: { securedProcedure: any };
+  validatorStorage: any;
+}) {
+  const { securedProcedure } = params.procedures;
 
-      if (input.index !== undefined) {
-        const result = await storage.existsByIndex(input.index);
-        if (result) {
-          validators.push(result);
+  return securedProcedure
+    .route({ method: 'GET', path: '/validators/search' })
+    .input(ValidatorSearchInputSchema)
+    .output(ApiResponseSchema(ValidatorSearchResponseSchema))
+    .handler(async ({ input }: any) => {
+      try {
+        const validators: Array<{
+          index: number;
+          pubkey: string | null;
+          withdrawalAddress: string | null;
+        }> = [];
+
+        if (input.index !== undefined) {
+          const result = await params.validatorStorage.existsByIndex(input.index);
+          if (result) {
+            validators.push(result);
+          }
+        } else if (input.indexes && input.indexes.length > 0) {
+          validators.push(...(await params.validatorStorage.existsByIndexes(input.indexes)));
+        } else if (input.pubkey) {
+          const result = await params.validatorStorage.findByPubkey(input.pubkey);
+          if (result) {
+            validators.push(result);
+          }
+        } else if (input.pubkeys && input.pubkeys.length > 0) {
+          validators.push(...(await params.validatorStorage.findByPubkeys(input.pubkeys)));
+        } else if (input.withdrawalAddress) {
+          validators.push(
+            ...(await params.validatorStorage.findByWithdrawalAddress(input.withdrawalAddress)),
+          );
+        } else if (input.withdrawalAddresses && input.withdrawalAddresses.length > 0) {
+          validators.push(
+            ...(await params.validatorStorage.findByWithdrawalAddresses(input.withdrawalAddresses)),
+          );
+        } else {
+          return {
+            success: false,
+            error: {
+              code: 'INVALID_INPUT',
+              message: 'Exactly one of index/es, pubkey/s or withdrawalAddress/es must be provided',
+            },
+            meta: { timestamp: new Date().toISOString() },
+          };
         }
-      } else if (input.indexes && input.indexes.length > 0) {
-        const results = await storage.existsByIndexes(input.indexes);
-        validators.push(...results);
-      } else if (input.pubkey) {
-        const result = await storage.findByPubkey(input.pubkey);
-        if (result) {
-          validators.push(result);
-        }
-      } else if (input.pubkeys && input.pubkeys.length > 0) {
-        const results = await storage.findByPubkeys(input.pubkeys);
-        validators.push(...results);
-      } else if (input.withdrawalAddress) {
-        const results = await storage.findByWithdrawalAddress(input.withdrawalAddress);
-        validators.push(...results);
-      } else if (input.withdrawalAddresses && input.withdrawalAddresses.length > 0) {
-        const results = await storage.findByWithdrawalAddresses(input.withdrawalAddresses);
-        validators.push(...results);
-      } else {
+
+        return {
+          success: true,
+          data: { validators },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
         return {
           success: false,
           error: {
-            code: 'INVALID_INPUT',
-            message: 'Exactly one of index/es, pubkey/s or withdrawalAddress/es must be provided',
+            code: 'VALIDATOR_SEARCH_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to search validators',
           },
           meta: { timestamp: new Date().toISOString() },
         };
       }
-
-      return {
-        success: true,
-        data: { validators },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to search validators';
-      return {
-        success: false,
-        error: { code: 'VALIDATOR_SEARCH_ERROR', message },
-        meta: { timestamp: new Date().toISOString() },
-      };
-    }
-  });
+    });
+}

--- a/packages/api/src/routers/validator/search.ts
+++ b/packages/api/src/routers/validator/search.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ValidatorSearchInputSchema, ValidatorSearchResponseSchema } from './schemas.js';
 
+import type { ApiProcedures } from '@/auth/middleware.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 
 /**
  * Creates the validator search route.
  */
 export function createSearchValidatorsRoute(params: {
-  procedures: { securedProcedure: any };
+  procedures: ApiProcedures;
   validatorStorage: any;
 }) {
   const { securedProcedure } = params.procedures;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -5,52 +5,51 @@ import { RPCHandler } from '@orpc/server/node';
 import { CORSPlugin } from '@orpc/server/plugins';
 
 import { isOriginAllowed } from './auth/origin.js';
-import { logger } from './lib/logger.js';
+import type { Logger } from './lib/logger.js';
 import {
   buildRequestLogPrefix,
   getRpcMethod,
   inferAuthStrategy,
   type RequestLogMeta,
 } from './lib/request-logging.js';
-import { router } from './routers/index.js';
+import type { createRouter } from './routers/index.js';
 
 /**
- * CORS plugin — allows cross-origin requests from approved origins.
- * Auth strategy (Telegram, API key, anonymous) is handled separately
- * by the procedure middleware — CORS headers must always be present
- * for browser-based requests (including Telegram Mini App WebViews).
+ * Creates the HTTP server from explicit runtime dependencies.
  */
-const corsPlugin = new CORSPlugin({
-  origin: (origin) => (isOriginAllowed(origin) ? origin : null),
-  allowHeaders: [
-    'Content-Type',
-    'Authorization',
-    'x-telegram-init-data',
-    'ns-anonymous-id',
-    'bot-signature',
-    'bot-user-id',
-    'bot-timestamp',
-  ],
-  credentials: true,
-});
+export function createHttpServer(params: {
+  allowedOrigins: string;
+  logger: Logger;
+  router: ReturnType<typeof createRouter>;
+}) {
+  const corsPlugin = new CORSPlugin({
+    origin: (origin) =>
+      isOriginAllowed(origin, {
+        allowedOrigins: params.allowedOrigins,
+        logger: params.logger,
+      })
+        ? origin
+        : null,
+    allowHeaders: [
+      'Content-Type',
+      'Authorization',
+      'x-telegram-init-data',
+      'ns-anonymous-id',
+      'bot-signature',
+      'bot-user-id',
+      'bot-timestamp',
+    ],
+    credentials: true,
+  });
 
-/**
- * Create and configure the HTTP server with both oRPC handlers
- * - OpenAPIHandler: for traditional HTTP requests (Postman, curl, etc.) - routes: /*
- * - RPCHandler: for oRPC client (RPCLink) - routes: /rpc/*
- */
-export function createHttpServer() {
-  // Handler for traditional HTTP requests (OpenAPI/REST-like)
-  const openApiHandler = new OpenAPIHandler(router, {
+  const openApiHandler = new OpenAPIHandler(params.router, {
+    plugins: [corsPlugin],
+  });
+  const rpcHandler = new RPCHandler(params.router, {
     plugins: [corsPlugin],
   });
 
-  // Handler for oRPC client (RPCLink)
-  const rpcHandler = new RPCHandler(router, {
-    plugins: [corsPlugin],
-  });
-
-  const server = createServer(async (req, res) => {
+  return createServer(async (req, res) => {
     const startedAt = Date.now();
     let requestPrefix = `${req.method ?? 'UNKNOWN'} ${req.url ?? 'UNKNOWN'}`;
 
@@ -65,9 +64,6 @@ export function createHttpServer() {
       };
       requestPrefix = buildRequestLogPrefix(method, pathname, meta);
 
-      // Determine which handler to use based on path prefix
-      // Routes starting with /rpc use RPCHandler (for oRPC client)
-      // All other routes use OpenAPIHandler (for traditional HTTP)
       const isRPC = pathname.startsWith('/rpc');
       const handler = isRPC ? rpcHandler : openApiHandler;
 
@@ -75,7 +71,7 @@ export function createHttpServer() {
         prefix: isRPC ? '/rpc' : undefined,
         context: {
           headers: req.headers,
-          logger,
+          logger: params.logger,
         },
       });
 
@@ -83,7 +79,7 @@ export function createHttpServer() {
         res.statusCode = 404;
         res.setHeader('Content-Type', 'text/plain');
         res.end('No procedure matched');
-        logger.warn(`${requestPrefix} status=404 duration=${Date.now() - startedAt}ms`);
+        params.logger.warn(`${requestPrefix} status=404 duration=${Date.now() - startedAt}ms`);
         return;
       }
 
@@ -92,19 +88,22 @@ export function createHttpServer() {
 
       if (status >= 400) {
         const details = [`status=${status}`, `duration=${durationMs}ms`].join(' ');
-        const logMethod = status >= 500 ? logger.error.bind(logger) : logger.warn.bind(logger);
+        const logMethod =
+          status >= 500
+            ? params.logger.error.bind(params.logger)
+            : params.logger.warn.bind(params.logger);
         logMethod(`${requestPrefix} ${details}`);
         return;
       }
 
       if (method === 'OPTIONS') {
-        logger.debug(`${requestPrefix} status=${status} duration=${durationMs}ms`);
+        params.logger.debug(`${requestPrefix} status=${status} duration=${durationMs}ms`);
         return;
       }
 
-      logger.info(`${requestPrefix} status=${status} duration=${durationMs}ms`);
+      params.logger.info(`${requestPrefix} status=${status} duration=${durationMs}ms`);
     } catch (error) {
-      logger.error({ err: error }, `${requestPrefix} Unhandled server error`);
+      params.logger.error({ err: error }, `${requestPrefix} Unhandled server error`);
       if (!res.headersSent) {
         res.statusCode = 500;
         res.setHeader('Content-Type', 'text/plain');
@@ -112,6 +111,4 @@ export function createHttpServer() {
       }
     }
   });
-
-  return server;
 }

--- a/packages/api/src/storage/analytics.ts
+++ b/packages/api/src/storage/analytics.ts
@@ -1,13 +1,11 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 /**
  * AnalyticsStorage - Database persistence layer for analytics queries
  * Uses raw SQL for aggregated missed attestation data
  */
 export class AnalyticsStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Get missed attestations from the performance snapshot table (1h data)

--- a/packages/api/src/storage/block.ts
+++ b/packages/api/src/storage/block.ts
@@ -1,9 +1,7 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 export class BlockStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Get paginated block proposals for a cluster or single validator

--- a/packages/api/src/storage/bot-communications.ts
+++ b/packages/api/src/storage/bot-communications.ts
@@ -1,12 +1,10 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 /**
  * Stores broadcast communications used by the Telegram bot.
  */
 export class BotCommunicationsStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Creates a new communication in pending state.

--- a/packages/api/src/storage/bot-incident-notifications.ts
+++ b/packages/api/src/storage/bot-incident-notifications.ts
@@ -1,7 +1,5 @@
 import { ClusterIncidentStatus, Prisma, PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 type IncidentNotificationType = 'incident_opened' | 'incident_closed';
 
 const incidentNotificationSelect = {
@@ -64,7 +62,7 @@ function getIncidentNotificationCreatedAt(incident: DueIncidentNotification): Da
 }
 
 export class BotIncidentNotificationsStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /** Lists cluster incident notifications due for bot delivery. */
   async listPending(limit: number) {

--- a/packages/api/src/storage/bot-notifications.ts
+++ b/packages/api/src/storage/bot-notifications.ts
@@ -1,9 +1,7 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 export class BotNotificationsStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /** Lists queued validator notifications for bot delivery. */
   async listPending(limit: number) {

--- a/packages/api/src/storage/bot-users.ts
+++ b/packages/api/src/storage/bot-users.ts
@@ -1,9 +1,7 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 export class BotUsersStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   async listNotifiableUsers() {
     return this.prisma.user.findMany({

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -1,7 +1,5 @@
 import { ClusterVisibility, PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 interface CreateClusterData {
   name: string;
   ownerId: string;
@@ -25,7 +23,7 @@ interface UpdateClusterWithValidatorsData extends UpdateClusterData {
  * Uses Prisma ORM for standard CRUD operations
  */
 export class ClusterStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Removes duplicate validator indexes while preserving the first occurrence.

--- a/packages/api/src/storage/incident.ts
+++ b/packages/api/src/storage/incident.ts
@@ -1,7 +1,5 @@
 import { ClusterIncidentStatus, Prisma, PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 type ListClusterIncidentsParams = {
   ownerId: string;
   clusterId: string;
@@ -32,7 +30,7 @@ type ListIncidentAffectedValidatorsParams = {
  * Reads and updates cluster incidents using ownership-scoped queries.
  */
 export class IncidentStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Confirms the cluster belongs to the authenticated user.

--- a/packages/api/src/storage/systemConfig.ts
+++ b/packages/api/src/storage/systemConfig.ts
@@ -1,7 +1,5 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 /**
  * SystemConfigStorage - Database persistence layer for system configuration tables
  * Handles all database operations for helper/config tables like Archive and IndexerConfig
@@ -23,7 +21,7 @@ interface IndexerConfigRow {
 }
 
 export class SystemConfigStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Get archive configuration

--- a/packages/api/src/storage/user.ts
+++ b/packages/api/src/storage/user.ts
@@ -1,12 +1,10 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 /**
  * UserStorage - Database persistence layer for user operations
  */
 export class UserStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Find user by session ID (stored in username for anonymous users)

--- a/packages/api/src/storage/validator.ts
+++ b/packages/api/src/storage/validator.ts
@@ -1,7 +1,5 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
-import { getPrisma } from '@/lib/prisma.js';
-
 /**
  * ValidatorStorage - Database persistence layer for validator-related operations
  * Handles all database operations using raw SQL queries for performance
@@ -39,7 +37,7 @@ interface EpochRewardsRow {
 }
 
 export class ValidatorStorage {
-  constructor(private readonly prisma: PrismaClient = getPrisma()) {}
+  constructor(private readonly prisma: PrismaClient) {}
 
   /**
    * Resolve validator index from pubkey

--- a/packages/api/src/utils/beaconTime.ts
+++ b/packages/api/src/utils/beaconTime.ts
@@ -1,20 +1,29 @@
-// Re-export BeaconTime and chain config from consensus-utils
 import { BeaconTime, getChainConfig } from '@beacon-indexer/beacon-utils';
 
-import { env } from '../config/env.js';
+export interface BeaconHelpers {
+  beaconTime: BeaconTime;
+  chainConfig: ReturnType<typeof getChainConfig>;
+}
 
-// Get chain configuration
-const chainConfig = getChainConfig(env.CHAIN);
+/**
+ * Creates the chain configuration and BeaconTime helper from plain parameters.
+ */
+export function createBeaconHelpers(params: {
+  chain: 'ethereum' | 'gnosis';
+  lookbackSlot: number;
+}): BeaconHelpers {
+  const chainConfig = getChainConfig(params.chain);
+  const beaconTime = new BeaconTime({
+    genesisTimestamp: chainConfig.beacon.genesisTimestamp,
+    slotDurationMs: chainConfig.beacon.slotDuration,
+    slotsPerEpoch: chainConfig.beacon.slotsPerEpoch,
+    epochsPerSyncCommitteePeriod: chainConfig.beacon.epochsPerSyncCommitteePeriod,
+    lookbackSlot: params.lookbackSlot,
+    delaySlotsToHead: chainConfig.beacon.delaySlotsToHead,
+  });
 
-// Create singleton BeaconTime instance
-export const beaconTime = new BeaconTime({
-  genesisTimestamp: chainConfig.beacon.genesisTimestamp,
-  slotDurationMs: chainConfig.beacon.slotDuration,
-  slotsPerEpoch: chainConfig.beacon.slotsPerEpoch,
-  epochsPerSyncCommitteePeriod: chainConfig.beacon.epochsPerSyncCommitteePeriod,
-  lookbackSlot: env.CONSENSUS_LOOKBACK_SLOT,
-  delaySlotsToHead: chainConfig.beacon.delaySlotsToHead,
-});
-
-// Re-export chain config for convenience
-export { chainConfig };
+  return {
+    beaconTime,
+    chainConfig,
+  };
+}

--- a/packages/api/src/utils/tokenFormat.ts
+++ b/packages/api/src/utils/tokenFormat.ts
@@ -1,59 +1,28 @@
-import { env } from '@/config/env.js';
-
 /**
- * Token formatting utilities for chain-aware conversion
- * Based on logic from beacon-monitor-bot notifyUserStatsMessage.ts
- *
- * Rules:
- * - Base unit: 1 token = 1e9 gWei
- * - Gnosis: 1 GNO = 32 mGNO (tokenMultiplier = 32)
- * - Ethereum: 1 ETH = 1 ETH (tokenMultiplier = 1)
+ * Converts gWei to the chain token using the provided config.
  */
-
-// 1 token = 1e9 gWei
-const GWEI_PER_TOKEN = BigInt(10) ** BigInt(9);
-
-// Chain-specific token multiplier
-// Gnosis: 1 GNO = 32 mGNO, Ethereum: 1 ETH = 1 ETH
-const TOKEN_MULTIPLIER = env.CHAIN === 'gnosis' ? BigInt(32) : BigInt(1);
-
-/**
- * Convert gWei (as BigInt or string) to token amount as decimal string
- * Based on bot logic: token = (gWei * 1e9) / tokenMultiplier / 1e18 = gWei / (tokenMultiplier * 1e9)
- * @param gwei - Amount in gWei (BigInt or string representation)
- * @returns Token amount as decimal string (e.g., "32.123456789")
- */
-export function formatGweiToToken(gwei: bigint | string): string {
+export function formatGweiToToken(gwei: bigint | string, chain: 'ethereum' | 'gnosis'): string {
+  const GWEI_PER_TOKEN = BigInt(10) ** BigInt(9);
+  const tokenMultiplier = chain === 'gnosis' ? BigInt(32) : BigInt(1);
   const gweiBigInt = typeof gwei === 'string' ? BigInt(gwei) : gwei;
-
-  // Convert gWei to wei (multiply by 1e9)
   const wei = gweiBigInt * GWEI_PER_TOKEN;
-
-  // Apply token multiplier: divide by tokenMultiplier
-  const weiAfterMultiplier = wei / TOKEN_MULTIPLIER;
-
-  // Convert wei to token (divide by 1e18)
-  // Since BigInt doesn't support decimals, we'll use string manipulation
+  const weiAfterMultiplier = wei / tokenMultiplier;
   const weiString = weiAfterMultiplier.toString();
   const weiLength = weiString.length;
 
   if (weiLength <= 18) {
-    // Less than 1 token
     const padded = weiString.padStart(18, '0');
     const decimalPart = padded.replace(/0+$/, '');
     return decimalPart ? `0.${decimalPart}` : '0';
   }
 
-  // 1 token or more
   const integerPart = weiString.slice(0, -18);
   const decimalPart = weiString.slice(-18).replace(/0+$/, '');
   return decimalPart ? `${integerPart}.${decimalPart}` : integerPart;
 }
 
 /**
- * Sum multiple reward parts (all in gWei) into a single BigInt
- * @param parts - Object with reward parts as BigInt or string
- * @returns Total in gWei as BigInt
+ * Sums several gWei reward parts into one bigint total.
  */
 export function sumRewardsGwei(parts: Record<string, bigint | string | null | undefined>): bigint {
   let total = BigInt(0);
@@ -62,6 +31,7 @@ export function sumRewardsGwei(parts: Record<string, bigint | string | null | un
     if (value === null || value === undefined) {
       continue;
     }
+
     const gweiBigInt = typeof value === 'string' ? BigInt(value) : value;
     total += gweiBigInt;
   }
@@ -70,48 +40,42 @@ export function sumRewardsGwei(parts: Record<string, bigint | string | null | un
 }
 
 /**
- * Format rewards from multiple gWei parts
- * @param parts - Object with reward parts as BigInt or string
- * @returns Object with totalGwei (as string) and token (as decimal string)
+ * Formats several gWei reward parts into aggregate values.
  */
 export function formatRewardsFromGweiParts(
   parts: Record<string, bigint | string | null | undefined>,
+  chain: 'ethereum' | 'gnosis',
 ): {
   totalGwei: string;
   token: string;
 } {
   const totalGwei = sumRewardsGwei(parts);
-  const token = formatGweiToToken(totalGwei);
 
   return {
     totalGwei: totalGwei.toString(),
-    token,
+    token: formatGweiToToken(totalGwei, chain),
   };
 }
 
 /**
- * Format a single balance/reward value from gWei to token string
- * Convenience wrapper for formatGweiToToken
- * @param gwei - Amount in gWei (BigInt or string)
- * @returns Token amount as decimal string
+ * Formats a nullable gWei balance into token units.
  */
-export function formatBalance(gwei: bigint | string | null | undefined): string {
+export function formatBalance(
+  gwei: bigint | string | null | undefined,
+  chain: 'ethereum' | 'gnosis',
+): string {
   if (gwei === null || gwei === undefined) {
     return '0';
   }
-  return formatGweiToToken(gwei);
+
+  return formatGweiToToken(gwei, chain);
 }
 
 /**
- * Convert wei (as BigInt or string) to token amount as decimal string.
- * Execution rewards are stored in wei and denominated in the native EL token
- * (xDAI for Gnosis, ETH for Ethereum) — no TOKEN_MULTIPLIER applies.
- * Uses NATIVE_TOKEN_DECIMALS from env config (default 18).
- * @param wei - Amount in wei (BigInt or string representation)
- * @returns Token amount as decimal string (e.g., "0.001628")
+ * Converts wei to the chain native token using the configured decimals.
  */
-export function formatWeiToToken(wei: bigint | string): string {
-  const decimals = env.NATIVE_TOKEN_DECIMALS;
+export function formatWeiToToken(wei: bigint | string, nativeTokenDecimals: number): string {
+  const decimals = nativeTokenDecimals;
   const weiBigInt = typeof wei === 'string' ? BigInt(wei) : wei;
   const weiString = weiBigInt.toString();
   const weiLength = weiString.length;

--- a/packages/api/src/utils/tokenPrice.ts
+++ b/packages/api/src/utils/tokenPrice.ts
@@ -1,39 +1,55 @@
 import memoizee from 'memoizee';
 import ms from 'ms';
 
-import { env } from '@/config/env.js';
-import { logger } from '@/lib/logger.js';
+import type { Logger } from '@/lib/logger.js';
 
-async function fetchTokenPrice(): Promise<number> {
-  try {
-    const response = await fetch(
-      `${env.COINGECKO_TOKEN_PRICE_API_URL}?ids=${env.COINGECKO_TOKEN_NAME}&vs_currencies=usd`,
-    );
+/**
+ * Fetches the token price for one apiUrl/tokenName pair.
+ */
+const fetchTokenPriceCached = memoizee(
+  async (apiUrl: string, tokenName: string): Promise<number> => {
+    const response = await fetch(`${apiUrl}?ids=${tokenName}&vs_currencies=usd`);
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
     const data = (await response.json()) as Record<string, { usd: number } | undefined>;
-    const price = data?.[env.COINGECKO_TOKEN_NAME]?.usd;
+    const price = data?.[tokenName]?.usd;
+
     if (typeof price !== 'number') {
-      throw new Error(`Token price not found for '${env.COINGECKO_TOKEN_NAME}'`);
+      throw new Error(`Token price not found for '${tokenName}'`);
     }
+
     return price;
+  },
+  {
+    promise: true,
+    maxAge: ms('1m'),
+    preFetch: true,
+    primitive: true,
+  },
+);
+
+/**
+ * Gets the current token price and logs failures.
+ */
+export async function getTokenPrice(
+  apiUrl: string,
+  tokenName: string,
+  logger: Logger,
+): Promise<number> {
+  try {
+    return await fetchTokenPriceCached(apiUrl, tokenName);
   } catch (error) {
     logger.error({ err: error }, 'Error fetching token price');
     throw error;
   }
 }
 
-// Memoize the function with a 1-minute TTL
-export const getTokenPrice = memoizee(fetchTokenPrice, {
-  promise: true,
-  maxAge: ms('1m'),
-  preFetch: true,
-  primitive: true,
-});
-
-export const clearTokenPriceCache = () => {
-  getTokenPrice.clear();
-};
+/**
+ * Clears the shared token price cache.
+ */
+export function clearTokenPriceCache() {
+  fetchTokenPriceCached.clear();
+}


### PR DESCRIPTION
## Summary
  - move API bootstrap wiring to `packages/api/src/index.ts` and remove import-time env/logger/prisma side effects
  - refactor API routers, auth, jobs, storages, and controllers to accept explicit dependencies instead of hidden globals/defaults
  - align API e2e setup with the indexer pattern by forcing the local e2e database URL and centralizing test defaults/overrides