### PR TITLE
Handle sync committee prefetch errors

### DIFF
--- a/packages/indexer/src/services/consensus/beacon.test.ts
+++ b/packages/indexer/src/services/consensus/beacon.test.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BeaconClient } from './beacon.js';
@@ -150,11 +151,65 @@ describe('BeaconClient reward cache', () => {
       },
     } as never);
 
-    // These calls use the same validators in different orders.
-    await beaconClient.getSyncCommitteeRewards(1, ['2', '1']);
-    await beaconClient.getSyncCommitteeRewards(1, ['1', '2']);
+    // These concurrent calls use the same validators in different orders.
+    await Promise.all([
+      beaconClient.getSyncCommitteeRewards(1, ['2', '1']),
+      beaconClient.getSyncCommitteeRewards(1, ['1', '2']),
+    ]);
 
     // This assertion verifies both calls use one canonical cache entry.
+    expect(postSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // This test verifies sync committee rewards use fresh cache entries by default.
+  it('serves sync committee reward cache entries by default', async () => {
+    // This client exercises the public sync committee rewards cache behavior.
+    const beaconClient = new BeaconClient({
+      fullNodeUrl: 'http://full-node',
+      fullNodeConcurrency: 1,
+      fullNodeRetries: 0,
+      archiveNodeUrl: 'http://archive-node',
+      archiveNodeConcurrency: 1,
+      archiveNodeRetries: 0,
+      baseDelay: 1,
+      slotStartIndexing: 1,
+      slotsPerEpoch: 32,
+    });
+
+    // This spy returns different responses so cache reuse and refresh are observable.
+    const axiosInstance = (beaconClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi
+      .spyOn(axiosInstance, 'post' as never)
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ validator_index: '1', reward: '10' }],
+          execution_optimistic: false,
+          finalized: true,
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ validator_index: '1', reward: '20' }],
+          execution_optimistic: false,
+          finalized: true,
+        },
+      } as never);
+
+    // This call fills the cache entry for the slot and validator.
+    await beaconClient.getSyncCommitteeRewards(1, ['1']);
+
+    // This call uses the default behavior and should reuse the cached entry.
+    const result = await beaconClient.getSyncCommitteeRewards(1, ['1']);
+
+    // This assertion verifies the default call returns the cached endpoint response.
+    expect(result).toEqual({
+      data: [{ validator_index: '1', reward: '10' }],
+      execution_optimistic: false,
+      finalized: true,
+    });
+
+    // This assertion verifies the cached entry was reused by default.
     expect(postSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -186,5 +241,171 @@ describe('BeaconClient reward cache', () => {
 
     // This assertion verifies no beacon request was made.
     expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  // This test verifies sync committee prefetch does not retry failed responses.
+  it('does not retry sync committee prefetch errors', async () => {
+    // This client is configured far behind head so sync committee prefetching is enabled.
+    const beaconClient = new BeaconClient({
+      fullNodeUrl: 'http://full-node',
+      fullNodeConcurrency: 1,
+      fullNodeRetries: 0,
+      archiveNodeUrl: 'http://archive-node',
+      archiveNodeConcurrency: 1,
+      archiveNodeRetries: 1,
+      baseDelay: 1,
+      slotStartIndexing: 1,
+      slotsPerEpoch: 32,
+    });
+
+    // This error simulates a failed beacon API response during prefetch.
+    const prefetchError = new AxiosError('Request failed with status code 500');
+    prefetchError.response = {
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: {},
+      config: {} as never,
+      data: { message: 'Internal Server Error' },
+    };
+
+    // This spy makes every prefetch attempt receive the failed response.
+    const axiosInstance = (beaconClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockRejectedValue(prefetchError);
+
+    // This call starts a prefetch that should stop on error without retrying.
+    beaconClient.prefetchSyncCommitteeRewards(1, ['1']);
+
+    // This wait lets the fire-and-forget prefetch make the initial request.
+    await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
+
+    // This wait covers the retry delay that would run for normal archive requests.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // This assertion verifies prefetch treated the failed response as final.
+    expect(postSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // This test verifies normal processing can join a successful in-flight sync committee prefetch.
+  it('coalesces normal sync committee rewards with an in-flight prefetch', async () => {
+    // This client is configured far behind head so sync committee prefetching is enabled.
+    const beaconClient = new BeaconClient({
+      fullNodeUrl: 'http://full-node',
+      fullNodeConcurrency: 1,
+      fullNodeRetries: 0,
+      archiveNodeUrl: 'http://archive-node',
+      archiveNodeConcurrency: 1,
+      archiveNodeRetries: 0,
+      baseDelay: 1,
+      slotStartIndexing: 1,
+      slotsPerEpoch: 32,
+    });
+
+    // This deferred response keeps the prefetch request in flight during normal processing.
+    let resolveResponse: (value: unknown) => void;
+    const responsePromise = new Promise((resolve) => {
+      resolveResponse = resolve;
+    });
+
+    // This spy returns the same delayed response to expose duplicate requests.
+    const axiosInstance = (beaconClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockReturnValue(responsePromise);
+
+    // This call starts the prefetch request for the slot and validators.
+    beaconClient.prefetchSyncCommitteeRewards(1, ['1']);
+
+    // This wait confirms the prefetch request is in flight before normal processing starts.
+    await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
+
+    // This call starts normal processing while prefetch is still unresolved.
+    const rewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
+
+    // This response completes the shared request.
+    resolveResponse!({
+      data: {
+        data: [{ validator_index: '1', reward: '10' }],
+        execution_optimistic: false,
+        finalized: true,
+      },
+    });
+
+    // This assertion verifies normal processing receives the prefetched response.
+    await expect(rewardsPromise).resolves.toEqual({
+      data: [{ validator_index: '1', reward: '10' }],
+      execution_optimistic: false,
+      finalized: true,
+    });
+
+    // This assertion verifies prefetch and normal processing shared one HTTP call.
+    expect(postSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // This test verifies normal processing stays strict after an in-flight prefetch 404.
+  it('fetches sync committee rewards strictly after an in-flight prefetch 404', async () => {
+    // This client is configured far behind head so sync committee prefetching is enabled.
+    const beaconClient = new BeaconClient({
+      fullNodeUrl: 'http://full-node',
+      fullNodeConcurrency: 1,
+      fullNodeRetries: 0,
+      archiveNodeUrl: 'http://archive-node',
+      archiveNodeConcurrency: 1,
+      archiveNodeRetries: 0,
+      baseDelay: 1,
+      slotStartIndexing: 1,
+      slotsPerEpoch: 32,
+    });
+
+    // This error simulates the beacon API response for rewards on a skipped slot.
+    const skippedSlotError = new AxiosError('Request failed with status code 404');
+    skippedSlotError.response = {
+      status: 404,
+      statusText: 'Not Found',
+      headers: {},
+      config: {} as never,
+      data: { message: 'NOT_FOUND: beacon block at slot 1' },
+    };
+
+    // This deferred rejection keeps the prefetch request in flight during normal processing.
+    let rejectPrefetchResponse: (error: unknown) => void;
+    const prefetchResponsePromise = new Promise((_resolve, reject) => {
+      rejectPrefetchResponse = reject;
+    });
+
+    // This spy makes prefetch receive 404 and normal processing receive rewards later.
+    const axiosInstance = (beaconClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi
+      .spyOn(axiosInstance, 'post' as never)
+      .mockReturnValueOnce(prefetchResponsePromise as never)
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ validator_index: '1', reward: '10' }],
+          execution_optimistic: false,
+          finalized: true,
+        },
+      } as never);
+
+    // This call starts a prefetch that should stop on 404 without filling the cache.
+    beaconClient.prefetchSyncCommitteeRewards(1, ['1']);
+
+    // This wait confirms the prefetch request is in flight before normal processing starts.
+    await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
+
+    // This normal processing call starts while prefetch is still unresolved.
+    const rewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
+
+    // This rejection completes the prefetch skipped-slot path.
+    rejectPrefetchResponse!(skippedSlotError);
+
+    // This assertion verifies normal processing receives the strict request response.
+    await expect(rewardsPromise).resolves.toEqual({
+      data: [{ validator_index: '1', reward: '10' }],
+      execution_optimistic: false,
+      finalized: true,
+    });
+
+    // This assertion verifies normal processing made a second HTTP call after prefetch 404.
+    expect(postSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -57,12 +57,39 @@ export class BeaconClient extends ReliableRequestClient {
     ttl: ms('1m'),
     fetchMethod: (slot) => this.fetchBlockRewardsUncached(slot),
   });
-  private readonly syncCommitteeRewardsCache = new LRUCache<string, SyncCommitteeRewards>({
+
+  /**
+   * Caches sync committee rewards fetched in advance.
+   */
+  private readonly syncCommitteeRewardsCache = new LRUCache<
+    string,
+    SyncCommitteeRewards,
+    { ignoreErrors?: boolean } | undefined
+  >({
     max: 5,
     ttl: ms('1m'),
-    fetchMethod: (key) => {
+    fetchMethod: async (key, _staleValue, { context }) => {
       const [slot, validatorIndexes] = this.parseSyncCommitteeRewardsCacheKey(key);
-      return this.fetchSyncCommitteeRewardsUncached(slot, validatorIndexes);
+      // null marks ignored prefetch errors as handled so makeReliableRequest does not retry.
+      const handleError = context?.ignoreErrors ? () => null : undefined;
+
+      const rewards = await this.makeReliableRequest<SyncCommitteeRewards | null>(
+        async (url) => {
+          const res = await this.axiosInstance.post<SyncCommitteeRewards>(
+            `${url}/eth/v1/beacon/rewards/sync_committee/${slot}`,
+            validatorIndexes,
+            {
+              timeout: ms('30s'),
+            },
+          );
+          return res.data;
+        },
+        this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
+        handleError,
+      );
+
+      // undefined prevents lru-cache from storing failed prefetch results.
+      return rewards ?? undefined;
     },
   });
 
@@ -366,28 +393,6 @@ export class BeaconClient extends ReliableRequestClient {
   };
 
   /**
-   * Fetch sync committee rewards without using the prefetch cache.
-   */
-  private fetchSyncCommitteeRewardsUncached = async (
-    slot: number,
-    validatorIndexes: string[],
-  ): Promise<SyncCommitteeRewards> => {
-    return this.makeReliableRequest<SyncCommitteeRewards>(
-      async (url) => {
-        const res = await this.axiosInstance.post<SyncCommitteeRewards>(
-          `${url}/eth/v1/beacon/rewards/sync_committee/${slot}`,
-          validatorIndexes,
-          {
-            timeout: ms('30s'),
-          },
-        );
-        return res.data;
-      },
-      this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
-    );
-  };
-
-  /**
    * Prefetch sync committee rewards for a delayed slot without blocking slot processing.
    */
   prefetchSyncCommitteeRewards(slot: number, validatorIndexes: string[]): void {
@@ -396,7 +401,9 @@ export class BeaconClient extends ReliableRequestClient {
     }
 
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
-    void this.syncCommitteeRewardsCache.fetch(key).catch(() => undefined);
+    void this.syncCommitteeRewardsCache
+      .fetch(key, { context: { ignoreErrors: true } })
+      .catch(() => undefined);
   }
 
   /**
@@ -411,7 +418,11 @@ export class BeaconClient extends ReliableRequestClient {
     }
 
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
-    const rewards = await this.syncCommitteeRewardsCache.fetch(key);
+    let rewards = await this.syncCommitteeRewardsCache.fetch(key);
+    if (rewards === undefined) {
+      rewards = await this.syncCommitteeRewardsCache.fetch(key);
+    }
+
     if (rewards === undefined) {
       throw new Error(`Failed to fetch sync committee rewards for slot ${slot} from cache.`);
     }

--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -198,11 +198,6 @@ export class SlotController extends SlotControllerHelpers {
    * Start fetching sync committee rewards before the slot reaches the normal processing path.
    */
   async prefetchSyncCommitteeRewards(slot: number) {
-    const isSyncCommitteeFetched = await this.slotStorage.isSyncCommitteeFetchedForSlot(slot);
-    if (isSyncCommitteeFetched) {
-      return;
-    }
-
     const epoch = this.beaconTime.getEpochFromSlot(slot);
     const syncCommitteeValidators = await this.slotStorage.getSyncCommitteeValidators(epoch);
     if (syncCommitteeValidators.length === 0) {

--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -110,16 +110,6 @@ export class SlotController extends SlotControllerHelpers {
   }
 
   /**
-   * Start fetching sync committee rewards before the slot reaches the normal processing path.
-   */
-  async prefetchSyncCommitteeRewards(slot: number) {
-    const epoch = this.beaconTime.getEpochFromSlot(slot);
-    const validators = await this.slotStorage.getSyncCommitteeValidators(epoch);
-
-    this.beaconClient.prefetchSyncCommitteeRewards(slot, validators);
-  }
-
-  /**
    * Process attestations for a slot
    * Checks if already processed before processing.
    * Throws an error if committee sizes are not available for all slots.
@@ -202,6 +192,25 @@ export class SlotController extends SlotControllerHelpers {
       blockInfo.address,
       blockInfo.blockNumber,
     );
+  }
+
+  /**
+   * Start fetching sync committee rewards before the slot reaches the normal processing path.
+   */
+  async prefetchSyncCommitteeRewards(slot: number) {
+    const isSyncCommitteeFetched = await this.slotStorage.isSyncCommitteeFetchedForSlot(slot);
+    if (isSyncCommitteeFetched) {
+      return;
+    }
+
+    const epoch = this.beaconTime.getEpochFromSlot(slot);
+    const syncCommitteeValidators = await this.slotStorage.getSyncCommitteeValidators(epoch);
+    if (syncCommitteeValidators.length === 0) {
+      // No validators in sync committee for this epoch, skip prefetching rewards
+      return;
+    }
+
+    this.beaconClient.prefetchSyncCommitteeRewards(slot, syncCommitteeValidators);
   }
 
   /**


### PR DESCRIPTION
## Goal

Make sync committee rewards prefetch safe.

Prefetch is only a best-effort cache warmup. If it fails, normal slot processing should behave like before.

## What changes

- Sync committee rewards prefetch ignores request errors.
- Ignored prefetch errors do not retry.
- Failed prefetch results are not stored in the cache.
- Normal getSyncCommitteeRewards still uses the cache normally.
- If normal processing reads an empty result from a failed prefetch, it fetches again through the normal path.

## Why

A prefetch failure should not affect the real slot processing flow.

## Validation

- pnpm --filter indexer exec vitest run src/services/consensus/beacon.test.ts
- pnpm --filter indexer type-check
- pre-push pnpm -r run lint