### PR TITLE
Batch hourly archive aggregation

### DIFF
--- a/packages/indexer/src/services/consensus/storage/hourlyArchive.test.ts
+++ b/packages/indexer/src/services/consensus/storage/hourlyArchive.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HourlyArchiveStorage } from './hourlyArchive.js';
+
+// This suite verifies resource-friendly hourly archive database writes.
+describe('HourlyArchiveStorage', () => {
+  // This test verifies hourly aggregation is split by validator ranges.
+  it('archives an hour in validator batches', async () => {
+    // This list records every raw SQL call made inside the archive transaction.
+    const rawCalls: string[] = [];
+
+    // This transaction client captures SQL and simulates a validator table larger than one batch.
+    const tx = {
+      $executeRawUnsafe: vi.fn().mockResolvedValue(undefined),
+      $executeRaw: vi.fn((strings: TemplateStringsArray) => {
+        rawCalls.push(strings.join('?'));
+        return Promise.resolve(undefined);
+      }),
+      $queryRaw: vi.fn().mockResolvedValue([{ max_idx: 100001 }]),
+      archive: {
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    // This prisma stub runs the interactive transaction callback with the mocked transaction.
+    const prisma = {
+      $transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<void>) => {
+        await callback(tx);
+      }),
+    };
+
+    // This storage instance executes the real archive method against the prisma stub.
+    const storage = new HourlyArchiveStorage(prisma as never);
+
+    // This call archives one hour and should split aggregation across validator ranges.
+    await storage.archiveHourAtomically(
+      new Date('2025-12-16T13:00:00.000Z'),
+      100,
+      200,
+      10,
+      20,
+      5,
+      'validator_hourly_archive_2025121613',
+      'committee_100_200',
+      'epoch_rewards_10_20',
+    );
+
+    // This filter keeps only the heavyweight archive INSERT statements.
+    const insertCalls = rawCalls.filter((sql) =>
+      sql.includes('INSERT INTO validator_hourly_archive'),
+    );
+
+    // This assertion verifies one INSERT is executed per validator batch.
+    expect(insertCalls).toHaveLength(3);
+
+    // This assertion verifies the batch loop is driven by validator cardinality.
+    expect(tx.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/indexer/src/services/consensus/storage/hourlyArchive.ts
+++ b/packages/indexer/src/services/consensus/storage/hourlyArchive.ts
@@ -126,8 +126,18 @@ export class HourlyArchiveStorage {
             `FOR VALUES FROM ('${timestamp.toISOString()}') TO ('${nextHourTimestamp.toISOString()}')`,
         );
 
-        // Execute aggregation
-        await tx.$executeRaw`
+        // Get max validator index for batching.
+        const [{ max_idx }] = await tx.$queryRaw<[{ max_idx: number }]>`
+          SELECT COALESCE(MAX(id), 0)::int AS max_idx FROM "validator"
+        `;
+
+        // Process validators in chunks to reduce peak memory and temp file usage.
+        const BATCH_SIZE = 50000;
+        for (let batchStart = 0; batchStart <= max_idx; batchStart += BATCH_SIZE) {
+          const batchEnd = batchStart + BATCH_SIZE;
+
+          // Execute aggregation for one validator range.
+          await tx.$executeRaw`
           WITH
             attestations AS (
               SELECT
@@ -136,6 +146,8 @@ export class HourlyArchiveStorage {
                 c.attestation_delay
               FROM committee c
               WHERE c.slot >= ${startSlot}::int AND c.slot <= ${endSlot}::int
+                AND c.validator_index >= ${batchStart}::int
+                AND c.validator_index < ${batchEnd}::int
             ),
 
             sync_rewards AS (
@@ -145,6 +157,8 @@ export class HourlyArchiveStorage {
                 vsr.sync_committee AS sync_committee_reward
               FROM validator_sync_rewards vsr
               WHERE vsr.slot >= ${startSlot}::int AND vsr.slot <= ${endSlot}::int
+                AND vsr.validator_index >= ${batchStart}::int
+                AND vsr.validator_index < ${batchEnd}::int
             ),
 
             block_rewards AS (
@@ -155,6 +169,8 @@ export class HourlyArchiveStorage {
               FROM slot
               WHERE slot >= ${startSlot}::int AND slot <= ${endSlot}::int
                 AND proposer_index IS NOT NULL
+                AND proposer_index >= ${batchStart}::int
+                AND proposer_index < ${batchEnd}::int
                 AND consensus_reward IS NOT NULL
                 AND consensus_reward > 0
             ),
@@ -167,6 +183,8 @@ export class HourlyArchiveStorage {
               FROM slot
               WHERE slot >= ${startSlot}::int AND slot <= ${endSlot}::int
                 AND proposer_index IS NOT NULL
+                AND proposer_index >= ${batchStart}::int
+                AND proposer_index < ${batchEnd}::int
                 AND execution_reward IS NOT NULL
                 AND execution_reward > 0
             ),
@@ -262,6 +280,8 @@ export class HourlyArchiveStorage {
                 missed_inactivity
               FROM epoch_rewards
               WHERE epoch >= ${startEpoch}::int AND epoch <= ${endEpoch}::int
+                AND validator_index >= ${batchStart}::int
+                AND validator_index < ${batchEnd}::int
             ),
 
             epoch_json AS (
@@ -321,6 +341,7 @@ export class HourlyArchiveStorage {
           FULL OUTER JOIN epoch_json ej ON sa.validator_index = ej.validator_index
           LEFT JOIN attestation_agg aa ON COALESCE(sa.validator_index, ej.validator_index) = aa.validator_index
         `;
+        }
 
         await tx.$executeRaw`
           DELETE FROM validator_sync_rewards


### PR DESCRIPTION
## Summary

This changes the hourly archive aggregation so it processes validators in fixed-size batches instead of aggregating the full validator set in one large SQL statement.

The archive flow remains atomic: partition creation, batched aggregation inserts, sync reward cleanup, source partition drops, and `archive.lastHour` update still run inside the same Prisma transaction.

## What changed

- Added a `MAX(id)` lookup on the `validator` table to determine the validator range to process.
- Split the heavy `INSERT INTO validator_hourly_archive ... SELECT ... GROUP BY validator_index` query into batches of 50,000 validators.
- Added validator-range filters to the heavy source CTEs:
  - `committee.validator_index`
  - `validator_sync_rewards.validator_index`
  - `slot.proposer_index`
  - `epoch_rewards.validator_index`
- Added a unit test that verifies the hourly archive emits multiple archive insert statements when the validator table spans multiple batches.

## Why

The previous hourly archive query aggregated the entire hour in one statement. On large source partitions this can create high peak CPU, memory, and temporary file pressure while PostgreSQL groups and builds JSON payloads for all validators at once.

Batching keeps the same final rows and the same archive semantics, but reduces the amount of data each aggregation query has to hold at once.

## Impact

- Expected lower peak resource usage during hourly archive compaction.
- Expected longer total archive duration in exchange for smoother database load.
- No intended API or schema behavior change.
- Atomicity is preserved because the batch loop remains inside the existing transaction.

## Validation

- `pnpm --filter indexer exec vitest run src/services/consensus/storage/hourlyArchive.test.ts`
- `pnpm --filter indexer type-check`
- Pre-push hook ran root `pnpm -r run lint` successfully.
