### PR TITLE
Optimize dashboard scheduler queries

### DIFF
--- a/packages/api/src/storage/cluster.test.ts
+++ b/packages/api/src/storage/cluster.test.ts
@@ -1,6 +1,19 @@
+import { readFile } from 'node:fs/promises';
+
 import { describe, expect, it, vi } from 'vitest';
 
+// Keeps this storage-unit test independent from the API runtime environment.
+vi.mock('@/lib/prisma.js', () => ({
+  getPrisma: vi.fn(),
+}));
+
 import { ClusterStorage } from './cluster.js';
+
+const schemaUrl = new URL('../../../db/prisma/schema.prisma', import.meta.url);
+const migrationUrl = new URL(
+  '../../../db/prisma/migrations/20251210144216_initial/migration.sql',
+  import.meta.url,
+);
 
 describe('ClusterStorage.getSummary', () => {
   it('returns total cluster count and validator count per cluster', async () => {
@@ -80,5 +93,39 @@ describe('ClusterStorage.getSummary', () => {
     });
     // Confirms users are counted without loading user rows.
     expect(count).toHaveBeenCalledWith();
+  });
+});
+
+describe('ClusterStorage query performance safeguards', () => {
+  it('keeps the owner cluster list backed by a matching index', async () => {
+    // This case verifies the hot owner-scoped cluster listing has schema and migration indexes.
+    const [schema, migration] = await Promise.all([
+      readFile(schemaUrl, 'utf8'),
+      readFile(migrationUrl, 'utf8'),
+    ]);
+
+    // Confirms Prisma schema documents the owner/date index used by listByOwner.
+    expect(schema).toContain('@@index([ownerId, createdAt(sort: Desc)])');
+    // Confirms the initial migration creates the same physical Postgres index.
+    expect(migration).toContain(
+      'CREATE INDEX "cluster_owner_id_created_at_idx" ON "public"."cluster"("owner_id", "created_at" DESC);',
+    );
+  });
+
+  it('builds cluster snapshots without rejoining membership for status breakdown', async () => {
+    // This case protects the snapshot aggregation from scanning cluster membership twice.
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const storage = new ClusterStorage({ $queryRaw: queryRaw } as never);
+
+    // Executes the method so the Prisma tagged SQL is constructed through real code.
+    await storage.getClusterSnapshot('cluster-a');
+
+    // Reads the raw SQL template sent to Prisma for structural assertions.
+    const sql = Array.from(queryRaw.mock.calls[0]?.[0] ?? []).join('?');
+
+    // Confirms the joined validator snapshot set is materialized once for reuse.
+    expect(sql).toContain('WITH merged_snapshot AS MATERIALIZED');
+    // Confirms status breakdown reuses the merged snapshot instead of a second membership join.
+    expect(sql).not.toContain('FROM cluster_validator cv2');
   });
 });

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -468,7 +468,7 @@ export class ClusterStorage {
         beacon_status_breakdown: string;
       }>
     >`
-      WITH merged_snapshot AS (
+      WITH merged_snapshot AS MATERIALIZED (
         SELECT
           cv.validator_index,
           vsa.is_inactive,
@@ -573,11 +573,10 @@ export class ClusterStorage {
         COALESCE(
           (SELECT json_object_agg(bs, cnt)::text
            FROM (
-             SELECT b2.beacon_status::text AS bs, COUNT(*)::int AS cnt
-             FROM cluster_validator cv2
-             JOIN validators_snapshot_balances b2 ON cv2.validator_index = b2.validator_index
-             WHERE cv2.cluster_id = ${clusterId}
-             GROUP BY b2.beacon_status
+             SELECT merged_snapshot.beacon_status::text AS bs, COUNT(*)::int AS cnt
+             FROM merged_snapshot
+             WHERE merged_snapshot.beacon_status IS NOT NULL
+             GROUP BY merged_snapshot.beacon_status
            ) sub),
           '{}'
         ) AS beacon_status_breakdown

--- a/packages/db/prisma/migrations/20251210144216_initial/migration.sql
+++ b/packages/db/prisma/migrations/20251210144216_initial/migration.sql
@@ -512,6 +512,9 @@ CREATE UNIQUE INDEX "user_telegram_id_key" ON "public"."user"("telegram_id");
 CREATE UNIQUE INDEX "user_username_key" ON "public"."user"("username");
 
 -- CreateIndex
+CREATE INDEX "cluster_owner_id_created_at_idx" ON "public"."cluster"("owner_id", "created_at" DESC);
+
+-- CreateIndex
 CREATE INDEX "cluster_validator_validator_index_idx" ON "public"."cluster_validator"("validator_index");
 
 -- CreateIndex

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -620,6 +620,7 @@ model Cluster {
   incidents  ClusterIncident[]
   validators ClusterValidator[]
 
+  @@index([ownerId, createdAt(sort: Desc)])
   @@map("cluster")
 }
 

--- a/packages/telegram-bot/src/scheduler/process-users.ts
+++ b/packages/telegram-bot/src/scheduler/process-users.ts
@@ -32,6 +32,6 @@ export async function processUsers(
     } catch (err) {
       log.error({ err, telegramId: user.telegramId }, 'Error notifying user');
     }
-    await delay(10_000, signal);
+    await delay(1_000, signal);
   }
 }


### PR DESCRIPTION
## Summary

- Reduce the Telegram user scheduler delay from 10 seconds to 1 second.
- Add a `cluster(owner_id, created_at DESC)` index to support owner-scoped cluster reads.
- Reuse the materialized snapshot CTE for `beacon_status_breakdown` so `getClusterSnapshot` does not rejoin cluster membership for that sub-aggregation.
- Add storage-level safeguards covering the index and query shape.

## Why

The dashboard notification loop was spending most of its wall time waiting between users. The cluster snapshot path also had avoidable database work that can increase server load as users and clusters grow.

## Validation

- `DATABASE_URL=postgresql://user:pass@localhost:5432/db API_TOKEN_SECRET=secretsecretsecretsecretsecretsecretsecretsecret TELEGRAM_BOT_TOKEN=dummy ALLOWED_ORIGINS=http://localhost:3000 CHAIN=gnosis COINGECKO_TOKEN_PRICE_API_URL=https://example.com COINGECKO_TOKEN_NAME=gnosis pnpm --filter @beacon-indexer/api test -- src/storage/cluster.test.ts`
- `pnpm --filter @beacon-indexer/api typecheck`
- `pnpm --filter @beacon-indexer/api lint`
- `pnpm --filter @beacon-indexer/db type-check`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db pnpm --filter @beacon-indexer/db exec prisma validate --schema prisma/schema.prisma`
- `pnpm --filter telegram-bot type-check`
- `git diff --check`
- pre-push `pnpm -r run lint`
