### PR TITLE
Use generic execution RPC rewards

### DIFF
--- a/docs/remote-indexer-restart.md
+++ b/docs/remote-indexer-restart.md
@@ -59,7 +59,8 @@ On the VPS:
 
 ```sh
 # Create a user used only for remote operations.
-sudo adduser ops
+# This avoids the interactive password prompt.
+sudo adduser --disabled-password --gecos "" ops
 ```
 
 Allow only the restart command:

--- a/docs/remote-indexer-restart.md
+++ b/docs/remote-indexer-restart.md
@@ -79,14 +79,43 @@ ops ALL=(root) NOPASSWD: /usr/local/bin/restart-indexer
 
 ## Step 5: Restart From Your Phone
 
-From your phone SSH app or shortcut:
+Find the VPS Tailscale name or IP:
 
 ```sh
-# Replace this with the VPS name shown in Tailscale.
+# Show the VPS name and Tailscale IP.
+tailscale status
+```
+
+Use either value in the SSH command:
+
+```sh
+# Replace this with the VPS name or Tailscale IP.
 ssh ops@<VPS_TAILSCALE_NAME> 'sudo /usr/local/bin/restart-indexer'
 ```
 
-That is the command to save as the phone shortcut.
+## Step 6: Add A One-Tap iPhone Shortcut
+
+On the iPhone:
+
+1. Open **Shortcuts**.
+2. Tap `+`.
+3. Search for **Run Script over SSH**.
+4. Set **Host** to the VPS Tailscale name or IP.
+5. Set **User** to `ops`.
+6. Set **Script** to:
+
+```sh
+# Restart the indexer service.
+sudo /usr/local/bin/restart-indexer
+```
+
+Then:
+
+1. Name it `Restart Indexer`.
+2. Tap the share button.
+3. Tap **Add to Home Screen**.
+
+After that, restarting the indexer is one tap from the iPhone home screen.
 
 ## Notes
 

--- a/packages/indexer/.env.example
+++ b/packages/indexer/.env.example
@@ -20,12 +20,8 @@ CONSENSUS_FULL_API_URL=https://...
 CONSENSUS_API_REQUEST_PER_SECOND=20
 ARCHIVE_DETAIL_RETENTION_DAYS=14
 
-EXECUTION_BLOCKSCOUT_URL=https://eth.blockscout.com
-EXECUTION_BLOCKSCOUT_KEY=
-EXECUTION_ETHERSCAN_URL=https://api.etherscan.io
-EXECUTION_ETHERSCAN_KEY=
-EXECUTION_QUICKNODE_URL=https://example.quicknode.pro
-EXECUTION_QUICKNODE_KEY=
+MAIN_EXECUTION_RPC=https://main-rpc.example.com/token-if-required
+BKP_EXECUTION_RPC=https://backup-rpc.example.com/token-if-required
 EXECUTION_API_REQUEST_PER_SECOND=3
 
 # ===========================================

