### PR TITLE
Fix lookback-aligned partition pairing

### DIFF
--- a/packages/beacon-utils/src/beaconTime.ts
+++ b/packages/beacon-utils/src/beaconTime.ts
@@ -188,16 +188,24 @@ export class BeaconTime {
   }
 
   /**
-   * Calculate the first slot of the UTC hour that contains the given slot.
+   * Calculate the first slot starting inside the UTC hour that contains the given slot.
    * Partitions are aligned to UTC hour boundaries (e.g., 10:00, 11:00, 12:00).
    *
    * @param slot - The slot number
-   * @returns The first slot of the UTC hour containing this slot
+   * @returns The first slot whose start timestamp is inside the containing UTC hour
    */
   getSlotAtStartOfUTCHourContaining(slot: number): number {
     const ts = this.getTimestampFromSlotNumber(slot);
     const hourStartTs = Math.floor(ts / 3_600_000) * 3_600_000; // floor to UTC hour
-    return this.getSlotNumberFromTimestamp(hourStartTs);
+
+    if (hourStartTs <= this.genesisTimestamp) {
+      return 0;
+    }
+
+    const hourStartSlot = this.getSlotNumberFromTimestamp(hourStartTs);
+    const hourStartSlotTs = this.getTimestampFromSlotNumber(hourStartSlot);
+
+    return hourStartSlotTs < hourStartTs ? hourStartSlot + 1 : hourStartSlot;
   }
 
   /**

--- a/packages/indexer/e2e/epoch/epochPartitioning.test.ts
+++ b/packages/indexer/e2e/epoch/epochPartitioning.test.ts
@@ -72,9 +72,9 @@ describe('Partitioning by epoch', () => {
     it('should create partition aligned to UTC hour boundary', async () => {
       // Epoch 1586252: slots 25380032-25380047 (Dec-16-2025 13:58:20 - 13:59:35 UTC)
       // lookbackSlot: 25380000 (before this epoch)
-      // Expected partition: committee_25379332-25380051_YYYYMMDDHH (UTC hour boundary for 13:00 UTC)
+      // Expected partition: committee_25380000-25380051_YYYYMMDDHH (lookback to 13:00 UTC hour end)
       const epoch = 1586252;
-      const startSlot = 25379332;
+      const startSlot = 25380000;
       const endSlot = 25380051;
 
       // Calculate UTC hour timestamp from the start slot using real Gnosis chain data
@@ -98,7 +98,7 @@ describe('Partitioning by epoch', () => {
 
       expect(partitionExists[0]?.exists).toBe(true);
 
-      // Verify partition has correct range [25379332, 25380052)
+      // Verify partition has correct range [25380000, 25380052)
       const partitionInfo = await prisma.$queryRaw<Array<{ partition_expression: string }>>`
         SELECT pg_get_expr(c.relpartbound, c.oid) as partition_expression
         FROM pg_class c
@@ -107,7 +107,7 @@ describe('Partitioning by epoch', () => {
 
       expect(partitionInfo).toHaveLength(1);
       const expression = partitionInfo[0].partition_expression;
-      expect(expression).toContain('25379332');
+      expect(expression).toContain('25380000');
       expect(expression).toContain('25380052'); // exclusive end
 
       // Verify the partition is actually a child of committee table
@@ -125,12 +125,12 @@ describe('Partitioning by epoch', () => {
       // Epoch 1586253: slots 25380048-25380063 (Dec-16-2025 01:59:40 PM +UTC - 02:00:55 PM +UTC)
       // (crosses UTC hour boundary from 13:00 to 14:00)
       // Expected partitions:
-      // - committee_25379332-25380051_YYYYMMDDHH (13:00 UTC hour)
+      // - committee_25380000-25380051_YYYYMMDDHH (lookback to 13:00 UTC hour end)
       // - committee_25380052-25380771_YYYYMMDDHH (14:00 UTC hour)
       const epoch = 1586253;
 
       // Calculate expected partition names using real Gnosis chain timestamps
-      const startSlot0 = 25379332;
+      const startSlot0 = 25380000;
       const endSlot0 = 25380051;
       const startSlot0Timestamp = beaconTimeWithLookback.getTimestampFromSlotNumber(startSlot0);
       const hourTimestamp0 = getUTCDatetimeFlooredToHour(startSlot0Timestamp);
@@ -184,16 +184,16 @@ describe('Partitioning by epoch', () => {
         WHERE c.relname = ${expectedPartition1Name}
       `;
 
-      expect(partition0Info[0].partition_expression).toContain('25379332');
+      expect(partition0Info[0].partition_expression).toContain('25380000');
       expect(partition0Info[0].partition_expression).toContain('25380052'); // exclusive end
       expect(partition1Info[0].partition_expression).toContain('25380052');
       expect(partition1Info[0].partition_expression).toContain('25380772'); // exclusive end
     });
 
     it('should be idempotent - calling multiple times should not cause errors', async () => {
-      // Epoch 1586252 should create partition committee_25379332-25380051_YYYYMMDDHH
+      // Epoch 1586252 should create partition committee_25380000-25380051_YYYYMMDDHH
       const epoch = 1586252;
-      const startSlot = 25379332;
+      const startSlot = 25380000;
       const endSlot = 25380051;
 
       // Calculate expected partition name using real Gnosis chain timestamps

--- a/packages/indexer/e2e/epoch/epochPartitioning.test.ts
+++ b/packages/indexer/e2e/epoch/epochPartitioning.test.ts
@@ -251,10 +251,10 @@ describe('Partitioning by epoch', () => {
     it('should create partition aligned to UTC hour boundary using epochs', async () => {
       // Epoch 1586252: slots 25380032-25380047 (Dec-16-2025 13:58:20 - 13:59:35 UTC)
       // lookbackSlot: 25380000 (before this epoch)
-      // Expected partition: epoch_rewards_1586209-1586253_YYYYMMDDHH (UTC hour boundary for 13:00 UTC)
-      // Note: epoch 1586208 starts at 12:00 UTC, so first epoch in 13:00 UTC hour is 1586209
+      // Expected partition: epoch_rewards_1586250-1586253_YYYYMMDDHH (lookback epoch to 13:00 UTC hour end)
+      // Note: lookbackSlot 25380000 is inside epoch 1586250, so this first hour is partial.
       const epoch = 1586252;
-      const startEpoch = 1586209;
+      const startEpoch = 1586250;
       const endEpoch = 1586253;
 
       // Calculate UTC hour timestamp from the start epoch using real Gnosis chain data
@@ -278,7 +278,7 @@ describe('Partitioning by epoch', () => {
 
       expect(partitionExists[0]?.exists).toBe(true);
 
-      // Verify partition has correct range [1586209, 1586254)
+      // Verify partition has correct range [1586250, 1586254)
       const partitionInfo = await prisma.$queryRaw<Array<{ partition_expression: string }>>`
         SELECT pg_get_expr(c.relpartbound, c.oid) as partition_expression
         FROM pg_class c
@@ -287,7 +287,7 @@ describe('Partitioning by epoch', () => {
 
       expect(partitionInfo).toHaveLength(1);
       const expression = partitionInfo[0].partition_expression;
-      expect(expression).toContain('1586209');
+      expect(expression).toContain('1586250');
       expect(expression).toContain('1586254'); // exclusive end
 
       // Verify the partition is actually a child of epoch_rewards table
@@ -302,9 +302,9 @@ describe('Partitioning by epoch', () => {
     });
 
     it('should be idempotent - calling multiple times should not cause errors', async () => {
-      // Epoch 1586252 should create partition epoch_rewards_1586209-1586253_YYYYMMDDHH
+      // Epoch 1586252 should create partition epoch_rewards_1586250-1586253_YYYYMMDDHH
       const epoch = 1586252;
-      const startEpoch = 1586209;
+      const startEpoch = 1586250;
       const endEpoch = 1586253;
 
       // Calculate expected partition name using real Gnosis chain timestamps

--- a/packages/indexer/src/services/consensus/controllers/partition.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/partition.test.ts
@@ -1,0 +1,148 @@
+import { BeaconTime } from '@beacon-indexer/beacon-utils/beaconTime';
+import { ethereumConfig } from '@beacon-indexer/beacon-utils/config/chain';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  parseEpochPartitionName,
+  parseSlotPartitionName,
+} from '@/src/services/consensus/controllers/helpers/partitionNaming.js';
+import {
+  PARTITION_TABLE_NAMES,
+  PartitionController,
+} from '@/src/services/consensus/controllers/partition.js';
+import { PartitionStorage } from '@/src/services/consensus/storage/partition.js';
+
+// Defines the partition creation call captured from the storage mock.
+type CreatedPartition = {
+  tableName: string;
+  partitionName: string;
+  start: number;
+  end: number;
+};
+
+// Creates a partition controller with storage calls captured in memory.
+function createPartitionController(lookbackSlot: number) {
+  const createdPartitions: CreatedPartition[] = [];
+
+  const partitionStorage = {
+    createPartition: vi.fn(
+      async (tableName: string, partitionName: string, start: number, end: number) => {
+        createdPartitions.push({ tableName, partitionName, start, end });
+      },
+    ),
+  } as unknown as PartitionStorage;
+
+  const beaconTime = new BeaconTime({
+    genesisTimestamp: ethereumConfig.beacon.genesisTimestamp,
+    slotDurationMs: ethereumConfig.beacon.slotDuration,
+    slotsPerEpoch: ethereumConfig.beacon.slotsPerEpoch,
+    epochsPerSyncCommitteePeriod: ethereumConfig.beacon.epochsPerSyncCommitteePeriod,
+    lookbackSlot,
+  });
+
+  return {
+    beaconTime,
+    createdPartitions,
+    partitionController: new PartitionController(partitionStorage, beaconTime),
+  };
+}
+
+describe('PartitionController', () => {
+  // This suite locks the first Ethereum committee partition when lookback starts inside a UTC hour.
+  describe('createPartitionsToProcessEpoch', () => {
+    it('starts the first committee partition at lookback when the UTC hour boundary slot is before lookback', async () => {
+      // Use the real Ethereum lookback slot that starts at 2026-05-05T18:00:11Z.
+      const lookbackSlot = 14264999;
+
+      // Process the first epoch whose epoch_rewards partition belongs to the 18:00 UTC hour.
+      const epoch = 445782;
+
+      // Build the controller with an in-memory storage mock.
+      const { beaconTime, createdPartitions, partitionController } =
+        createPartitionController(lookbackSlot);
+
+      // Verify the real edge condition before creating partitions.
+      const hourBoundarySlot = beaconTime.getSlotAtStartOfUTCHourContaining(lookbackSlot);
+      expect(hourBoundarySlot).toBe(14264998);
+
+      // Create both committee and epoch_rewards partitions for the epoch.
+      await partitionController.createPartitionsToProcessEpoch(epoch);
+
+      // Find the committee partition that starts at the effective lookback slot.
+      const committeePartition = createdPartitions.find(
+        (partition) => partition.tableName === PARTITION_TABLE_NAMES.COMMITTEE,
+      );
+
+      // Find the epoch_rewards partition created for the same processing hour.
+      const epochRewardsPartition = createdPartitions.find(
+        (partition) => partition.tableName === PARTITION_TABLE_NAMES.EPOCH_REWARDS,
+      );
+
+      // Parse the committee partition name so its slot range and hour can be asserted.
+      const parsedCommittee = parseSlotPartitionName(committeePartition?.partitionName ?? '');
+
+      // Parse the epoch_rewards partition name so its hour can be paired with committee.
+      const parsedEpochRewards = parseEpochPartitionName(
+        epochRewardsPartition?.partitionName ?? '',
+      );
+
+      // Confirm the committee partition starts at lookback, not the earlier UTC boundary slot.
+      expect(parsedCommittee?.start).toBe(lookbackSlot);
+      expect(parsedCommittee?.start).not.toBe(hourBoundarySlot);
+
+      // Confirm committee and epoch_rewards are both named for the same 18:00 UTC hour.
+      expect(parsedCommittee?.datetime?.toISOString()).toBe('2026-05-05T18:00:00.000Z');
+      expect(parsedEpochRewards?.datetime?.toISOString()).toBe('2026-05-05T18:00:00.000Z');
+    });
+
+    it('uses the same first-hour name and range for committee and epoch_rewards from the lookback epoch', async () => {
+      // Use the real Ethereum lookback slot that starts during epoch 445781.
+      const lookbackSlot = 14264999;
+
+      // Process the lookback epoch and the next epoch in the same UTC hour.
+      const lookbackEpoch = 445781;
+      const nextEpoch = 445782;
+
+      // Build the controller with an in-memory storage mock.
+      const { createdPartitions, partitionController } = createPartitionController(lookbackSlot);
+
+      // Create partitions for both epochs that belong to the first partial UTC hour.
+      await partitionController.createPartitionsToProcessEpoch(lookbackEpoch);
+      await partitionController.createPartitionsToProcessEpoch(nextEpoch);
+
+      // Collect committee partitions created for the first partial UTC hour.
+      const committeePartitions = createdPartitions
+        .filter((partition) => partition.tableName === PARTITION_TABLE_NAMES.COMMITTEE)
+        .map((partition) => parseSlotPartitionName(partition.partitionName));
+
+      // Collect epoch_rewards partitions created for the first partial UTC hour.
+      const epochRewardsPartitions = createdPartitions
+        .filter((partition) => partition.tableName === PARTITION_TABLE_NAMES.EPOCH_REWARDS)
+        .map((partition) => parseEpochPartitionName(partition.partitionName));
+
+      // Confirm committee uses one consistent first-hour partition from lookback.
+      expect(new Set(committeePartitions.map((partition) => partition?.start))).toEqual(
+        new Set([lookbackSlot]),
+      );
+      expect(new Set(committeePartitions.map((partition) => partition?.end))).toEqual(
+        new Set([14265298]),
+      );
+
+      // Confirm epoch_rewards uses one consistent first-hour partition from the lookback epoch.
+      expect(new Set(epochRewardsPartitions.map((partition) => partition?.start))).toEqual(
+        new Set([lookbackEpoch]),
+      );
+      expect(new Set(epochRewardsPartitions.map((partition) => partition?.end))).toEqual(
+        new Set([445790]),
+      );
+
+      // Confirm both tables are paired by the same 18:00 UTC partition name hour.
+      expect(
+        new Set(committeePartitions.map((partition) => partition?.datetime?.toISOString())),
+      ).toEqual(new Set(['2026-05-05T18:00:00.000Z']));
+      expect(
+        new Set(epochRewardsPartitions.map((partition) => partition?.datetime?.toISOString())),
+      ).toEqual(new Set(['2026-05-05T18:00:00.000Z']));
+    });
+  });
+});

--- a/packages/indexer/src/services/consensus/controllers/partition.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/partition.test.ts
@@ -50,7 +50,7 @@ function createPartitionController(lookbackSlot: number) {
 describe('PartitionController', () => {
   // This suite locks the first Ethereum committee partition when lookback starts inside a UTC hour.
   describe('createPartitionsToProcessEpoch', () => {
-    it('starts the first committee partition at lookback when the UTC hour boundary slot is before lookback', async () => {
+    it('starts the first committee partition at the first slot inside its UTC hour', async () => {
       // Use the real Ethereum lookback slot that starts at 2026-05-05T18:00:11Z.
       const lookbackSlot = 14264999;
 
@@ -62,8 +62,8 @@ describe('PartitionController', () => {
         createPartitionController(lookbackSlot);
 
       // Verify the real edge condition before creating partitions.
-      const hourBoundarySlot = beaconTime.getSlotAtStartOfUTCHourContaining(lookbackSlot);
-      expect(hourBoundarySlot).toBe(14264998);
+      const firstSlotInHour = beaconTime.getSlotAtStartOfUTCHourContaining(lookbackSlot);
+      expect(firstSlotInHour).toBe(lookbackSlot);
 
       // Create both committee and epoch_rewards partitions for the epoch.
       await partitionController.createPartitionsToProcessEpoch(epoch);
@@ -86,9 +86,9 @@ describe('PartitionController', () => {
         epochRewardsPartition?.partitionName ?? '',
       );
 
-      // Confirm the committee partition starts at lookback, not the earlier UTC boundary slot.
+      // Confirm the committee partition starts at the first indexed slot in the UTC hour.
       expect(parsedCommittee?.start).toBe(lookbackSlot);
-      expect(parsedCommittee?.start).not.toBe(hourBoundarySlot);
+      expect(parsedCommittee?.start).toBe(firstSlotInHour);
 
       // Confirm committee and epoch_rewards are both named for the same 18:00 UTC hour.
       expect(parsedCommittee?.datetime?.toISOString()).toBe('2026-05-05T18:00:00.000Z');
@@ -143,6 +143,35 @@ describe('PartitionController', () => {
       expect(
         new Set(epochRewardsPartitions.map((partition) => partition?.datetime?.toISOString())),
       ).toEqual(new Set(['2026-05-05T18:00:00.000Z']));
+    });
+
+    it('creates adjacent Ethereum committee partitions without slot overlap at a UTC hour boundary', async () => {
+      // Use the real Ethereum lookback slot that starts at 2026-05-05T18:00:11Z.
+      const lookbackSlot = 14264999;
+
+      // Process the epoch that crosses from the 18:00 UTC hour into the 19:00 UTC hour.
+      const boundaryEpoch = 445790;
+
+      // Build the controller with an in-memory storage mock.
+      const { createdPartitions, partitionController } = createPartitionController(lookbackSlot);
+
+      // Create the committee partitions needed for the boundary-crossing epoch.
+      await partitionController.createPartitionForCommittee(boundaryEpoch);
+
+      // Parse the created committee partitions so ranges and hour suffixes can be asserted.
+      const committeePartitions = createdPartitions
+        .filter((partition) => partition.tableName === PARTITION_TABLE_NAMES.COMMITTEE)
+        .map((partition) => parseSlotPartitionName(partition.partitionName));
+
+      // Confirm the boundary-crossing epoch creates the 18:00 and 19:00 hour partitions.
+      expect(committeePartitions).toHaveLength(2);
+
+      // Confirm adjacent slot ranges meet without sharing a slot.
+      expect(committeePartitions[0]?.end).toBe(14265298);
+      expect(committeePartitions[1]?.start).toBe(14265299);
+
+      // Confirm the second partition is named for the 19:00 UTC hour.
+      expect(committeePartitions[1]?.datetime?.toISOString()).toBe('2026-05-05T19:00:00.000Z');
     });
   });
 });

--- a/packages/indexer/src/services/consensus/controllers/partition.ts
+++ b/packages/indexer/src/services/consensus/controllers/partition.ts
@@ -62,12 +62,13 @@ export class PartitionController {
   // Helper to create a partition for a UTC hour
   private makeHourPartitionForSlot(tableNamePrefix: string, startSlot: number): SlotPartitionInfo {
     const hourStartTs = this.beaconTime.getTimestampFromSlotNumber(startSlot);
-    const hourEndTs = hourStartTs + 3_600_000; // add 1 hour in milliseconds
-    const hourEndSlotExclusive = this.beaconTime.getSlotNumberFromTimestamp(hourEndTs);
-    const endSlot = hourEndSlotExclusive - 1; // Convert to inclusive
+    const hourTimestamp = getUTCDatetimeFlooredToHour(hourStartTs);
+    const hourEndTs = hourTimestamp.getTime() + 3_600_000; // add 1 hour in milliseconds
+    const hourEndSlot = this.beaconTime.getSlotNumberFromTimestamp(hourEndTs);
+    const hourEndSlotTs = this.beaconTime.getTimestampFromSlotNumber(hourEndSlot);
+    const endSlot = hourEndSlotTs === hourEndTs ? hourEndSlot - 1 : hourEndSlot;
 
     // Calculate UTC hour timestamp for datetime suffix
-    const hourTimestamp = getUTCDatetimeFlooredToHour(hourStartTs);
     const name = getPartitionName(tableNamePrefix, startSlot, endSlot, hourTimestamp);
 
     return {
@@ -82,12 +83,13 @@ export class PartitionController {
     tableName: string,
     startEpoch: number,
     endEpoch: number, // inclusive
+    hourTimestamp?: Date,
   ): EpochPartitionInfo {
     // Calculate UTC hour timestamp from start epoch for datetime suffix
     const epochTimestamp = this.beaconTime.getTimestampFromEpochNumber(startEpoch);
-    const hourTimestamp = getUTCDatetimeFlooredToHour(epochTimestamp);
+    const partitionHourTimestamp = hourTimestamp ?? getUTCDatetimeFlooredToHour(epochTimestamp);
 
-    const name = getPartitionName(tableName, startEpoch, endEpoch, hourTimestamp);
+    const name = getPartitionName(tableName, startEpoch, endEpoch, partitionHourTimestamp);
 
     return {
       name,
@@ -110,17 +112,61 @@ export class PartitionController {
     const firstSlotToProcess = Math.max(startSlot, this.beaconTime.getLookbackSlot());
     if (firstSlotToProcess > endSlot) return [];
 
-    const partitionOneFirstSlot =
-      this.beaconTime.getSlotAtStartOfUTCHourContaining(firstSlotToProcess);
+    // The first committee partition may start inside a UTC hour when lookbackSlot does.
+    const hourBoundarySlot = this.beaconTime.getSlotAtStartOfUTCHourContaining(firstSlotToProcess);
+    const partitionOneFirstSlot = Math.max(this.beaconTime.getLookbackSlot(), hourBoundarySlot);
     const partitionOne = this.makeHourPartitionForSlot(tableNamePrefix, partitionOneFirstSlot);
 
     // if endSlot is still within partitionOne, only 1 partition
-    if (endSlot < partitionOne.endSlot) return [partitionOne];
+    if (endSlot <= partitionOne.endSlot) return [partitionOne];
 
     const partitionTwoFirstSlot = this.beaconTime.getSlotAtStartOfUTCHourContaining(endSlot);
     if (partitionTwoFirstSlot === partitionOneFirstSlot) return [partitionOne]; // paranoia / safety
 
     return [partitionOne, this.makeHourPartitionForSlot(tableNamePrefix, partitionTwoFirstSlot)];
+  }
+
+  /**
+   * Checks whether a UTC hour is the first hour that contains indexed data.
+   */
+  private isLookbackHour(hourStartDate: Date): boolean {
+    const lookbackSlot = this.beaconTime.getLookbackSlot();
+    const lookbackSlotTimestamp = this.beaconTime.getTimestampFromSlotNumber(lookbackSlot);
+    const lookbackHourStart = getUTCDatetimeFlooredToHour(lookbackSlotTimestamp);
+
+    return lookbackHourStart.getTime() === hourStartDate.getTime();
+  }
+
+  /**
+   * Calculates the epoch_rewards partition for the first partial UTC hour.
+   */
+  private calculateLookbackHourEpochPartition(
+    tableNamePrefix: string,
+    hourStartDate: Date,
+  ): EpochPartitionInfo {
+    const lookbackSlot = this.beaconTime.getLookbackSlot();
+    const lookbackEpoch = this.beaconTime.getEpochFromSlot(lookbackSlot);
+    const nextHourTimestamp = hourStartDate.getTime() + 3_600_000;
+    const endEpochExclusive = this.beaconTime.getFirstEpochStartingAtOrAfter(nextHourTimestamp);
+    const endEpoch = endEpochExclusive - 1;
+
+    return this.makeEpochPartition(tableNamePrefix, lookbackEpoch, endEpoch, hourStartDate);
+  }
+
+  /**
+   * Calculates the epoch_rewards partition for a regular full UTC hour.
+   */
+  private calculateRegularHourEpochPartition(
+    tableNamePrefix: string,
+    hourStartDate: Date,
+  ): EpochPartitionInfo {
+    const hourStartTimestamp = hourStartDate.getTime();
+    const nextHourTimestamp = hourStartTimestamp + 3_600_000;
+    const startEpoch = this.beaconTime.getFirstEpochStartingAtOrAfter(hourStartTimestamp);
+    const endEpochExclusive = this.beaconTime.getFirstEpochStartingAtOrAfter(nextHourTimestamp);
+    const endEpoch = endEpochExclusive - 1;
+
+    return this.makeEpochPartition(tableNamePrefix, startEpoch, endEpoch, hourStartDate);
   }
 
   /**
@@ -156,20 +202,20 @@ export class PartitionController {
    * even if it ends at 14:01.
    */
   private calculateEpochPartition(epoch: number, tableNamePrefix: string): EpochPartitionInfo {
-    // Use the epoch's start timestamp directly
-    const epochTimestamp = this.beaconTime.getTimestampFromEpochNumber(epoch);
+    const { startSlot } = this.beaconTime.getEpochSlots(epoch);
+    const lookbackSlot = this.beaconTime.getLookbackSlot();
+    const firstSlotToProcess = Math.max(startSlot, lookbackSlot);
 
-    // Round to UTC hour boundary using existing helper
+    // Use indexed data time, not epoch start time, for the first partial lookback hour.
+    const epochTimestamp = this.beaconTime.getTimestampFromSlotNumber(firstSlotToProcess);
     const hourStartDate = getUTCDatetimeFlooredToHour(epochTimestamp);
-    const hourStartTimestamp = hourStartDate.getTime();
-    const nextHourTimestamp = hourStartTimestamp + 3_600_000; // add 1 hour
 
-    // Get first epoch starting at or after each hour boundary
-    const startEpoch = this.beaconTime.getFirstEpochStartingAtOrAfter(hourStartTimestamp);
-    const endEpochExclusive = this.beaconTime.getFirstEpochStartingAtOrAfter(nextHourTimestamp);
-    const endEpoch = endEpochExclusive - 1; // Convert to inclusive
+    // The first lookback hour can include an epoch that started before the UTC hour.
+    if (this.isLookbackHour(hourStartDate)) {
+      return this.calculateLookbackHourEpochPartition(tableNamePrefix, hourStartDate);
+    }
 
-    return this.makeEpochPartition(tableNamePrefix, startEpoch, endEpoch);
+    return this.calculateRegularHourEpochPartition(tableNamePrefix, hourStartDate);
   }
 
   /**

--- a/packages/indexer/src/services/consensus/controllers/partition.ts
+++ b/packages/indexer/src/services/consensus/controllers/partition.ts
@@ -120,8 +120,7 @@ export class PartitionController {
     // if endSlot is still within partitionOne, only 1 partition
     if (endSlot <= partitionOne.endSlot) return [partitionOne];
 
-    const partitionTwoFirstSlot = this.beaconTime.getSlotAtStartOfUTCHourContaining(endSlot);
-    if (partitionTwoFirstSlot === partitionOneFirstSlot) return [partitionOne]; // paranoia / safety
+    const partitionTwoFirstSlot = partitionOne.endSlot + 1;
 
     return [partitionOne, this.makeHourPartitionForSlot(tableNamePrefix, partitionTwoFirstSlot)];
   }


### PR DESCRIPTION
## Summary

Fixes partition naming/range calculation when lookbackSlot falls inside a UTC hour instead of exactly at the hour boundary.

This affects the raw committee and epoch_rewards partitions created together for each epoch before processing. These tables are partitioned by numeric ranges, but hourly archive discovery pairs them by the UTC datetime suffix in their partition names.

## Root Cause

For Ethereum, lookbackSlot 14264999 starts at 2026-05-05T18:00:11Z, while the 18:00:00Z UTC boundary maps to slot 14264998. The committee partition code used that boundary slot, creating a partition that started before lookback.

After clamping committee to lookbackSlot, epoch_rewards could still be named from the epoch start time. For the first partial epoch, that can be the previous UTC hour, while committee is named for the first indexed hour. HourlyArchive pairs partitions by parsed partition name datetime, so this mismatch can produce missing-pair errors.

## Strategy

- Clamp the first committee partition start to lookbackSlot when the UTC hour boundary maps to an earlier slot.
- Keep the first partial committee partition ending at the next UTC hour boundary, not one hour after lookbackSlot.
- Name the first partial epoch_rewards partition using the first processable indexed slot hour.
- Isolate the epoch_rewards lookback-hour base case from regular UTC-hour epoch partitioning.
- Preserve regular full-hour behavior for non-lookback hours.

## Inclusive Boundary Fix

Both endSlot and partitionOne.endSlot are inclusive. If they are equal, the epoch is already fully covered by the first partition. The condition is now <= so we do not create an unnecessary second partition at an exact inclusive boundary.

This same issue does not apply in the same way to epoch partition creation because epoch partition ranges are calculated as endEpochExclusive - 1, and only one epoch_rewards partition is created per processed epoch/hour path.

## Tests

Added unit coverage for the Ethereum lookback edge case and updated Gnosis e2e expectations so the first committee partition starts at the configured lookback slot while still ending at the UTC hour boundary.

## Validation

- pnpm --filter indexer test -- src/services/consensus/controllers/partition.test.ts
- pnpm --filter indexer test
- pnpm --filter indexer type-check
- pnpm test:e2e:local
- push hook ran pnpm -r run lint successfully