### PR TITLE
Optimize hourly archive epoch rewards key

### DIFF
--- a/packages/db/prisma/migrations/20260511120000_add_archive_source_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20260511120000_add_archive_source_indexes/migration.sql
@@ -1,0 +1,4 @@
+-- Reorder epoch_rewards primary key for validator-batched archive reads.
+ALTER TABLE "epoch_rewards" DROP CONSTRAINT "epoch_rewards_pkey";
+ALTER TABLE "epoch_rewards"
+ADD CONSTRAINT "epoch_rewards_pkey" PRIMARY KEY ("validator_index", "epoch");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -133,7 +133,7 @@ model epochRewards {
   missedSource     BigInt @map("missed_source")
   missedInactivity BigInt @map("missed_inactivity")
 
-  @@id([epoch, validatorIndex])
+  @@id([validatorIndex, epoch])
   @@map("epoch_rewards")
 }
 


### PR DESCRIPTION
## What changed

This reorders the epoch_rewards primary key from (epoch, validator_index) to (validator_index, epoch).

The same two columns still define uniqueness for epoch reward rows, but the primary index now matches the hourly archive access pattern.

## Why

The hourly archive job processes validators in batches. For each batch it reads epoch_rewards with a validator range plus an epoch range.

The previous primary key started with epoch. Adding a separate (validator_index, epoch) index would help the archive query, but it would duplicate a large index on a high-row-count hourly partition and add write cost during raw reward ingestion.

Reordering the primary key gives the archive path the validator-first index order it needs without maintaining a second large epoch_rewards index.

## Scope

This targets the expensive raw-to-hourly archive query, specifically the repeated per-batch reads from epoch_rewards. It does not optimize upstream raw ingestion steps such as COPY tmp_epoch_rewards or UPDATE committee attestation_delay.

The validator_sync_rewards index proposed earlier was removed because that table is not expected to be the problematic part of this archive path.

## Validation

- DATABASE_URL=postgresql://user:pass@localhost:5432/db pnpm --filter @beacon-indexer/db exec prisma validate --schema prisma/schema.prisma
- pnpm --filter @beacon-indexer/db build
- push hook ran pnpm -r run lint successfully