--- a/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
+++ b/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
@@ -90,11 +90,8 @@ describe('Slot Processor E2E Tests', () => {
 
       // Create execution client mock
       const mockExecutionClient = new ExecutionClient({
-        executionBlockscoutUrl: 'http://mock-execution',
-        executionEtherscanUrl: 'http://mock-execution-backup',
-        executionQuicknodeUrl: 'http://mock-quicknode',
-        chainId: gnosisConfig.blockchain.chainId,
-        slotDuration: gnosisConfig.beacon.slotDuration,
+        mainExecutionRpc: 'http://mock-execution',
+        bkpExecutionRpc: 'http://mock-execution-backup',
         requestsPerSecond: 3,
       });
 
@@ -246,11 +243,8 @@ describe('Slot Processor E2E Tests', () => {
 
       // Create execution client mock
       const mockExecutionClient = new ExecutionClient({
-        executionBlockscoutUrl: 'http://mock-execution',
-        executionEtherscanUrl: 'http://mock-execution-backup',
-        executionQuicknodeUrl: 'http://mock-quicknode',
-        chainId: gnosisConfig.blockchain.chainId,
-        slotDuration: gnosisConfig.beacon.slotDuration,
+        mainExecutionRpc: 'http://mock-execution',
+        bkpExecutionRpc: 'http://mock-execution-backup',
         requestsPerSecond: 3,
       });
 
@@ -358,7 +352,7 @@ describe('Slot Processor E2E Tests', () => {
    * fetchExecutionRewards tests verify that execution layer rewards
    * (priority fees from the fee recipient) are correctly fetched and stored.
    *
-   * The QuickNode calculation test uses real JSON-RPC batch response data captured
+   * The execution RPC calculation test uses real JSON-RPC batch response data captured
    * from Gnosis block 45214731. The mock data is injected at the axios level so
    * the full getBlock() code path (hex parsing, baseFee subtraction, receipt iteration)
    * is exercised end-to-end.
@@ -367,17 +361,15 @@ describe('Slot Processor E2E Tests', () => {
     let executionClient: ExecutionClient;
     let slotControllerWithMock: SlotController;
 
-    // Real data from Gnosis block 45214731 fetched via QuickNode JSON-RPC batch
+    // Real data from Gnosis block 45214731 fetched via execution JSON-RPC batch.
     const BLOCK_NUMBER = 45214731;
     const SLOT = 24519343; // reuse an existing test slot number
     const EXPECTED_FEE_RECIPIENT = '0x86ead908fb5d6f900ff109c9e26f79300f99271a';
     // Verified against Blockscout Miner Reward for the same block
     const EXPECTED_REWARD = '1173967697074274';
 
-    // Real QuickNode JSON-RPC batch response for block 45214731 (Gnosis)
-    // Captured via: POST https://holy-sly-needle.xdai.quiknode.pro/...
-    // with [eth_getBlockByNumber, eth_getBlockReceipts] batch
-    const quicknodeBatchResponse = [
+    // Real execution JSON-RPC batch response for block 45214731 on Gnosis.
+    const executionRpcBatchResponse = [
       {
         jsonrpc: '2.0',
         id: 1,
@@ -421,16 +413,11 @@ describe('Slot Processor E2E Tests', () => {
       await prisma.validatorDeposits.deleteMany();
       await prisma.validatorConsolidationsRequests.deleteMany();
 
-      // Create execution client with only QuickNode configured (Gnosis chain).
-      // Blockscout URL is set to an unreachable address so the fallback chain
-      // reaches QuickNode, whose axios POST is intercepted below.
+      // Create execution client with generic execution RPC endpoints.
+      // The main RPC URL is intercepted below so the production JSON-RPC path runs.
       executionClient = new ExecutionClient({
-        executionBlockscoutUrl: 'http://0.0.0.0:1',
-        executionEtherscanUrl: 'http://0.0.0.0:1',
-        executionQuicknodeUrl: 'http://mock-quicknode',
-        executionQuicknodeKey: 'test-key',
-        chainId: gnosisConfig.blockchain.chainId,
-        slotDuration: gnosisConfig.beacon.slotDuration,
+        mainExecutionRpc: 'http://mock-execution-rpc',
+        bkpExecutionRpc: 'http://mock-execution-rpc-backup',
         requestsPerSecond: 3,
       });
 
@@ -477,8 +464,8 @@ describe('Slot Processor E2E Tests', () => {
       getBlockSpy.mockRestore();
     });
 
-    it('should calculate execution rewards from QuickNode JSON-RPC data and store in DB', async () => {
-      // Intercept the axios POST call that getBlock() makes to QuickNode.
+    it('should calculate execution rewards from execution JSON-RPC data and store in DB', async () => {
+      // Intercept the axios POST call that getBlock() makes to the execution RPC.
       // The real batch JSON-RPC response is returned so the full priority fee
       // calculation (hex parsing, baseFee subtraction, gasUsed multiplication)
       // runs through the production code path.
@@ -486,17 +473,17 @@ describe('Slot Processor E2E Tests', () => {
         .axiosInstance;
       const postSpy = vi
         .spyOn(axiosInstance, 'post' as never)
-        .mockResolvedValueOnce({ data: quicknodeBatchResponse } as never);
+        .mockResolvedValueOnce({ data: executionRpcBatchResponse } as never);
 
-      // Call fetchExecutionRewards — this triggers getBlock() which calls QuickNode
+      // Call fetchExecutionRewards — this triggers getBlock() which calls the execution RPC.
       await slotControllerWithMock.fetchExecutionRewards(SLOT, BLOCK_NUMBER);
 
-      // Verify the QuickNode batch POST was called with the correct URL and params
+      // Verify the execution RPC batch POST was called with the correct URL and params.
       expect(postSpy).toHaveBeenCalledOnce();
       const [url, body] = postSpy.mock.calls[0] as [string, unknown[]];
-      // URL should be base + key
-      expect(url).toBe('http://mock-quicknode/test-key');
-      // Body should be a JSON-RPC batch array
+      // URL should be the configured main execution RPC.
+      expect(url).toBe('http://mock-execution-rpc');
+      // Body should be a JSON-RPC batch array.
       expect(Array.isArray(body)).toBe(true);
       expect(body).toHaveLength(2);
 
@@ -586,11 +573,8 @@ describe('Slot Processor E2E Tests', () => {
 
       // Create execution client mock
       const mockExecutionClient = new ExecutionClient({
-        executionBlockscoutUrl: 'http://mock-execution',
-        executionEtherscanUrl: 'http://mock-execution-backup',
-        executionQuicknodeUrl: 'http://mock-quicknode',
-        chainId: gnosisConfig.blockchain.chainId,
-        slotDuration: gnosisConfig.beacon.slotDuration,
+        mainExecutionRpc: 'http://mock-execution',
+        bkpExecutionRpc: 'http://mock-execution-backup',
         requestsPerSecond: 3,
       });
 

--- a/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
+++ b/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
@@ -498,16 +498,18 @@ describe('Slot Processor E2E Tests', () => {
       postSpy.mockRestore();
     });
 
-    it('should throw error when getBlock returns null', async () => {
-      // Mock getBlock to return null (block not found)
-      const getBlockSpy = vi.spyOn(executionClient, 'getBlock').mockResolvedValueOnce(null);
+    it('should not update execution rewards when getBlock throws', async () => {
+      // Mock getBlock to throw when the execution RPC cannot return the block.
+      const getBlockSpy = vi
+        .spyOn(executionClient, 'getBlock')
+        .mockRejectedValueOnce(new Error(`Block ${BLOCK_NUMBER} not found`));
 
-      // Should throw error for missing block
+      // Should propagate the execution client error.
       await expect(
         slotControllerWithMock.fetchExecutionRewards(SLOT, BLOCK_NUMBER),
       ).rejects.toThrow(`Block ${BLOCK_NUMBER} not found`);
 
-      // Verify slot was NOT updated
+      // Verify slot was NOT updated.
       const slotData = await slotStorage.getBaseSlot(SLOT);
       expect(slotData.executionRewardsFetched).toBe(false);
 

--- a/packages/indexer/src/__tests__/setup.ts
+++ b/packages/indexer/src/__tests__/setup.ts
@@ -20,9 +20,8 @@ vi.hoisted(() => {
   process.env.CONSENSUS_API_REQUEST_PER_SECOND = '10';
 
   // Execution layer
-  process.env.EXECUTION_BLOCKSCOUT_URL = 'https://execution.example.com';
-  process.env.EXECUTION_ETHERSCAN_URL = 'https://execution-bkp.example.com';
-  process.env.EXECUTION_QUICKNODE_URL = 'https://quicknode.example.com';
+  process.env.MAIN_EXECUTION_RPC = 'https://execution.example.com';
+  process.env.BKP_EXECUTION_RPC = 'https://execution-bkp.example.com';
   process.env.EXECUTION_API_REQUEST_PER_SECOND = '10';
 });
 

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -135,14 +135,8 @@ async function main() {
   );
 
   const executionClient = new ExecutionClient({
-    executionBlockscoutUrl: env.EXECUTION_BLOCKSCOUT_URL,
-    executionBlockscoutKey: env.EXECUTION_BLOCKSCOUT_KEY,
-    executionEtherscanUrl: env.EXECUTION_ETHERSCAN_URL,
-    executionEtherscanKey: env.EXECUTION_ETHERSCAN_KEY,
-    executionQuicknodeUrl: env.EXECUTION_QUICKNODE_URL,
-    executionQuicknodeKey: env.EXECUTION_QUICKNODE_KEY,
-    chainId: chainConfig.blockchain.chainId,
-    slotDuration: chainConfig.beacon.slotDuration,
+    mainExecutionRpc: env.MAIN_EXECUTION_RPC,
+    bkpExecutionRpc: env.BKP_EXECUTION_RPC,
     requestsPerSecond: env.EXECUTION_API_REQUEST_PER_SECOND,
   });
 

--- a/packages/indexer/src/lib/env.ts
+++ b/packages/indexer/src/lib/env.ts
@@ -46,12 +46,8 @@ export const env = createEnv({
       z.number().int().positive().default(14),
     ),
     // Blockchain - Execution layer
-    EXECUTION_BLOCKSCOUT_URL: z.string().url(),
-    EXECUTION_BLOCKSCOUT_KEY: z.string().optional(),
-    EXECUTION_ETHERSCAN_URL: z.string().url(),
-    EXECUTION_ETHERSCAN_KEY: z.string().optional(),
-    EXECUTION_QUICKNODE_URL: z.string().url(),
-    EXECUTION_QUICKNODE_KEY: z.string().optional(),
+    MAIN_EXECUTION_RPC: z.string().url(),
+    BKP_EXECUTION_RPC: z.string().url(),
     EXECUTION_API_REQUEST_PER_SECOND: z.preprocess(
       (val) => Number(val),
       z.number().int().positive(),

--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -179,9 +179,6 @@ export class SlotController extends SlotControllerHelpers {
     }
 
     const blockInfo = await this.executionClient.getBlock(blockNumber);
-    if (!blockInfo) {
-      throw new Error(`Block ${blockNumber} not found`);
-    }
     await this.slotStorage.saveExecutionRewardsAndUpdateSlot(
       slot,
       blockInfo.amount,

--- a/packages/indexer/src/services/execution/execution.test.ts
+++ b/packages/indexer/src/services/execution/execution.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ExecutionClient } from '@/src/services/execution/execution.js';
 
@@ -10,11 +10,17 @@ describe('ExecutionClient', () => {
   // This hook resets mocks and creates a clean execution client before each test.
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     executionClient = new ExecutionClient({
       mainExecutionRpc: 'http://main-rpc',
       bkpExecutionRpc: 'http://bkp-rpc',
       requestsPerSecond: 3,
     });
+  });
+
+  // This hook restores fake timers if a test exits before its local cleanup runs.
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   // This test verifies that getBlock calculates the fee recipient reward from JSON-RPC data.
@@ -61,6 +67,120 @@ describe('ExecutionClient', () => {
 
     // This assertion verifies the generic RPC URL is called directly without provider-specific keys.
     expect(postSpy.mock.calls[0]?.[0]).toBe('http://main-rpc');
+  });
+
+  // This test verifies that JSON-RPC batch responses are matched by response id, not array order.
+  it('matches JSON-RPC batch responses by id when the RPC returns them out of order', async () => {
+    // This response intentionally returns receipts before the block response.
+    const rpcBatchResponse = [
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        result: [{ gasUsed: '0x1', effectiveGasPrice: '0xb' }],
+      },
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          number: '0xa',
+          timestamp: '0x64',
+          miner: '0xfeeRecipient',
+          baseFeePerGas: '0xa',
+        },
+      },
+    ];
+
+    // This spy returns the out-of-order batch from the main RPC endpoint.
+    const axiosInstance = (executionClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    vi.spyOn(axiosInstance, 'post' as never).mockResolvedValueOnce({
+      data: rpcBatchResponse,
+    } as never);
+
+    // This call verifies the client uses response ids to find the block and receipts.
+    await expect(executionClient.getBlock(10)).resolves.toMatchObject({
+      address: '0xfeeRecipient',
+      amount: '1',
+      blockNumber: 10,
+    });
+  });
+
+  // This test verifies that waiting retries do not hold the RPC concurrency limiter.
+  it('does not hold a concurrency slot while a failed block waits before retrying', async () => {
+    // This client has one RPC slot so a sleeping retry would block all other blocks.
+    executionClient = new ExecutionClient({
+      mainExecutionRpc: 'http://main-rpc',
+      bkpExecutionRpc: 'http://bkp-rpc',
+      requestsPerSecond: 1,
+    });
+
+    // This fake timer lets the test pause the first request during its backoff delay.
+    vi.useFakeTimers();
+
+    // This successful response is returned for the second block while the first block waits.
+    const successResponse = [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          number: '0xb',
+          timestamp: '0x64',
+          miner: '0xfeeRecipient',
+          baseFeePerGas: '0xa',
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        result: [{ gasUsed: '0x1', effectiveGasPrice: '0xb' }],
+      },
+    ];
+
+    // This spy fails block 10 but succeeds for block 11.
+    const axiosInstance = (executionClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockImplementation(((
+      url: string,
+      body: Array<{ params: string[] }>,
+    ) => {
+      const requestedBlock = body[0]?.params[0];
+      if (requestedBlock === '0xb') {
+        return Promise.resolve({ data: successResponse });
+      }
+      return Promise.reject(new Error(`failed ${url}`));
+    }) as never);
+
+    // This request fails against main and backup, then waits before retrying.
+    const failedBlockPromise = executionClient.getBlock(10).catch((error: unknown) => error);
+
+    // This timer advance lets the first request enter its first backoff delay.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // This request should use the free RPC slot while the first request is sleeping.
+    const successfulBlockPromise = executionClient.getBlock(11);
+
+    // This timer advance lets the second request make its network call.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // This assertion proves the second block was not blocked by the first block's sleep.
+    await expect(successfulBlockPromise).resolves.toMatchObject({
+      address: '0xfeeRecipient',
+      amount: '1',
+      blockNumber: 11,
+    });
+
+    // This assertion verifies that the second request reached the RPC during the first backoff.
+    expect(postSpy.mock.calls.map((call) => call[0])).toContain('http://main-rpc');
+    expect(postSpy.mock.calls).toHaveLength(3);
+
+    // This timer advance lets the failed first block exhaust its retry cycles.
+    await vi.advanceTimersByTimeAsync(100 + 200 + 400 + 800);
+    const failedBlockError = await failedBlockPromise;
+    expect(failedBlockError).toBeInstanceOf(Error);
+    expect((failedBlockError as Error).message).toContain('[BKP] failed for block 10');
+
+    // This cleanup restores real timers for the rest of the test process.
+    vi.useRealTimers();
   });
 
   // This test verifies that getBlock tries main then backup as a pair before each backoff delay.

--- a/packages/indexer/src/services/execution/execution.test.ts
+++ b/packages/indexer/src/services/execution/execution.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExecutionClient } from '@/src/services/execution/execution.js';
+
+// This test suite verifies the generic execution RPC reward calculation and fallback strategy.
+describe('ExecutionClient', () => {
+  // This block creates a client with main and backup RPC URLs for each test.
+  let executionClient: ExecutionClient;
+
+  // This hook resets mocks and creates a clean execution client before each test.
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    executionClient = new ExecutionClient({
+      mainExecutionRpc: 'http://main-rpc',
+      bkpExecutionRpc: 'http://bkp-rpc',
+      requestsPerSecond: 3,
+    });
+  });
+
+  // This test verifies that getBlock calculates the fee recipient reward from JSON-RPC data.
+  it('calculates block priority fees from a generic execution RPC response', async () => {
+    // This response provides one block and two receipts with EIP-1559 fee data.
+    const rpcBatchResponse = [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          number: '0xa',
+          timestamp: '0x64',
+          miner: '0xfeeRecipient',
+          baseFeePerGas: '0xa',
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        result: [
+          { gasUsed: '0x5208', effectiveGasPrice: '0xf' },
+          { gasUsed: '0x10', effectiveGasPrice: '0xc' },
+        ],
+      },
+    ];
+
+    // This spy returns the batch response from the main RPC endpoint.
+    const axiosInstance = (executionClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi
+      .spyOn(axiosInstance, 'post' as never)
+      .mockResolvedValueOnce({ data: rpcBatchResponse } as never);
+
+    // This call exercises the full getBlock JSON-RPC parsing and reward calculation path.
+    const block = await executionClient.getBlock(10);
+
+    // This assertion verifies the execution reward is the sum of positive priority fees.
+    expect(block).toEqual({
+      address: '0xfeeRecipient',
+      timestamp: new Date(100_000),
+      amount: '105032',
+      blockNumber: 10,
+    });
+
+    // This assertion verifies the generic RPC URL is called directly without provider-specific keys.
+    expect(postSpy.mock.calls[0]?.[0]).toBe('http://main-rpc');
+  });
+
+  // This test verifies that getBlock tries main then backup as a pair before each backoff delay.
+  it('tries main then backup for each retry cycle before waiting with exponential backoff', async () => {
+    // This response succeeds on the final backup attempt.
+    const successResponse = [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          number: '0xa',
+          timestamp: '0x64',
+          miner: '0xfeeRecipient',
+          baseFeePerGas: '0xa',
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        result: [{ gasUsed: '0x1', effectiveGasPrice: '0xb' }],
+      },
+    ];
+
+    // This fake timer lets the test assert backoff without waiting in real time.
+    vi.useFakeTimers();
+
+    // This spy fails two complete main/backup cycles, then succeeds on backup in cycle three.
+    const axiosInstance = (executionClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi
+      .spyOn(axiosInstance, 'post' as never)
+      .mockRejectedValueOnce(new Error('main cycle 1') as never)
+      .mockRejectedValueOnce(new Error('bkp cycle 1') as never)
+      .mockRejectedValueOnce(new Error('main cycle 2') as never)
+      .mockRejectedValueOnce(new Error('bkp cycle 2') as never)
+      .mockRejectedValueOnce(new Error('main cycle 3') as never)
+      .mockResolvedValueOnce({ data: successResponse } as never);
+
+    // This promise starts the retry sequence while fake timers control the delays.
+    const blockPromise = executionClient.getBlock(10);
+
+    // This microtask flush lets the first main/backup pair fail and schedule the 100ms delay.
+    await vi.advanceTimersByTimeAsync(100);
+
+    // This timer advance lets the second main/backup pair fail and schedule the 200ms delay.
+    await vi.advanceTimersByTimeAsync(200);
+
+    // This assertion verifies the final backup attempt returns the successful block response.
+    await expect(blockPromise).resolves.toMatchObject({
+      address: '0xfeeRecipient',
+      amount: '1',
+    });
+
+    // This assertion verifies the endpoint order is main, backup for each retry cycle.
+    expect(postSpy.mock.calls.map((call) => call[0])).toEqual([
+      'http://main-rpc',
+      'http://bkp-rpc',
+      'http://main-rpc',
+      'http://bkp-rpc',
+      'http://main-rpc',
+      'http://bkp-rpc',
+    ]);
+
+    // This cleanup restores real timers for the rest of the test process.
+    vi.useRealTimers();
+  });
+});

--- a/packages/indexer/src/services/execution/execution.ts
+++ b/packages/indexer/src/services/execution/execution.ts
@@ -1,15 +1,12 @@
 import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import ms from 'ms';
 import pLimit from 'p-limit';
-import pRetry from 'p-retry';
 
 import { logError, logRequest, logResponse } from '@/src/lib/httpPino.js';
 import {
-  Blockscout_Blocks,
-  Etherscan_BlockReward,
   JsonRpcResponse,
-  QuickNode_Block,
-  QuickNode_TransactionReceipt,
+  RpcBlock,
+  RpcTransactionReceipt,
 } from '@/src/services/execution/types.js';
 
 export type BlockResponse = {
@@ -20,20 +17,13 @@ export type BlockResponse = {
 };
 
 export interface ExecutionClientConfig {
-  executionBlockscoutUrl: string;
-  executionBlockscoutKey?: string;
-  executionEtherscanUrl: string;
-  executionEtherscanKey?: string;
-  executionQuicknodeUrl: string;
-  executionQuicknodeKey?: string;
-  chainId: number;
-  slotDuration: number;
+  mainExecutionRpc: string;
+  bkpExecutionRpc: string;
   requestsPerSecond: number;
 }
 
 /**
- * ExecutionClient - Client for execution layer endpoints
- * Similar pattern to BeaconClient, receives configuration via constructor
+ * ExecutionClient fetches execution block rewards from generic JSON-RPC endpoints.
  */
 export class ExecutionClient {
   private readonly axiosInstance: AxiosInstance;
@@ -45,7 +35,7 @@ export class ExecutionClient {
     this.limiter = pLimit(config.requestsPerSecond);
     this.axiosInstance = axios.create({ timeout: ms('2.5s') });
 
-    // Setup interceptors
+    // Log every execution RPC request before it is sent.
     this.axiosInstance.interceptors.request.use(async (config: InternalAxiosRequestConfig) => {
       logRequest(config);
       return config;
@@ -54,163 +44,122 @@ export class ExecutionClient {
     this.axiosInstance.interceptors.response.use(logResponse, logError);
   }
 
+  /**
+   * Fetch execution block rewards from the main RPC and fallback RPC.
+   */
   async getBlock(blockNumber: number): Promise<BlockResponse | null> {
     return this.limiter(async () => {
-      // Define endpoints
-      const etherscanEndpoint = {
-        name: 'Etherscan',
-        fetch: async (): Promise<BlockResponse> => {
-          // https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblockreward&blockno=2165403&apikey=YourApiKeyToken
-          const url = `${this.config.executionEtherscanUrl}/api?chainid=${this.config.chainId}&module=block&action=getblockreward&blockno=${blockNumber}&apikey=${this.config.executionEtherscanKey || ''}`;
-          const response = await this.axiosInstance.get<Etherscan_BlockReward>(url);
-          const blockInfo = response.data;
-
-          if (blockInfo.status !== '1' || blockInfo.message !== 'OK') {
-            throw new Error(
-              `Etherscan API error: ${blockInfo.message} (status: ${blockInfo.status})`,
-            );
-          }
-
-          if (!blockInfo.result?.blockMiner || !blockInfo.result?.blockReward) {
-            throw new Error(`Unexpected Etherscan block response: ${JSON.stringify(blockInfo)}`);
-          }
-
-          return {
-            address: blockInfo.result.blockMiner,
-            timestamp: new Date(Number(blockInfo.result.timeStamp) * 1000),
-            amount: blockInfo.result.blockReward,
-            blockNumber: Number(blockInfo.result.blockNumber),
-          };
-        },
-      };
-
-      const blockscoutEndpoint = {
-        name: 'Blockscout',
-        fetch: async (): Promise<BlockResponse> => {
-          const url = `${this.config.executionBlockscoutUrl}/api/v2/blocks/${blockNumber}`;
-          const response = await this.axiosInstance.get<Blockscout_Blocks>(url);
-          const blockInfo = response.data;
-          const minerReward = blockInfo.rewards.find((r) => r.type === 'Miner Reward');
-
-          if (!minerReward || blockInfo.rewards.length === 0) {
-            return {
-              address: blockInfo.miner?.hash ?? '',
-              timestamp: new Date(blockInfo.timestamp),
-              amount: '0',
-              blockNumber: blockInfo.height,
-            };
-          }
-
-          if (!blockInfo.miner || !blockInfo.miner.hash) {
-            throw new Error(`Unexpected block response: ${JSON.stringify(blockInfo)}`);
-          }
-
-          return {
-            address: blockInfo.miner.hash,
-            timestamp: new Date(blockInfo.timestamp),
-            amount: minerReward?.reward ?? '0',
-            blockNumber: blockInfo.height,
-          };
-        },
-      };
-
-      const quicknodeEndpoint = {
-        name: 'QuickNode',
-        fetch: async (): Promise<BlockResponse> => {
-          const baseUrl = this.config.executionQuicknodeUrl.replace(/\/$/, '');
-          const quicknodeUrl = this.config.executionQuicknodeKey
-            ? `${baseUrl}/${this.config.executionQuicknodeKey}`
-            : baseUrl;
-          const hexBlock = `0x${blockNumber.toString(16)}`;
-
-          // Single batch JSON-RPC request for block header + receipts
-          const batchRes = await this.axiosInstance.post<
-            [JsonRpcResponse<QuickNode_Block>, JsonRpcResponse<QuickNode_TransactionReceipt[]>]
-          >(quicknodeUrl, [
-            {
-              jsonrpc: '2.0',
-              id: 1,
-              method: 'eth_getBlockByNumber',
-              params: [hexBlock, false],
-            },
-            { jsonrpc: '2.0', id: 2, method: 'eth_getBlockReceipts', params: [hexBlock] },
-          ]);
-
-          const [blockRpc, receiptsRpc] = batchRes.data;
-
-          if (blockRpc.error) {
-            throw new Error(`QuickNode eth_getBlockByNumber error: ${blockRpc.error.message}`);
-          }
-          if (receiptsRpc.error) {
-            throw new Error(`QuickNode eth_getBlockReceipts error: ${receiptsRpc.error.message}`);
-          }
-
-          const block = blockRpc.result;
-          const receipts = receiptsRpc.result;
-
-          if (!block || !receipts) {
-            throw new Error(`QuickNode returned null for block ${blockNumber}`);
-          }
-
-          const baseFee = BigInt(block.baseFeePerGas);
-
-          // Total priority fees = sum of (effectiveGasPrice - baseFeePerGas) * gasUsed
-          let totalPriorityFees = 0n;
-          for (const receipt of receipts) {
-            const effectiveGasPrice = BigInt(receipt.effectiveGasPrice);
-            const gasUsed = BigInt(receipt.gasUsed);
-            const tip = effectiveGasPrice - baseFee;
-            if (tip > 0n) {
-              totalPriorityFees += tip * gasUsed;
-            }
-          }
-
-          return {
-            address: block.miner,
-            timestamp: new Date(Number(BigInt(block.timestamp)) * 1000),
-            amount: totalPriorityFees.toString(),
-            blockNumber: Number(BigInt(block.number)),
-          };
-        },
-      };
-
-      // Gnosis: Blockscout > QuickNode (Etherscan doesn't support getblockreward for Gnosis)
-      // Ethereum: Etherscan > Blockscout > QuickNode
-      const isGnosis = this.config.chainId === 100;
-      const endpoints = isGnosis
-        ? [quicknodeEndpoint, blockscoutEndpoint]
-        : [etherscanEndpoint, quicknodeEndpoint, blockscoutEndpoint];
-
-      // Try all endpoints in sequence, then backoff and retry the full cycle
-      return await pRetry(
-        async () => {
-          let lastError: unknown;
-
-          for (const endpoint of endpoints) {
-            try {
-              return await endpoint.fetch();
-            } catch (error) {
-              const status = axios.isAxiosError(error) ? error.response?.status : undefined;
-              const responseData = axios.isAxiosError(error) ? error.response?.data : undefined;
-
-              const context =
-                `[${endpoint.name}] failed for block ${blockNumber}` +
-                (status ? ` (HTTP ${status})` : '') +
-                (responseData
-                  ? ` - response: ${JSON.stringify(responseData)}`
-                  : ` - ${error instanceof Error ? error.message : String(error)}`);
-
-              lastError = new Error(context, { cause: error });
-            }
-          }
-
-          throw lastError || new Error(`All endpoints failed for block ${blockNumber}`);
-        },
-        {
-          retries: 30,
-          minTimeout: ms('1s'),
-        },
-      );
+      return await this.fetchBlockWithFallback(blockNumber);
     });
+  }
+
+  /**
+   * Try main and backup RPC endpoints as a pair before applying exponential backoff.
+   */
+  private async fetchBlockWithFallback(blockNumber: number): Promise<BlockResponse> {
+    const maxCycles = 5;
+    const baseDelayMs = 100;
+    let lastError: unknown;
+
+    for (let cycle = 0; cycle < maxCycles; cycle++) {
+      for (const endpoint of this.getRpcEndpoints()) {
+        try {
+          return await this.fetchBlockFromRpc(endpoint.url, blockNumber);
+        } catch (error) {
+          lastError = new Error(
+            `[${endpoint.name}] failed for block ${blockNumber} - ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+            { cause: error },
+          );
+        }
+      }
+
+      if (cycle < maxCycles - 1) {
+        await this.wait(baseDelayMs * Math.pow(2, cycle));
+      }
+    }
+
+    throw lastError || new Error(`All execution RPC endpoints failed for block ${blockNumber}`);
+  }
+
+  /**
+   * Return the execution RPC endpoints in the order they should be tried.
+   */
+  private getRpcEndpoints(): Array<{ name: 'MAIN' | 'BKP'; url: string }> {
+    return [
+      { name: 'MAIN', url: this.config.mainExecutionRpc },
+      { name: 'BKP', url: this.config.bkpExecutionRpc },
+    ];
+  }
+
+  /**
+   * Fetch and parse one execution block using standard JSON-RPC methods.
+   */
+  private async fetchBlockFromRpc(url: string, blockNumber: number): Promise<BlockResponse> {
+    const hexBlock = `0x${blockNumber.toString(16)}`;
+
+    // Fetch the block header and receipts together so reward calculation uses one block view.
+    const batchRes = await this.axiosInstance.post<
+      [JsonRpcResponse<RpcBlock>, JsonRpcResponse<RpcTransactionReceipt[]>]
+    >(url, [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_getBlockByNumber',
+        params: [hexBlock, false],
+      },
+      { jsonrpc: '2.0', id: 2, method: 'eth_getBlockReceipts', params: [hexBlock] },
+    ]);
+
+    const [blockRpc, receiptsRpc] = batchRes.data;
+
+    if (blockRpc.error) {
+      throw new Error(`eth_getBlockByNumber error: ${blockRpc.error.message}`);
+    }
+    if (receiptsRpc.error) {
+      throw new Error(`eth_getBlockReceipts error: ${receiptsRpc.error.message}`);
+    }
+
+    const block = blockRpc.result;
+    const receipts = receiptsRpc.result;
+
+    if (!block || !receipts) {
+      throw new Error(`Execution RPC returned null for block ${blockNumber}`);
+    }
+
+    return {
+      address: block.miner,
+      timestamp: new Date(Number(BigInt(block.timestamp)) * 1000),
+      amount: this.calculatePriorityFees(block.baseFeePerGas, receipts),
+      blockNumber: Number(BigInt(block.number)),
+    };
+  }
+
+  /**
+   * Calculate the total priority fees paid to the execution block fee recipient.
+   */
+  private calculatePriorityFees(baseFeePerGas: string, receipts: RpcTransactionReceipt[]): string {
+    const baseFee = BigInt(baseFeePerGas);
+    let totalPriorityFees = 0n;
+
+    for (const receipt of receipts) {
+      const effectiveGasPrice = BigInt(receipt.effectiveGasPrice);
+      const gasUsed = BigInt(receipt.gasUsed);
+      const tip = effectiveGasPrice - baseFee;
+
+      if (tip > 0n) {
+        totalPriorityFees += tip * gasUsed;
+      }
+    }
+
+    return totalPriorityFees.toString();
+  }
+
+  /**
+   * Wait for the given number of milliseconds before the next retry cycle.
+   */
+  private async wait(delayMs: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
 }

--- a/packages/indexer/src/services/execution/execution.ts
+++ b/packages/indexer/src/services/execution/execution.ts
@@ -47,7 +47,7 @@ export class ExecutionClient {
   /**
    * Fetch execution block rewards from the main RPC and fallback RPC.
    */
-  async getBlock(blockNumber: number): Promise<BlockResponse | null> {
+  async getBlock(blockNumber: number): Promise<BlockResponse> {
     return await this.fetchBlockWithFallback(blockNumber);
   }
 

--- a/packages/indexer/src/services/execution/execution.ts
+++ b/packages/indexer/src/services/execution/execution.ts
@@ -48,9 +48,7 @@ export class ExecutionClient {
    * Fetch execution block rewards from the main RPC and fallback RPC.
    */
   async getBlock(blockNumber: number): Promise<BlockResponse | null> {
-    return this.limiter(async () => {
-      return await this.fetchBlockWithFallback(blockNumber);
-    });
+    return await this.fetchBlockWithFallback(blockNumber);
   }
 
   /**
@@ -67,9 +65,7 @@ export class ExecutionClient {
           return await this.fetchBlockFromRpc(endpoint.url, blockNumber);
         } catch (error) {
           lastError = new Error(
-            `[${endpoint.name}] failed for block ${blockNumber} - ${
-              error instanceof Error ? error.message : String(error)
-            }`,
+            `[${endpoint.name}] failed for block ${blockNumber}${this.formatErrorContext(error)}`,
             { cause: error },
           );
         }
@@ -100,19 +96,36 @@ export class ExecutionClient {
     const hexBlock = `0x${blockNumber.toString(16)}`;
 
     // Fetch the block header and receipts together so reward calculation uses one block view.
-    const batchRes = await this.axiosInstance.post<
-      [JsonRpcResponse<RpcBlock>, JsonRpcResponse<RpcTransactionReceipt[]>]
-    >(url, [
-      {
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'eth_getBlockByNumber',
-        params: [hexBlock, false],
-      },
-      { jsonrpc: '2.0', id: 2, method: 'eth_getBlockReceipts', params: [hexBlock] },
-    ]);
+    const batchRes = await this.limiter(() =>
+      this.axiosInstance.post<
+        Array<JsonRpcResponse<RpcBlock> | JsonRpcResponse<RpcTransactionReceipt[]>>
+      >(url, [
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_getBlockByNumber',
+          params: [hexBlock, false],
+        },
+        { jsonrpc: '2.0', id: 2, method: 'eth_getBlockReceipts', params: [hexBlock] },
+      ]),
+    );
 
-    const [blockRpc, receiptsRpc] = batchRes.data;
+    const responses = batchRes.data;
+
+    if (!Array.isArray(responses)) {
+      throw new Error(`Execution RPC returned invalid batch response for block ${blockNumber}`);
+    }
+
+    const blockRpc = responses.find((response) => response.id === 1) as
+      | JsonRpcResponse<RpcBlock>
+      | undefined;
+    const receiptsRpc = responses.find((response) => response.id === 2) as
+      | JsonRpcResponse<RpcTransactionReceipt[]>
+      | undefined;
+
+    if (!blockRpc || !receiptsRpc) {
+      throw new Error(`Execution RPC batch response missing results for block ${blockNumber}`);
+    }
 
     if (blockRpc.error) {
       throw new Error(`eth_getBlockByNumber error: ${blockRpc.error.message}`);
@@ -161,5 +174,19 @@ export class ExecutionClient {
    */
   private async wait(delayMs: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  /**
+   * Format HTTP and RPC error context for retry failure messages.
+   */
+  private formatErrorContext(error: unknown): string {
+    const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+    const responseData = axios.isAxiosError(error) ? error.response?.data : undefined;
+    const message = error instanceof Error ? error.message : String(error);
+
+    return (
+      (status ? ` (HTTP ${status})` : '') +
+      (responseData ? ` - response: ${JSON.stringify(responseData)}` : ` - ${message}`)
+    );
   }
 }

--- a/packages/indexer/src/services/execution/types.ts
+++ b/packages/indexer/src/services/execution/types.ts
@@ -1,81 +1,11 @@
-export type Blockscout_Miner = {
-  ens_domain_name: string | null;
-  hash: string; // miner address
-  implementations: unknown[];
-  is_contract: boolean;
-  is_verified: boolean;
-  metadata: unknown | null;
-  name: string | null;
-  private_tags: unknown[];
-  proxy_type: string | null;
-  public_tags: unknown[];
-  watchlist_names: unknown[];
-};
-
-export type Blockscout_Reward = {
-  reward: string; // reward in wei
-  type: string; // check for "Miner Reward"
-};
-
-export type Blockscout_Blocks = {
-  base_fee_per_gas: string;
-  blob_gas_price: string | null;
-  blob_gas_used: string;
-  blob_tx_count: number;
-  burnt_blob_fees: string;
-  burnt_fees: string;
-  burnt_fees_percentage: number | null;
-  difficulty: string;
-  excess_blob_gas: string;
-  gas_limit: string;
-  gas_target_percentage: number;
-  gas_used: string;
-  gas_used_percentage: number;
-  hash: string;
-  height: number;
-  miner: Blockscout_Miner;
-  nonce: string;
-  parent_hash: string;
-  priority_fee: number;
-  rewards: Blockscout_Reward[];
-  size: number;
-  timestamp: string;
-  total_difficulty: string;
-  tx_count: number;
-  tx_fees: string;
-  type: string;
-  uncles_hashes: string[];
-  withdrawals_count: number;
-};
-
-export type Etherscan_Uncle = {
-  miner: string;
-  unclePosition: string;
-  blockreward: string;
-};
-
-export type Etherscan_BlockReward = {
-  status: string;
-  message: string;
-  result: {
-    blockNumber: string;
-    timeStamp: string;
-    blockMiner: string;
-    blockReward: string;
-    uncles: Etherscan_Uncle[];
-    uncleInclusionReward: string;
-  };
-};
-
-// QuickNode JSON-RPC types
-export type QuickNode_Block = {
+export type RpcBlock = {
   number: string; // hex
   timestamp: string; // hex
   miner: string; // fee recipient address
   baseFeePerGas: string; // hex
 };
 
-export type QuickNode_TransactionReceipt = {
+export type RpcTransactionReceipt = {
   gasUsed: string; // hex
   effectiveGasPrice: string; // hex
 };

--- a/packages/indexer/src/services/execution/types.ts
+++ b/packages/indexer/src/services/execution/types.ts
@@ -13,6 +13,6 @@ export type RpcTransactionReceipt = {
 export type JsonRpcResponse<T> = {
   jsonrpc: string;
   id: number;
-  result: T;
+  result?: T;
   error?: { code: number; message: string };
 };


### PR DESCRIPTION
## Summary

- Replace Etherscan/Blockscout execution reward fetching with generic execution JSON-RPC calls.
- Add MAIN_EXECUTION_RPC and BKP_EXECUTION_RPC env config.
- Retry execution reward fetches in five MAIN > BKP cycles with short exponential backoff.
- Keep priority-fee reward calculation and update e2e/unit coverage for the new RPC path.

## Validation

- pnpm --filter indexer test -- src/services/execution/execution.test.ts
- pnpm --filter indexer type-check
- commit hook: ESLint, Prettier, indexer type-check
- push hook: pnpm -r run lint