### PR TITLE
Fix cluster form, analytics labels, and mobile empty state

### DIFF
--- a/packages/webapp/app/page.tsx
+++ b/packages/webapp/app/page.tsx
@@ -10,6 +10,7 @@ import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { useClusters } from '@/hooks/use-clusters';
 import { toClusterList } from '@/lib/cluster-adapter';
 import { useUserId } from '@/lib/user-id';
+import { cn } from '@/lib/utils';
 import { CLUSTER_FILTER_ALL, type ClusterFilter } from '@/types/cluster';
 
 const demoNotifications: Notification[] = [];
@@ -23,22 +24,30 @@ export default function DashboardOverview() {
   const { data: apiClusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters();
 
   const clusters = useMemo(() => toClusterList(apiClusters || []), [apiClusters]);
+  const hasNoClusters = !!userId && !clustersLoading && clusters.length === 0;
 
   return (
-    <div className="py-3 md:py-8 space-y-4 md:space-y-8">
+    <div className="flex min-h-[calc(100dvh-4rem)] flex-col space-y-4 py-3 md:block md:min-h-0 md:space-y-8 md:py-8">
       <NotificationBanner notifications={demoNotifications} />
 
       <ChainStatistics />
 
-      <UserDashboard
-        clusters={clusters}
-        isLoading={!userId || clustersLoading}
-        onAddCluster={() => setClusterFormOpen(true)}
-        onManageCluster={setManagingClusterId}
-        hideAllTab={true}
-        selectedCluster={selectedCluster}
-        onClusterChange={setSelectedCluster}
-      />
+      <div
+        className={cn(
+          'w-full',
+          hasNoClusters && 'flex flex-1 flex-col justify-center md:block md:flex-none',
+        )}
+      >
+        <UserDashboard
+          clusters={clusters}
+          isLoading={!userId || clustersLoading}
+          onAddCluster={() => setClusterFormOpen(true)}
+          onManageCluster={setManagingClusterId}
+          hideAllTab={true}
+          selectedCluster={selectedCluster}
+          onClusterChange={setSelectedCluster}
+        />
+      </div>
 
       {/* Add cluster */}
       <Sheet open={clusterFormOpen} onOpenChange={setClusterFormOpen}>

--- a/packages/webapp/app/page.tsx
+++ b/packages/webapp/app/page.tsx
@@ -27,17 +27,12 @@ export default function DashboardOverview() {
   const hasNoClusters = !!userId && !clustersLoading && clusters.length === 0;
 
   return (
-    <div className="flex min-h-[calc(100dvh-4rem)] flex-col space-y-4 py-3 md:block md:min-h-0 md:space-y-8 md:py-8">
+    <div className="py-3 md:py-8 space-y-4 md:space-y-8">
       <NotificationBanner notifications={demoNotifications} />
 
       <ChainStatistics />
 
-      <div
-        className={cn(
-          'w-full',
-          hasNoClusters && 'flex flex-1 flex-col justify-center md:block md:flex-none',
-        )}
-      >
+      <div className={cn(hasNoClusters && 'pt-4 md:pt-0')}>
         <UserDashboard
           clusters={clusters}
           isLoading={!userId || clustersLoading}

--- a/packages/webapp/components/cluster/analytics-content.tsx
+++ b/packages/webapp/components/cluster/analytics-content.tsx
@@ -19,11 +19,12 @@ import {
   UnderlineTabsList,
   UnderlineTabsTrigger,
 } from '@/components/underline-tabs';
+import { env } from '@/env';
 import { useMissedAttestations } from '@/hooks/use-missed-attestations';
 import { useRewards } from '@/hooks/use-rewards';
 import { useTokenPrice } from '@/hooks/use-token-price';
 import { type AnalyticsTimeRange, bucketByTime } from '@/lib/analytics-buckets';
-import { formatNumber } from '@/lib/utils';
+import { formatNumber, getTokenConfig } from '@/lib/utils';
 import type { ClusterFilter } from '@/types/cluster';
 import type { MissedAttestation, Reward } from '@/types/validator';
 
@@ -245,6 +246,8 @@ function RewardsTab({
   const { data: rewardsResponse, isLoading } = useRewards(clusterFilter, null, timeRange);
 
   const tokenPrice = rewardsResponse?.tokenPrice ?? tokenPriceData?.tokenPrice ?? 0;
+  const { executionTokenSymbol, tokenSymbol } = getTokenConfig(env.NEXT_PUBLIC_CHAIN);
+  const executionTokenPrice = executionTokenSymbol === tokenSymbol ? tokenPrice : 1;
 
   const rewardsChartData = useMemo(
     () =>
@@ -270,7 +273,7 @@ function RewardsTab({
           const blockConsensus = acc?.blockConsensus ?? 0;
           const blockExecution = acc?.blockExecution ?? 0;
           const clTotal = (head + target + source + sync + blockConsensus - missed) * tokenPrice;
-          const elTotal = blockExecution;
+          const elTotal = blockExecution * executionTokenPrice;
           return {
             time,
             head,
@@ -284,7 +287,7 @@ function RewardsTab({
           };
         },
       ),
-    [rewardsResponse, timeRange, tokenPrice],
+    [executionTokenPrice, rewardsResponse, timeRange, tokenPrice],
   );
 
   const rewardsStats = useMemo(() => {
@@ -319,11 +322,11 @@ function RewardsTab({
         source: d.source * tokenPrice,
         sync: d.sync * tokenPrice,
         blockConsensus: d.blockConsensus * tokenPrice,
-        blockExecution: d.blockExecution,
+        blockExecution: d.blockExecution * executionTokenPrice,
         missed: -d.missed * tokenPrice,
         _raw: d,
       })),
-    [rewardsChartData, tokenPrice],
+    [executionTokenPrice, rewardsChartData, tokenPrice],
   );
 
   if (isLoading) {
@@ -358,7 +361,7 @@ function RewardsTab({
           label="SOURCE"
           help="Reward for correctly identifying the justified checkpoint. This is the largest component of attestation rewards."
           value={rewardsStats.source}
-          token="GNO"
+          token={tokenSymbol}
           color="#3b82f6"
           tokenPrice={tokenPrice}
         />
@@ -366,7 +369,7 @@ function RewardsTab({
           label="TARGET"
           help="Reward for correctly voting on the epoch checkpoint (target). Validators earn this by agreeing on the correct target block."
           value={rewardsStats.target}
-          token="GNO"
+          token={tokenSymbol}
           color="#10b981"
           tokenPrice={tokenPrice}
         />
@@ -374,7 +377,7 @@ function RewardsTab({
           label="HEAD"
           help="Reward for correctly voting on the most recent block (head of the chain). A smaller component of attestation rewards."
           value={rewardsStats.head}
-          token="GNO"
+          token={tokenSymbol}
           color="#8b5cf6"
           tokenPrice={tokenPrice}
         />
@@ -382,7 +385,7 @@ function RewardsTab({
           label="MISSED"
           help="Penalties incurred when your validator fails to attest or attests incorrectly. Small amounts are normal; large values may indicate downtime."
           value={rewardsStats.missed}
-          token="GNO"
+          token={tokenSymbol}
           color="hsl(var(--destructive))"
           tokenPrice={tokenPrice}
           isDestructive
@@ -391,7 +394,7 @@ function RewardsTab({
           label="SYNC"
           help="Reward for participating in a sync committee. Only ~512 validators are randomly selected every ~27 hours, so this may be zero most of the time."
           value={rewardsStats.sync}
-          token="GNO"
+          token={tokenSymbol}
           color="#fbbf24"
           tokenPrice={tokenPrice}
         />
@@ -399,17 +402,17 @@ function RewardsTab({
           label="BLOCK (CL)"
           help="Consensus layer reward earned when your validator is randomly selected to propose a block. Includes attestation packing and sync aggregate rewards."
           value={rewardsStats.blockConsensus}
-          token="GNO"
+          token={tokenSymbol}
           color="#f97316"
           tokenPrice={tokenPrice}
         />
         <RewardHeader
           label="BLOCK (EL)"
-          help="Execution layer reward (tips) earned when your validator proposes a block. Paid in the native token (xDAI on Gnosis, ETH on Ethereum)."
+          help="Execution layer reward earned when your validator proposes a block."
           value={rewardsStats.blockExecution}
-          token="xDAI"
+          token={executionTokenSymbol}
           color="#06b6d4"
-          tokenPrice={1}
+          tokenPrice={executionTokenPrice}
         />
       </div>
 
@@ -454,7 +457,7 @@ function RewardsTab({
                       <div className="flex items-center justify-between gap-4">
                         <span className="text-muted-foreground">Source:</span>
                         <span className="font-normal" style={{ color: '#3b82f6' }}>
-                          {fmtToken(raw.source)} GNO{' '}
+                          {fmtToken(raw.source)} {tokenSymbol}{' '}
                           <span className="text-muted-foreground">
                             ({toUsd(raw.source, tokenPrice)})
                           </span>
@@ -463,7 +466,7 @@ function RewardsTab({
                       <div className="flex items-center justify-between gap-4">
                         <span className="text-muted-foreground">Target:</span>
                         <span className="font-normal" style={{ color: '#10b981' }}>
-                          {fmtToken(raw.target)} GNO{' '}
+                          {fmtToken(raw.target)} {tokenSymbol}{' '}
                           <span className="text-muted-foreground">
                             ({toUsd(raw.target, tokenPrice)})
                           </span>
@@ -472,7 +475,7 @@ function RewardsTab({
                       <div className="flex items-center justify-between gap-4">
                         <span className="text-muted-foreground">Head:</span>
                         <span className="font-normal" style={{ color: '#8b5cf6' }}>
-                          {fmtToken(raw.head)} GNO{' '}
+                          {fmtToken(raw.head)} {tokenSymbol}{' '}
                           <span className="text-muted-foreground">
                             ({toUsd(raw.head, tokenPrice)})
                           </span>
@@ -481,7 +484,7 @@ function RewardsTab({
                       <div className="flex items-center justify-between gap-4">
                         <span className="text-muted-foreground">Missed:</span>
                         <span className="font-normal text-destructive">
-                          {fmtToken(raw.missed)} GNO{' '}
+                          {fmtToken(raw.missed)} {tokenSymbol}{' '}
                           <span className="text-muted-foreground">
                             ({toUsd(raw.missed, tokenPrice)})
                           </span>
@@ -491,7 +494,7 @@ function RewardsTab({
                         <div className="flex items-center justify-between gap-4">
                           <span className="text-muted-foreground">Sync Committee:</span>
                           <span className="font-normal text-warning">
-                            {fmtToken(raw.sync)} GNO{' '}
+                            {fmtToken(raw.sync)} {tokenSymbol}{' '}
                             <span className="text-muted-foreground">
                               ({toUsd(raw.sync, tokenPrice)})
                             </span>
@@ -502,7 +505,7 @@ function RewardsTab({
                         <div className="flex items-center justify-between gap-4">
                           <span className="text-muted-foreground">Block (CL):</span>
                           <span className="font-normal" style={{ color: '#f97316' }}>
-                            {fmtToken(raw.blockConsensus)} GNO{' '}
+                            {fmtToken(raw.blockConsensus)} {tokenSymbol}{' '}
                             <span className="text-muted-foreground">
                               ({toUsd(raw.blockConsensus, tokenPrice)})
                             </span>
@@ -513,9 +516,9 @@ function RewardsTab({
                         <div className="flex items-center justify-between gap-4">
                           <span className="text-muted-foreground">Block (EL):</span>
                           <span className="font-normal" style={{ color: '#06b6d4' }}>
-                            {fmtToken(raw.blockExecution)} xDAI{' '}
+                            {fmtToken(raw.blockExecution)} {executionTokenSymbol}{' '}
                             <span className="text-muted-foreground">
-                              ({toUsd(raw.blockExecution, 1)})
+                              ({toUsd(raw.blockExecution, executionTokenPrice)})
                             </span>
                           </span>
                         </div>

--- a/packages/webapp/components/cluster/analytics-token-labels.test.ts
+++ b/packages/webapp/components/cluster/analytics-token-labels.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('Cluster analytics token labels', () => {
+  it('does not render hardcoded consensus or execution token labels', () => {
+    // Read both analytics components because the dashboard has legacy and current analytics views.
+    const sources = [
+      readFileSync(new URL('./analytics.tsx', import.meta.url), 'utf8'),
+      readFileSync(new URL('./analytics-content.tsx', import.meta.url), 'utf8'),
+    ].join('\n');
+
+    // Confirm rendered token labels come from chain-derived variables instead of fixed Gnosis labels.
+    assert.doesNotMatch(sources, /\}\s+GNO/);
+    assert.doesNotMatch(sources, /\}\s+xDAI/);
+    assert.doesNotMatch(sources, /token="GNO"/);
+    assert.doesNotMatch(sources, /token="xDAI"/);
+  });
+});

--- a/packages/webapp/components/cluster/analytics.tsx
+++ b/packages/webapp/components/cluster/analytics.tsx
@@ -18,6 +18,8 @@ import {
   UnderlineTabsList,
   UnderlineTabsTrigger,
 } from '@/components/underline-tabs';
+import { env } from '@/env';
+import { getTokenConfig } from '@/lib/utils';
 import type { MissedAttestation } from '@/types/validator';
 
 interface AnalyticsProps {
@@ -28,6 +30,7 @@ type TimeRange = '1h' | '24h';
 
 export default function Analytics({ data }: AnalyticsProps) {
   const [timeRange, setTimeRange] = useState<TimeRange>('1h');
+  const { tokenSymbol } = getTokenConfig(env.NEXT_PUBLIC_CHAIN);
 
   const chartData = useMemo(() => {
     const now = new Date();
@@ -211,31 +214,31 @@ export default function Analytics({ data }: AnalyticsProps) {
                 <div>
                   <p className="text-[10px] md:text-[11px] text-muted-foreground mb-1">SOURCE</p>
                   <span className="text-base md:text-lg font-display text-[#3b82f6]">
-                    {rewardsStats.totalSource} GNO
+                    {rewardsStats.totalSource} {tokenSymbol}
                   </span>
                 </div>
                 <div>
                   <p className="text-[10px] md:text-[11px] text-muted-foreground mb-1">TARGET</p>
                   <span className="text-base md:text-lg font-display text-[#10b981]">
-                    {rewardsStats.totalTarget} GNO
+                    {rewardsStats.totalTarget} {tokenSymbol}
                   </span>
                 </div>
                 <div>
                   <p className="text-[10px] md:text-[11px] text-muted-foreground mb-1">HEAD</p>
                   <span className="text-base md:text-lg font-display text-[#8b5cf6]">
-                    {rewardsStats.totalHead} GNO
+                    {rewardsStats.totalHead} {tokenSymbol}
                   </span>
                 </div>
                 <div>
                   <p className="text-[10px] md:text-[11px] text-muted-foreground mb-1">SYNC</p>
                   <span className="text-base md:text-lg font-display text-[#fbbf24]">
-                    {rewardsStats.totalSyncCommittee} GNO
+                    {rewardsStats.totalSyncCommittee} {tokenSymbol}
                   </span>
                 </div>
                 <div>
                   <p className="text-[10px] md:text-[11px] text-muted-foreground mb-1">MISSED</p>
                   <span className="text-base md:text-lg font-display text-destructive">
-                    {rewardsStats.totalMissed} GNO
+                    {rewardsStats.totalMissed} {tokenSymbol}
                   </span>
                 </div>
               </div>
@@ -297,38 +300,40 @@ export default function Analytics({ data }: AnalyticsProps) {
                               <div className="flex items-center justify-between gap-4">
                                 <span className="text-muted-foreground">Source:</span>
                                 <span className="font-display" style={{ color: '#3b82f6' }}>
-                                  {data.source} GNO
+                                  {data.source} {tokenSymbol}
                                 </span>
                               </div>
                               <div className="flex items-center justify-between gap-4">
                                 <span className="text-muted-foreground">Target:</span>
                                 <span className="font-display" style={{ color: '#10b981' }}>
-                                  {data.target} GNO
+                                  {data.target} {tokenSymbol}
                                 </span>
                               </div>
                               <div className="flex items-center justify-between gap-4">
                                 <span className="text-muted-foreground">Head:</span>
                                 <span className="font-display" style={{ color: '#8b5cf6' }}>
-                                  {data.head} GNO
+                                  {data.head} {tokenSymbol}
                                 </span>
                               </div>
                               {data.syncCommittee > 0 && (
                                 <div className="flex items-center justify-between gap-4">
                                   <span className="text-muted-foreground">Sync Committee:</span>
                                   <span className="font-display text-warning">
-                                    {data.syncCommittee} GNO
+                                    {data.syncCommittee} {tokenSymbol}
                                   </span>
                                 </div>
                               )}
                               <div className="flex items-center justify-between gap-4">
                                 <span className="text-muted-foreground">Missed:</span>
                                 <span className="font-display text-destructive">
-                                  {data.missed} GNO
+                                  {data.missed} {tokenSymbol}
                                 </span>
                               </div>
                               <div className="flex items-center justify-between gap-4 pt-1 border-t">
                                 <span className="text-muted-foreground">Total:</span>
-                                <span className="font-display">{data.consensusTotal} GNO</span>
+                                <span className="font-display">
+                                  {data.consensusTotal} {tokenSymbol}
+                                </span>
                               </div>
                             </div>
                           </div>

--- a/packages/webapp/components/cluster/cluster-form/bulk-action-dialog.tsx
+++ b/packages/webapp/components/cluster/cluster-form/bulk-action-dialog.tsx
@@ -17,6 +17,12 @@ interface BulkAction {
   action: 'add' | 'remove';
   withdrawalAddress: string;
   validatorCount: number;
+  lidoCsmOperatorId?: number;
+}
+
+interface BulkActionDialogCopy {
+  description: string;
+  sourceValue?: string;
 }
 
 interface BulkActionDialogProps {
@@ -26,6 +32,28 @@ interface BulkActionDialogProps {
   onConfirmRemove: () => void;
 }
 
+/** Builds the confirmation copy for bulk validator changes. */
+export function getBulkActionDialogCopy(bulkAction: BulkAction): BulkActionDialogCopy {
+  if (bulkAction.action === 'remove') {
+    return {
+      description: `This will remove ${bulkAction.validatorCount} validators from your cluster. This action cannot be undone.`,
+      sourceValue: bulkAction.withdrawalAddress,
+    };
+  }
+
+  if (bulkAction.lidoCsmOperatorId !== undefined) {
+    return {
+      description: `Lido CSM operator ${bulkAction.lidoCsmOperatorId} has ${bulkAction.validatorCount} validators. Do you want to add all of them to your cluster?`,
+    };
+  }
+
+  return {
+    description: `This withdrawal address has ${bulkAction.validatorCount} validators. Do you want to add all of them to your cluster?`,
+    sourceValue: bulkAction.withdrawalAddress,
+  };
+}
+
+/** Renders the confirmation dialog for bulk validator add and remove actions. */
 export function BulkActionDialog({
   bulkAction,
   onClose,
@@ -33,6 +61,7 @@ export function BulkActionDialog({
   onConfirmRemove,
 }: BulkActionDialogProps) {
   const isAdd = bulkAction?.action === 'add';
+  const copy = bulkAction ? getBulkActionDialogCopy(bulkAction) : null;
 
   return (
     <AlertDialog open={bulkAction !== null} onOpenChange={(open) => !open && onClose()}>
@@ -44,14 +73,12 @@ export function BulkActionDialog({
           </AlertDialogTitle>
           <AlertDialogDescription asChild>
             <div className="space-y-2 text-sm text-muted-foreground">
-              <div>
-                {isAdd
-                  ? `This withdrawal address has ${bulkAction?.validatorCount} validators. Do you want to add all of them to your cluster?`
-                  : `This will remove ${bulkAction?.validatorCount} validators from your cluster. This action cannot be undone.`}
-              </div>
-              <code className="block bg-muted px-3 py-2 rounded text-xs break-all font-mono">
-                {bulkAction?.withdrawalAddress}
-              </code>
+              <div>{copy?.description}</div>
+              {copy?.sourceValue && (
+                <code className="block bg-muted px-3 py-2 rounded text-xs break-all font-mono">
+                  {copy.sourceValue}
+                </code>
+              )}
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/packages/webapp/components/cluster/cluster-form/lido-csm-operator-card.tsx
+++ b/packages/webapp/components/cluster/cluster-form/lido-csm-operator-card.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Image from 'next/image';
+
+import { Button } from '@/components/ui/button';
+
+interface LidoCsmOperatorCardProps {
+  missingCount: number;
+  onAddMissing: () => void;
+  operatorId: string;
+  validatorCount: number;
+}
+
+/** Renders the stored Lido CSM operator and missing validator action. */
+export function LidoCsmOperatorCard({
+  missingCount,
+  onAddMissing,
+  operatorId,
+  validatorCount,
+}: LidoCsmOperatorCardProps) {
+  return (
+    <div className="rounded-lg border border-border/50 bg-background/50 overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2 bg-muted/30 border-b border-border/50">
+        <Image
+          src="/assets/lido-csm.svg"
+          alt=""
+          width={20}
+          height={20}
+          className="size-5"
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1">
+          <span className="text-[10px] font-medium text-muted-foreground block">
+            Lido CSM operator {operatorId}
+          </span>
+          <span className="text-[10px] text-muted-foreground">
+            {validatorCount} validator{validatorCount !== 1 ? 's' : ''} in cluster
+          </span>
+        </div>
+      </div>
+
+      {missingCount > 0 && (
+        <div className="p-2">
+          <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-md bg-warning/10 text-warning">
+            <span className="text-xs flex-1">
+              {missingCount} more validator{missingCount > 1 ? 's' : ''} available
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onAddMissing}
+              className="h-6 px-2 text-xs text-warning hover:text-warning hover:bg-warning/20"
+            >
+              Add all
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/webapp/components/cluster/cluster-form/validator-input-field.test.tsx
+++ b/packages/webapp/components/cluster/cluster-form/validator-input-field.test.tsx
@@ -6,6 +6,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import { getBulkActionDialogCopy } from './bulk-action-dialog';
 import { ValidatorInputField } from './validator-input-field';
+import { ValidatorsList } from './validators-list';
 import { WithdrawalAddressCard } from './withdrawal-address-card';
 
 (globalThis as { React?: typeof React }).React = React;
@@ -199,5 +200,30 @@ describe('WithdrawalAddressCard', () => {
     );
 
     assert.match(markup, /Withdrawal address/);
+  });
+});
+
+describe('ValidatorsList', () => {
+  it('shows a Lido CSM add banner when operator validators are missing', () => {
+    const markup = renderToStaticMarkup(
+      <ValidatorsList
+        validators={[]}
+        allWithdrawalAddresses={[]}
+        validatorsByAddress={{}}
+        missingValidatorsByAddress={{}}
+        isEditMode
+        lidoCsmOperatorId="344"
+        lidoCsmValidatorCount={50}
+        missingLidoCsmValidatorCount={1}
+        onRemoveValidator={noop}
+        onRemoveByWithdrawal={noop}
+        onAddMissingValidators={noop}
+        onAddMissingLidoCsmValidators={noop}
+      />,
+    );
+
+    assert.match(markup, /Lido CSM operator 344/);
+    assert.match(markup, /1 more validator available/);
+    assert.match(markup, /Add all/);
   });
 });

--- a/packages/webapp/components/cluster/cluster-form/validator-input-field.test.tsx
+++ b/packages/webapp/components/cluster/cluster-form/validator-input-field.test.tsx
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
+import { getBulkActionDialogCopy } from './bulk-action-dialog';
 import { ValidatorInputField } from './validator-input-field';
 import { WithdrawalAddressCard } from './withdrawal-address-card';
 
@@ -59,6 +60,30 @@ describe('ValidatorInputField', () => {
 
     assert.match(markup, /Lido CSM/);
     assert.match(markup, /\/assets\/lido-csm\.svg/);
+    assert.ok(markup.indexOf('Lido CSM') < markup.indexOf('Index'));
+  });
+
+  it('renders the category tabs in a horizontal scroll area', () => {
+    const markup = renderToStaticMarkup(
+      <ValidatorInputField
+        inputValue=""
+        selectedCategory="index"
+        validationState="idle"
+        chain="ethereum"
+        errorMessage=""
+        isSearching={false}
+        isMobile
+        helpDialogOpen={false}
+        onCategoryChange={noop}
+        onHelpDialogChange={noop}
+        onInputChange={noop}
+        onKeyDown={noop}
+        onAdd={noop}
+      />,
+    );
+
+    assert.match(markup, /overflow-x-auto/);
+    assert.match(markup, /w-max/);
   });
 
   it('hides the Lido CSM category for Gnosis', () => {
@@ -130,6 +155,23 @@ describe('ValidatorInputField', () => {
     assert.match(markup, /value="12"/);
     assert.match(markup, /disabled=""/);
     assert.match(markup, />Delete</);
+  });
+});
+
+describe('BulkActionDialog', () => {
+  it('uses Lido CSM copy without rendering an empty source box', () => {
+    const bulkAction = {
+      action: 'add' as const,
+      withdrawalAddress: '',
+      validatorCount: 12,
+      validators: [],
+      lidoCsmOperatorId: 344,
+    };
+
+    const copy = getBulkActionDialogCopy(bulkAction);
+
+    assert.match(copy.description, /Lido CSM operator 344 has 12 validators/);
+    assert.equal(copy.sourceValue, undefined);
   });
 });
 

--- a/packages/webapp/components/cluster/cluster-form/validator-input-field.tsx
+++ b/packages/webapp/components/cluster/cluster-form/validator-input-field.tsx
@@ -190,7 +190,7 @@ export function ValidatorInputField({
   validationState,
 }: ValidatorInputFieldProps) {
   const categoryOptions =
-    chain === 'ethereum' ? [...BASE_CATEGORY_OPTIONS, LIDO_CSM_CATEGORY] : BASE_CATEGORY_OPTIONS;
+    chain === 'ethereum' ? [LIDO_CSM_CATEGORY, ...BASE_CATEGORY_OPTIONS] : BASE_CATEGORY_OPTIONS;
   const hasCurrentLidoCsmOperator =
     selectedCategory === 'lidoCsm' &&
     currentLidoCsmOperatorId !== null &&
@@ -223,32 +223,34 @@ export function ValidatorInputField({
         <HelpButton isMobile={isMobile} open={helpDialogOpen} onOpenChange={onHelpDialogChange} />
       </div>
 
-      <div
-        className="grid gap-1 rounded-xl bg-muted p-1"
-        style={{ gridTemplateColumns: `repeat(${categoryOptions.length}, minmax(0, 1fr))` }}
-      >
-        {categoryOptions.map((category) => {
-          const Icon = category.icon;
-          const isSelected = selectedCategory === category.value;
+      <div className="overflow-x-auto sm:overflow-visible">
+        <div
+          className="flex w-max gap-1 rounded-xl bg-muted p-1 sm:grid sm:w-full"
+          style={{ gridTemplateColumns: `repeat(${categoryOptions.length}, minmax(0, 1fr))` }}
+        >
+          {categoryOptions.map((category) => {
+            const Icon = category.icon;
+            const isSelected = selectedCategory === category.value;
 
-          return (
-            <button
-              key={category.value}
-              type="button"
-              onClick={() => onCategoryChange(category.value)}
-              className={cn(
-                'flex h-12 items-center justify-center gap-2 rounded-lg px-2 text-sm font-bold transition-colors sm:text-base',
-                isSelected
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-              aria-pressed={isSelected}
-            >
-              <Icon className="size-5" />
-              <span>{category.label}</span>
-            </button>
-          );
-        })}
+            return (
+              <button
+                key={category.value}
+                type="button"
+                onClick={() => onCategoryChange(category.value)}
+                className={cn(
+                  'flex h-12 w-32 shrink-0 items-center justify-center gap-2 rounded-lg px-2 text-sm font-bold transition-colors sm:w-auto sm:text-base',
+                  isSelected
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                aria-pressed={isSelected}
+              >
+                <Icon className="size-5" />
+                <span>{category.label}</span>
+              </button>
+            );
+          })}
+        </div>
       </div>
 
       <div className="flex gap-3">

--- a/packages/webapp/components/cluster/cluster-form/validator-input.tsx
+++ b/packages/webapp/components/cluster/cluster-form/validator-input.tsx
@@ -63,6 +63,7 @@ export function ValidatorInput({
     validationState,
     validatorsByAddress,
   } = useValidatorInput({
+    chain: env.NEXT_PUBLIC_CHAIN,
     validators,
     onValidatorsChange,
     currentLidoCsmOperatorId,

--- a/packages/webapp/components/cluster/cluster-form/validator-input.tsx
+++ b/packages/webapp/components/cluster/cluster-form/validator-input.tsx
@@ -37,11 +37,13 @@ export function ValidatorInput({
   const [helpDialogOpen, setHelpDialogOpen] = useState(false);
 
   const {
+    addMissingLidoCsmValidators,
     addMissingValidators,
     allWithdrawalAddresses,
     bulkAction,
     clearLidoCsmSelection,
     closeBulkAction,
+    currentLidoCsmValidatorCount,
     errorMessage,
     handleAddValidator,
     handleCategoryChange,
@@ -54,6 +56,7 @@ export function ValidatorInput({
     isSearching,
     lidoCsmOperatorId,
     lidoCsmValidatorIndexes,
+    missingLidoCsmValidators,
     missingValidatorsByAddress,
     removeValidator,
     selectedSearchCategory,
@@ -62,6 +65,7 @@ export function ValidatorInput({
   } = useValidatorInput({
     validators,
     onValidatorsChange,
+    currentLidoCsmOperatorId,
     withdrawalAddresses,
   });
 
@@ -109,10 +113,14 @@ export function ValidatorInput({
         allWithdrawalAddresses={allWithdrawalAddresses}
         validatorsByAddress={validatorsByAddress}
         missingValidatorsByAddress={missingValidatorsByAddress}
+        lidoCsmOperatorId={visibleLidoCsmOperatorId}
+        lidoCsmValidatorCount={currentLidoCsmValidatorCount}
+        missingLidoCsmValidatorCount={missingLidoCsmValidators.length}
         isEditMode={isEditMode}
         onRemoveValidator={removeValidator}
         onRemoveByWithdrawal={handleRemoveByWithdrawal}
         onAddMissingValidators={addMissingValidators}
+        onAddMissingLidoCsmValidators={addMissingLidoCsmValidators}
       />
 
       <BulkActionDialog

--- a/packages/webapp/components/cluster/cluster-form/validators-list.tsx
+++ b/packages/webapp/components/cluster/cluster-form/validators-list.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { LidoCsmOperatorCard } from './lido-csm-operator-card';
 import { VirtualizedChipList } from './virtualized-chip-list';
 import { WithdrawalAddressCard } from './withdrawal-address-card';
 
@@ -12,22 +13,33 @@ interface ValidatorsListProps {
   validatorsByAddress: Record<string, ValidatorItem[]>;
   missingValidatorsByAddress: Record<string, ValidatorItem[]>;
   isEditMode: boolean;
+  lidoCsmOperatorId?: string | null;
+  lidoCsmValidatorCount?: number;
+  missingLidoCsmValidatorCount?: number;
   onRemoveValidator: (id: string) => void;
   onRemoveByWithdrawal: (address: string) => void;
   onAddMissingValidators: (address: string) => void;
+  onAddMissingLidoCsmValidators?: () => void;
 }
 
+/** Renders the selected validators with grouped missing-validator actions. */
 export function ValidatorsList({
   allWithdrawalAddresses,
   isEditMode: _isEditMode,
+  lidoCsmOperatorId,
+  lidoCsmValidatorCount = 0,
+  missingLidoCsmValidatorCount = 0,
   missingValidatorsByAddress,
+  onAddMissingLidoCsmValidators,
   onAddMissingValidators,
   onRemoveByWithdrawal,
   onRemoveValidator,
   validators,
   validatorsByAddress,
 }: ValidatorsListProps) {
-  if (validators.length === 0) {
+  const hasLidoCsmOperator = lidoCsmOperatorId !== null && lidoCsmOperatorId !== undefined;
+
+  if (validators.length === 0 && !hasLidoCsmOperator) {
     return null;
   }
 
@@ -43,39 +55,49 @@ export function ValidatorsList({
         <Label className="text-primary">Validators ({validators.length})</Label>
       </div>
 
-      {showGroupedByAddress ? (
-        <div className="space-y-3">
-          {allWithdrawalAddresses.map((address) => {
-            const lowerAddr = address.toLowerCase();
-            const addressValidators = validatorsByAddress[lowerAddr] || [];
-            const missingCount = missingValidatorsByAddress[lowerAddr]?.length || 0;
-            const totalCount = addressValidators.length + missingCount;
-
-            if (addressValidators.length === 0) {
-              return null;
-            }
-
-            return (
-              <WithdrawalAddressCard
-                key={address}
-                address={address}
-                validators={addressValidators}
-                totalCount={totalCount}
-                missingCount={missingCount}
-                onRemoveAddress={() => onRemoveByWithdrawal(address)}
-                onRemoveValidator={onRemoveValidator}
-                onAddMissing={() => onAddMissingValidators(address)}
-              />
-            );
-          })}
-        </div>
-      ) : (
-        <VirtualizedChipList
-          validators={sortedValidators}
-          onRemoveValidator={onRemoveValidator}
-          maxHeight={192}
+      {hasLidoCsmOperator && (
+        <LidoCsmOperatorCard
+          operatorId={lidoCsmOperatorId}
+          validatorCount={lidoCsmValidatorCount}
+          missingCount={missingLidoCsmValidatorCount}
+          onAddMissing={onAddMissingLidoCsmValidators ?? (() => {})}
         />
       )}
+
+      {validators.length > 0 &&
+        (showGroupedByAddress ? (
+          <div className="space-y-3">
+            {allWithdrawalAddresses.map((address) => {
+              const lowerAddr = address.toLowerCase();
+              const addressValidators = validatorsByAddress[lowerAddr] || [];
+              const missingCount = missingValidatorsByAddress[lowerAddr]?.length || 0;
+              const totalCount = addressValidators.length + missingCount;
+
+              if (addressValidators.length === 0) {
+                return null;
+              }
+
+              return (
+                <WithdrawalAddressCard
+                  key={address}
+                  address={address}
+                  validators={addressValidators}
+                  totalCount={totalCount}
+                  missingCount={missingCount}
+                  onRemoveAddress={() => onRemoveByWithdrawal(address)}
+                  onRemoveValidator={onRemoveValidator}
+                  onAddMissing={() => onAddMissingValidators(address)}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <VirtualizedChipList
+            validators={sortedValidators}
+            onRemoveValidator={onRemoveValidator}
+            maxHeight={192}
+          />
+        ))}
     </div>
   );
 }

--- a/packages/webapp/components/cluster/events/blocks-tab-utils.test.ts
+++ b/packages/webapp/components/cluster/events/blocks-tab-utils.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { formatBlockProposalDate } from './blocks-tab-utils';
+
+describe('formatBlockProposalDate', () => {
+  it('formats block proposal timestamps as yyyy-mm-dd', () => {
+    // Build a stable UTC timestamp so the date assertion is timezone-independent.
+    const timestamp = Date.UTC(2026, 4, 12, 18, 30, 0);
+
+    // Confirm collapsed block rows can show the requested compact date.
+    assert.equal(formatBlockProposalDate(timestamp), '2026-05-12');
+  });
+});

--- a/packages/webapp/components/cluster/events/blocks-tab-utils.ts
+++ b/packages/webapp/components/cluster/events/blocks-tab-utils.ts
@@ -1,0 +1,4 @@
+/** Formats a block proposal timestamp for collapsed block rows. */
+export function formatBlockProposalDate(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 10);
+}

--- a/packages/webapp/components/cluster/events/blocks-tab.test.ts
+++ b/packages/webapp/components/cluster/events/blocks-tab.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('BlocksTab collapsed row', () => {
+  it('shows the proposed date instead of validator id in the collapsed row', () => {
+    // Read the component source because the row depends on client-only collapsible state.
+    const source = readFileSync(new URL('./blocks-tab.tsx', import.meta.url), 'utf8');
+
+    // Confirm the collapsed summary uses the block date helper.
+    assert.match(source, /formatBlockProposalDate\(block\.timestamp\)/);
+
+    // Confirm the validator id stays out of the collapsed summary.
+    assert.doesNotMatch(source, /Val #\{block\.validatorIndex\}/);
+  });
+});

--- a/packages/webapp/components/cluster/events/blocks-tab.test.ts
+++ b/packages/webapp/components/cluster/events/blocks-tab.test.ts
@@ -14,3 +14,15 @@ describe('BlocksTab collapsed row', () => {
     assert.doesNotMatch(source, /Val #\{block\.validatorIndex\}/);
   });
 });
+
+describe('BlocksTab reward token labels', () => {
+  it('does not render hardcoded consensus or execution token labels', () => {
+    // Read the component source to catch token labels that bypass chain-derived helpers.
+    const source = readFileSync(new URL('./blocks-tab.tsx', import.meta.url), 'utf8');
+
+    // Confirm block reward labels come from chain token config instead of fixed Gnosis labels.
+    assert.doesNotMatch(source, /\}\s+GNO/);
+    assert.match(source, /tokenSymbol/);
+    assert.match(source, /executionTokenSymbol/);
+  });
+});

--- a/packages/webapp/components/cluster/events/blocks-tab.tsx
+++ b/packages/webapp/components/cluster/events/blocks-tab.tsx
@@ -8,8 +8,9 @@ import { EventsTabPagination } from './events-tab-pagination';
 
 import ArrowRight from '@/components/icons/arrow-right';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { env } from '@/env';
 import { useBlockProposals } from '@/hooks/use-block-proposals';
-import { cn } from '@/lib/utils';
+import { cn, getTokenConfig } from '@/lib/utils';
 
 interface BlocksTabProps {
   clusterId: string | null;
@@ -69,6 +70,7 @@ export function BlocksTab({ clusterId }: BlocksTabProps) {
 /** Renders one block row and expands into block details. */
 function BlockItem({ block }: BlockItemProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const { executionTokenSymbol, tokenSymbol } = getTokenConfig(env.NEXT_PUBLIC_CHAIN);
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -121,7 +123,7 @@ function BlockItem({ block }: BlockItemProps) {
             <div className="flex items-center justify-between gap-4">
               <span className="text-muted-foreground text-xs md:text-sm">Consensus Reward</span>
               <span className="font-normal text-success text-xs md:text-sm">
-                {block.consensusReward} GNO
+                {block.consensusReward} {tokenSymbol}
               </span>
             </div>
           )}
@@ -129,7 +131,7 @@ function BlockItem({ block }: BlockItemProps) {
             <div className="flex items-center justify-between gap-4">
               <span className="text-muted-foreground text-xs md:text-sm">Execution Reward</span>
               <span className="font-normal text-success text-xs md:text-sm">
-                {block.executionReward}
+                {block.executionReward} {executionTokenSymbol}
               </span>
             </div>
           )}

--- a/packages/webapp/components/cluster/events/blocks-tab.tsx
+++ b/packages/webapp/components/cluster/events/blocks-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { formatBlockProposalDate } from './blocks-tab-utils';
 import { EmptyStateTab } from './empty-state-tab';
 import { EventsTabPagination } from './events-tab-pagination';
 
@@ -75,7 +76,7 @@ function BlockItem({ block }: BlockItemProps) {
         <div className="flex items-center gap-2 md:gap-3 p-2 md:p-3 rounded-lg bg-accent hover:bg-accent/80 transition-colors group cursor-pointer border border-border/50 hover:border-border">
           <div className="flex-1 flex items-center gap-2 text-left min-w-0">
             <span className="text-xs md:text-sm font-mono text-muted-foreground whitespace-nowrap">
-              Val #{block.validatorIndex}
+              {formatBlockProposalDate(block.timestamp)}
             </span>
             <span className="text-xs md:text-sm font-mono whitespace-nowrap">
               Slot #{block.slot.toLocaleString()}

--- a/packages/webapp/components/cluster/validator-header.tsx
+++ b/packages/webapp/components/cluster/validator-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bell, MessageSquare, Settings } from 'lucide-react';
+import { MessageSquare, Settings } from 'lucide-react';
 import Link from 'next/link';
 import * as React from 'react';
 
@@ -40,10 +40,10 @@ export default function ValidatorHeader() {
                 </a>
               </Button>
 
-              <Button variant="ghost" size="sm" onClick={() => setAlertsOpen(true)}>
+              {/*  <Button variant="ghost" size="sm" onClick={() => setAlertsOpen(true)}>
                 <Bell className="size-4 mr-2" />
                 Configure Alerts
-              </Button>
+              </Button> */}
             </nav>
 
             <div className="flex md:hidden items-center gap-2">

--- a/packages/webapp/components/cluster/validator-header.tsx
+++ b/packages/webapp/components/cluster/validator-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MessageSquare, Settings } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 import Link from 'next/link';
 import * as React from 'react';
 
@@ -55,10 +55,6 @@ export default function ValidatorHeader() {
                 >
                   <MessageSquare className="size-5" />
                 </a>
-              </Button>
-
-              <Button variant="ghost" size="icon" onClick={() => setAlertsOpen(true)}>
-                <Settings className="size-5" />
               </Button>
             </div>
           </div>

--- a/packages/webapp/hooks/use-validator-input-default-category.test.ts
+++ b/packages/webapp/hooks/use-validator-input-default-category.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('useValidatorInput default category', () => {
+  it('initializes the selected search category from the selected chain', () => {
+    // Read the hook source because it depends on React state and app environment wiring.
+    const hookSource = readFileSync(new URL('./use-validator-input.ts', import.meta.url), 'utf8');
+
+    // Confirm the hook asks the shared helper for the chain-specific default category.
+    assert.match(hookSource, /getDefaultValidatorSearchCategory\(chain\)/);
+  });
+
+  it('receives the configured chain from the cluster validator input component', () => {
+    // Read the component source to confirm the app chain reaches the hook initializer.
+    const inputSource = readFileSync(
+      new URL('../components/cluster/cluster-form/validator-input.tsx', import.meta.url),
+      'utf8',
+    );
+
+    // Confirm the component passes NEXT_PUBLIC_CHAIN into the validator input hook.
+    assert.match(inputSource, /chain:\s*env\.NEXT_PUBLIC_CHAIN/);
+  });
+});

--- a/packages/webapp/hooks/use-validator-input-utils.test.ts
+++ b/packages/webapp/hooks/use-validator-input-utils.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { getMissingValidatorItems, type ValidatorItem } from './use-validator-input-utils';
+
+describe('getMissingValidatorItems', () => {
+  it('returns validators linked to a Lido CSM operator that are not in the cluster', () => {
+    const currentValidators: ValidatorItem[] = [
+      {
+        id: 'validator-50',
+        type: 'index',
+        value: '50',
+        index: 50,
+        displayName: 'Validator #50',
+        withdrawalAddress: '0x0000000000000000000000000000000000000050',
+      },
+    ];
+
+    const missingValidators = getMissingValidatorItems({
+      currentValidators,
+      idPrefix: 'missing-lido-csm-344',
+      searchResults: [
+        {
+          index: 50,
+          pubkey: null,
+          withdrawalAddress: '0x0000000000000000000000000000000000000050',
+        },
+        {
+          index: 51,
+          pubkey: null,
+          withdrawalAddress: '0x0000000000000000000000000000000000000051',
+        },
+      ],
+    });
+
+    assert.deepEqual(
+      missingValidators.map((validator) => validator.index),
+      [51],
+    );
+    assert.equal(missingValidators[0].id, 'missing-lido-csm-344-0');
+  });
+});

--- a/packages/webapp/hooks/use-validator-input-utils.test.ts
+++ b/packages/webapp/hooks/use-validator-input-utils.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { getMissingValidatorItems, type ValidatorItem } from './use-validator-input-utils';
+import {
+  getMissingValidatorItems,
+  parseSavedLidoCsmOperatorId,
+  type ValidatorItem,
+} from './use-validator-input-utils';
 
 describe('getMissingValidatorItems', () => {
   it('returns validators linked to a Lido CSM operator that are not in the cluster', () => {
@@ -38,5 +42,13 @@ describe('getMissingValidatorItems', () => {
       [51],
     );
     assert.equal(missingValidators[0].id, 'missing-lido-csm-344-0');
+  });
+});
+
+describe('parseSavedLidoCsmOperatorId', () => {
+  it('keeps operator zero valid while ignoring blank values', () => {
+    assert.equal(parseSavedLidoCsmOperatorId('0'), 0);
+    assert.equal(parseSavedLidoCsmOperatorId(''), undefined);
+    assert.equal(parseSavedLidoCsmOperatorId('   '), undefined);
   });
 });

--- a/packages/webapp/hooks/use-validator-input-utils.ts
+++ b/packages/webapp/hooks/use-validator-input-utils.ts
@@ -15,6 +15,21 @@ interface MissingValidatorItemsParams {
   searchResults: ValidatorSearchResult[];
 }
 
+/** Parses a saved Lido CSM operator id without treating blank values as zero. */
+export function parseSavedLidoCsmOperatorId(
+  operatorId: string | null | undefined,
+): number | undefined {
+  const trimmedOperatorId = operatorId?.trim();
+
+  if (!trimmedOperatorId) {
+    return undefined;
+  }
+
+  const parsedOperatorId = Number(trimmedOperatorId);
+
+  return Number.isInteger(parsedOperatorId) && parsedOperatorId >= 0 ? parsedOperatorId : undefined;
+}
+
 /** Sorts validator items by index from highest to lowest. */
 export function sortValidatorsDescending(validators: ValidatorItem[]): ValidatorItem[] {
   return [...validators].sort((a, b) => b.index - a.index);

--- a/packages/webapp/hooks/use-validator-input-utils.ts
+++ b/packages/webapp/hooks/use-validator-input-utils.ts
@@ -1,0 +1,43 @@
+import type { ValidatorSearchResult } from './use-validator-search';
+
+export type ValidatorItem = {
+  id: string;
+  type: 'withdrawal' | 'pubkey' | 'index';
+  value: string;
+  index: number;
+  displayName: string;
+  withdrawalAddress: string | null;
+};
+
+interface MissingValidatorItemsParams {
+  currentValidators: ValidatorItem[];
+  idPrefix: string;
+  searchResults: ValidatorSearchResult[];
+}
+
+/** Sorts validator items by index from highest to lowest. */
+export function sortValidatorsDescending(validators: ValidatorItem[]): ValidatorItem[] {
+  return [...validators].sort((a, b) => b.index - a.index);
+}
+
+/** Builds validator items for search results that are not already in the cluster. */
+export function getMissingValidatorItems({
+  currentValidators,
+  idPrefix,
+  searchResults,
+}: MissingValidatorItemsParams): ValidatorItem[] {
+  const currentIndexes = new Set(currentValidators.map((validator) => validator.index));
+
+  return sortValidatorsDescending(
+    searchResults
+      .filter((result) => !currentIndexes.has(result.index))
+      .map((result, index) => ({
+        id: `${idPrefix}-${index}`,
+        type: 'index' as const,
+        value: result.index.toString(),
+        index: result.index,
+        displayName: `Validator #${result.index}`,
+        withdrawalAddress: result.withdrawalAddress,
+      })),
+  );
+}

--- a/packages/webapp/hooks/use-validator-input.ts
+++ b/packages/webapp/hooks/use-validator-input.ts
@@ -4,6 +4,12 @@ import { useMemo, useState } from 'react';
 
 import { useToast } from '@/hooks/use-toast';
 import {
+  getMissingValidatorItems,
+  sortValidatorsDescending,
+  type ValidatorItem,
+} from '@/hooks/use-validator-input-utils';
+import {
+  useGetValidatorsFromLidoCsmOperatorId,
   useGetValidatorsFromWithdrawalAddresses,
   useSearchByIndex,
   useSearchByIndexes,
@@ -18,14 +24,7 @@ import {
   type ValidatorSearchCategory,
 } from '@/lib/validator-search-input';
 
-export type ValidatorItem = {
-  id: string;
-  type: 'withdrawal' | 'pubkey' | 'index';
-  value: string;
-  index: number;
-  displayName: string;
-  withdrawalAddress: string | null;
-};
+export type { ValidatorItem };
 
 export type ValidationState = 'idle' | 'validating' | 'valid' | 'invalid';
 
@@ -42,14 +41,8 @@ const BULK_ADD_THRESHOLD = 10;
 interface UseValidatorInputProps {
   validators: ValidatorItem[];
   onValidatorsChange: (validators: ValidatorItem[]) => void;
+  currentLidoCsmOperatorId?: string | null;
   withdrawalAddresses?: string[];
-}
-
-/**
- * Sort validators by index descending (highest first)
- */
-function sortValidatorsDescending(validators: ValidatorItem[]): ValidatorItem[] {
-  return [...validators].sort((a, b) => b.index - a.index);
 }
 
 /**
@@ -60,6 +53,7 @@ function sortValidatorsDescending(validators: ValidatorItem[]): ValidatorItem[] 
  * Groups validators by their actual withdrawal address.
  */
 export function useValidatorInput({
+  currentLidoCsmOperatorId,
   onValidatorsChange,
   validators,
   withdrawalAddresses: knownWithdrawalAddresses = [],
@@ -91,6 +85,21 @@ export function useValidatorInput({
   const searchByPubkeys = useSearchByPubkeys();
   const searchByWithdrawalAddresses = useSearchByWithdrawalAddresses();
 
+  const parsedSavedLidoCsmOperatorId =
+    currentLidoCsmOperatorId !== null && currentLidoCsmOperatorId !== undefined
+      ? Number(currentLidoCsmOperatorId)
+      : undefined;
+  const savedLidoCsmOperatorId =
+    parsedSavedLidoCsmOperatorId !== undefined &&
+    Number.isInteger(parsedSavedLidoCsmOperatorId) &&
+    parsedSavedLidoCsmOperatorId >= 0
+      ? parsedSavedLidoCsmOperatorId
+      : undefined;
+  const trackedLidoCsmOperatorId = lidoCsmOperatorId ?? savedLidoCsmOperatorId;
+
+  const { validators: validatorsByLidoCsmOperator } =
+    useGetValidatorsFromLidoCsmOperatorId(trackedLidoCsmOperatorId);
+
   // Combine known and discovered withdrawal addresses for fetching all validators
   const allWithdrawalAddressesToFetch = useMemo(() => {
     const combined = new Set([
@@ -118,7 +127,6 @@ export function useValidatorInput({
 
   // Compute validatorsByAddress and missingValidatorsByAddress
   const { missingValidatorsByAddress, validatorsByAddress } = useMemo(() => {
-    const currentIndexes = new Set(validators.map((v) => v.index));
     const byAddress: Record<string, ValidatorItem[]> = {};
     const missing: Record<string, ValidatorItem[]> = {};
 
@@ -143,16 +151,11 @@ export function useValidatorInput({
       const lowerAddr = address.toLowerCase();
       const results = validatorsByWithdrawalAddress[address] || [];
 
-      const missingForAddress = results
-        .filter((r) => !currentIndexes.has(r.index))
-        .map((r, i) => ({
-          id: `missing-${lowerAddr}-${i}`,
-          type: 'index' as const,
-          value: r.index.toString(),
-          index: r.index,
-          displayName: `Validator #${r.index}`,
-          withdrawalAddress: r.withdrawalAddress,
-        }));
+      const missingForAddress = getMissingValidatorItems({
+        currentValidators: validators,
+        idPrefix: `missing-${lowerAddr}`,
+        searchResults: results,
+      });
 
       if (missingForAddress.length > 0) {
         missing[lowerAddr] = sortValidatorsDescending(missingForAddress);
@@ -161,6 +164,24 @@ export function useValidatorInput({
 
     return { validatorsByAddress: byAddress, missingValidatorsByAddress: missing };
   }, [validatorsByWithdrawalAddress, validators, allWithdrawalAddressesToFetch]);
+
+  const missingLidoCsmValidators = useMemo(() => {
+    if (trackedLidoCsmOperatorId === undefined) {
+      return [];
+    }
+
+    return getMissingValidatorItems({
+      currentValidators: validators,
+      idPrefix: `missing-lido-csm-${trackedLidoCsmOperatorId}`,
+      searchResults: validatorsByLidoCsmOperator,
+    });
+  }, [trackedLidoCsmOperatorId, validators, validatorsByLidoCsmOperator]);
+
+  const currentLidoCsmValidatorCount = useMemo(() => {
+    const currentIndexes = new Set(validators.map((validator) => validator.index));
+    return validatorsByLidoCsmOperator.filter((validator) => currentIndexes.has(validator.index))
+      .length;
+  }, [validators, validatorsByLidoCsmOperator]);
 
   const isSearching =
     searchByIndex.isPending ||
@@ -480,6 +501,22 @@ export function useValidatorInput({
     });
   };
 
+  const addMissingLidoCsmValidators = () => {
+    if (missingLidoCsmValidators.length === 0) return;
+
+    onValidatorsChange(sortValidatorsDescending([...validators, ...missingLidoCsmValidators]));
+    setLidoCsmValidatorIndexes((currentIndexes) => [
+      ...new Set([
+        ...currentIndexes,
+        ...missingLidoCsmValidators.map((validator) => validator.index),
+      ]),
+    ]);
+    toast({
+      title: 'Validators added',
+      description: `Added ${missingLidoCsmValidators.length} Lido CSM validators`,
+    });
+  };
+
   const handleInputChange = (value: string) => {
     setInputValue(value);
     setValidationState('idle');
@@ -522,6 +559,8 @@ export function useValidatorInput({
     allWithdrawalAddresses,
     validatorsByAddress,
     missingValidatorsByAddress,
+    missingLidoCsmValidators,
+    currentLidoCsmValidatorCount,
     lidoCsmOperatorId,
     lidoCsmValidatorIndexes,
 
@@ -532,6 +571,7 @@ export function useValidatorInput({
     handleConfirmBulkRemove,
     removeValidator,
     addMissingValidators,
+    addMissingLidoCsmValidators,
     handleInputChange,
     handleCategoryChange,
     handleKeyDown,

--- a/packages/webapp/hooks/use-validator-input.ts
+++ b/packages/webapp/hooks/use-validator-input.ts
@@ -20,6 +20,7 @@ import {
   useSearchByWithdrawalAddresses,
 } from '@/hooks/use-validator-search';
 import {
+  getDefaultValidatorSearchCategory,
   parseValidatorSearchInput,
   type ValidatorSearchCategory,
 } from '@/lib/validator-search-input';
@@ -39,6 +40,7 @@ export type BulkAction = {
 const BULK_ADD_THRESHOLD = 10;
 
 interface UseValidatorInputProps {
+  chain: 'gnosis' | 'ethereum';
   validators: ValidatorItem[];
   onValidatorsChange: (validators: ValidatorItem[]) => void;
   currentLidoCsmOperatorId?: string | null;
@@ -53,6 +55,7 @@ interface UseValidatorInputProps {
  * Groups validators by their actual withdrawal address.
  */
 export function useValidatorInput({
+  chain,
   currentLidoCsmOperatorId,
   onValidatorsChange,
   validators,
@@ -67,8 +70,9 @@ export function useValidatorInput({
   const [bulkAction, setBulkAction] = useState<BulkAction>(null);
   const [lidoCsmOperatorId, setLidoCsmOperatorId] = useState<number | undefined>(undefined);
   const [lidoCsmValidatorIndexes, setLidoCsmValidatorIndexes] = useState<number[]>([]);
-  const [selectedSearchCategory, setSelectedSearchCategory] =
-    useState<ValidatorSearchCategory>('index');
+  const [selectedSearchCategory, setSelectedSearchCategory] = useState<ValidatorSearchCategory>(
+    () => getDefaultValidatorSearchCategory(chain),
+  );
 
   // Track withdrawal addresses discovered when adding validators by index/pubkey
   // These are addresses not in knownWithdrawalAddresses but found from validators added

--- a/packages/webapp/hooks/use-validator-input.ts
+++ b/packages/webapp/hooks/use-validator-input.ts
@@ -5,6 +5,7 @@ import { useMemo, useState } from 'react';
 import { useToast } from '@/hooks/use-toast';
 import {
   getMissingValidatorItems,
+  parseSavedLidoCsmOperatorId,
   sortValidatorsDescending,
   type ValidatorItem,
 } from '@/hooks/use-validator-input-utils';
@@ -89,16 +90,7 @@ export function useValidatorInput({
   const searchByPubkeys = useSearchByPubkeys();
   const searchByWithdrawalAddresses = useSearchByWithdrawalAddresses();
 
-  const parsedSavedLidoCsmOperatorId =
-    currentLidoCsmOperatorId !== null && currentLidoCsmOperatorId !== undefined
-      ? Number(currentLidoCsmOperatorId)
-      : undefined;
-  const savedLidoCsmOperatorId =
-    parsedSavedLidoCsmOperatorId !== undefined &&
-    Number.isInteger(parsedSavedLidoCsmOperatorId) &&
-    parsedSavedLidoCsmOperatorId >= 0
-      ? parsedSavedLidoCsmOperatorId
-      : undefined;
+  const savedLidoCsmOperatorId = parseSavedLidoCsmOperatorId(currentLidoCsmOperatorId);
   const trackedLidoCsmOperatorId = lidoCsmOperatorId ?? savedLidoCsmOperatorId;
 
   const { validators: validatorsByLidoCsmOperator } =

--- a/packages/webapp/hooks/use-validator-search.ts
+++ b/packages/webapp/hooks/use-validator-search.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation, useQueries } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
 
 import { orpcClient } from '@/lib/orpc';
 
@@ -118,6 +118,30 @@ export function useSearchByLidoCsmOperatorId() {
       return response.data.validators;
     },
   });
+}
+
+/**
+ * Hook to fetch validators for one Lido CSM operator id in the background
+ */
+export function useGetValidatorsFromLidoCsmOperatorId(lidoCsmOperatorId: number | undefined) {
+  const query = useQuery({
+    queryKey: ['validators', 'byLidoCsmOperatorId', lidoCsmOperatorId],
+    queryFn: async (): Promise<ValidatorSearchResult[]> => {
+      if (lidoCsmOperatorId === undefined) {
+        return [];
+      }
+
+      const response = await orpcClient.validator.search({ lidoCsmOperatorId });
+      if (!response.success || !response.data) {
+        throw new Error(response.error?.message || 'Failed to fetch Lido CSM validators');
+      }
+      return response.data.validators;
+    },
+    enabled: lidoCsmOperatorId !== undefined,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return { validators: query.data ?? [], isLoading: query.isLoading };
 }
 
 /**

--- a/packages/webapp/lib/validator-search-input.test.ts
+++ b/packages/webapp/lib/validator-search-input.test.ts
@@ -1,9 +1,22 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { parseValidatorSearchInput } from './validator-search-input';
+import {
+  getDefaultValidatorSearchCategory,
+  parseValidatorSearchInput,
+} from './validator-search-input';
 
 describe('parseValidatorSearchInput', () => {
+  it('uses Lido CSM as the default Ethereum validator search category', () => {
+    // Confirm Ethereum cluster configuration opens on the Lido CSM tab.
+    assert.equal(getDefaultValidatorSearchCategory('ethereum'), 'lidoCsm');
+  });
+
+  it('uses index as the default Gnosis validator search category', () => {
+    // Confirm Gnosis keeps index first because Lido CSM is not available there.
+    assert.equal(getDefaultValidatorSearchCategory('gnosis'), 'index');
+  });
+
   it('treats numeric input as invalid when the pubkey category is selected', () => {
     const result = parseValidatorSearchInput('123', 'pubkey');
 

--- a/packages/webapp/lib/validator-search-input.ts
+++ b/packages/webapp/lib/validator-search-input.ts
@@ -1,11 +1,19 @@
 import { isAddress, isHex, size } from 'viem';
 
 export type ValidatorSearchCategory = 'index' | 'pubkey' | 'withdrawalAddress' | 'lidoCsm';
+type ValidatorSearchChain = 'gnosis' | 'ethereum';
 
 export interface ParsedValidatorSearchInput {
   type: ValidatorSearchCategory;
   values: string[];
   invalidValues: string[];
+}
+
+/** Returns the first validator search category for a chain. */
+export function getDefaultValidatorSearchCategory(
+  chain: ValidatorSearchChain,
+): ValidatorSearchCategory {
+  return chain === 'ethereum' ? 'lidoCsm' : 'index';
 }
 
 /** Checks whether a value is valid for the selected validator search category. */

--- a/packages/webapp/next-config.test.ts
+++ b/packages/webapp/next-config.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('next.config', () => {
+  it('hides the Next development indicator', () => {
+    // Read the config source so the dev indicator stays disabled in local development.
+    const source = readFileSync(new URL('./next.config.mjs', import.meta.url), 'utf8');
+
+    // Confirm the bottom-left Next development indicator is disabled.
+    assert.match(source, /devIndicators:\s*false/);
+  });
+});

--- a/packages/webapp/next.config.mjs
+++ b/packages/webapp/next.config.mjs
@@ -14,6 +14,8 @@ const createNextConfig = (phase) => {
     images: {
       unoptimized: true,
     },
+    // Hide the Next.js development indicator in the app viewport.
+    devIndicators: false,
     async headers() {
       // Allow localhost connections in development for API calls
       const connectSrc = isDevelopment


### PR DESCRIPTION
## Summary
- Improves cluster validator entry tabs and defaults Ethereum to Lido CSM while keeping Gnosis on index input.
- Shows missing Lido CSM validators the same way withdrawal-address clusters show newly linked validators.
- Replaces hardcoded GNO/xDAI reward labels with chain token labels in analytics and block events.
- Updates block event collapsed rows to show the proposal date on mobile.
- Hides alert triggers and the Next.js development indicator, and adjusts mobile empty dashboard spacing.

## Validation
- `pnpm exec tsx --test next-config.test.ts` from `packages/webapp`
- `pnpm exec tsx --test cluster-form/validator-input-field.test.tsx cluster-form/validator-input-helpers.test.ts blocks-tab.test.ts`
- `pnpm --filter @beacon-indexer/api build && pnpm --filter @beacon-indexer/webapp exec tsc --noEmit`
- pre-push `pnpm -r run lint`
