### PR TITLE
Fix validator deposit keying

### DIFF
--- a/packages/db/prisma/migrations/20260519175000_rekey_validator_deposits/migration.sql
+++ b/packages/db/prisma/migrations/20260519175000_rekey_validator_deposits/migration.sql
@@ -22,7 +22,8 @@ UPDATE "public"."validator_deposits" target
 SET "index" = numbered_deposits."backfilled_index"::integer
 FROM numbered_deposits
 WHERE target."slot" = numbered_deposits."slot"
-  AND target."pubkey" = numbered_deposits."pubkey";
+  AND target."pubkey" = numbered_deposits."pubkey"
+  AND target."index" IS NULL;
 
 ALTER TABLE "public"."validator_deposits"
   ALTER COLUMN "source" SET NOT NULL,

--- a/packages/db/prisma/migrations/20260519175000_rekey_validator_deposits/migration.sql
+++ b/packages/db/prisma/migrations/20260519175000_rekey_validator_deposits/migration.sql
@@ -1,0 +1,35 @@
+ALTER TABLE "public"."validator_deposits"
+  ADD COLUMN "source" CHAR(1);
+
+UPDATE "public"."validator_deposits"
+SET "source" = CASE
+  WHEN "index" IS NULL THEN 'd'
+  ELSE 'e'
+END;
+
+WITH numbered_deposits AS (
+  SELECT
+    "slot",
+    "pubkey",
+    ROW_NUMBER() OVER (
+      PARTITION BY "slot"
+      ORDER BY "pubkey", "withdrawal_credentials", "amount"
+    ) - 1 AS "backfilled_index"
+  FROM "public"."validator_deposits"
+  WHERE "index" IS NULL
+)
+UPDATE "public"."validator_deposits" target
+SET "index" = numbered_deposits."backfilled_index"::integer
+FROM numbered_deposits
+WHERE target."slot" = numbered_deposits."slot"
+  AND target."pubkey" = numbered_deposits."pubkey";
+
+ALTER TABLE "public"."validator_deposits"
+  ALTER COLUMN "source" SET NOT NULL,
+  ALTER COLUMN "index" SET NOT NULL,
+  DROP CONSTRAINT "validator_deposits_pkey",
+  ADD CONSTRAINT "validator_deposits_source_check" CHECK ("source" IN ('d', 'e')),
+  ADD CONSTRAINT "validator_deposits_pkey" PRIMARY KEY ("slot", "source", "index");
+
+CREATE INDEX "validator_deposits_pubkey_slot_idx"
+  ON "public"."validator_deposits"("pubkey", "slot" DESC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -149,12 +149,16 @@ model validatorWithdrawals {
 
 model validatorDeposits {
   slot                  Int    @map("slot")
+  // Stores the compact deposit origin: body deposits use d, execution requests use e.
+  source                String @map("source") @db.Char(1)
   pubkey                String @map("pubkey") @db.VarChar(98)
   withdrawalCredentials String @map("withdrawal_credentials") @db.VarChar(66)
   amount                BigInt @map("amount")
-  index                 Int?   @map("index")
+  // Body deposits store the block-body array position; execution request deposits store the request index.
+  index                 Int    @map("index")
 
-  @@id([slot, pubkey])
+  @@id([slot, source, index])
+  @@index([pubkey, slot(sort: Desc)], map: "validator_deposits_pubkey_slot_idx")
   @@map("validator_deposits")
 }
 

--- a/packages/indexer/src/services/consensus/controllers/slot.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.test.ts
@@ -60,4 +60,142 @@ describe('SlotController', () => {
       },
     ]);
   });
+
+  // This test verifies beacon body deposits get a source-local index because the
+  // Beacon API body deposit payload has no protocol deposit index.
+  it('stores body deposits with data source and positional index', async () => {
+    // This storage mock returns an unprocessed slot and captures body deposit rows.
+    const slotStorage = {
+      getBaseSlot: vi.fn().mockResolvedValue({
+        slot: 456,
+        depositsFetched: false,
+      }),
+      saveBodyDeposits: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // This controller only needs slot storage for body deposit processing.
+    const controller = new SlotController(
+      slotStorage as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    // This call uses two body deposits in one slot; their order is the only
+    // source-local identity available for body deposits in the block response.
+    await controller.processDeposits(456, [
+      {
+        proof: [],
+        data: {
+          pubkey:
+            '0x95bfbd34770dcf14d605342f8141ff54c5737af55edd3034dd3bc3beecef5c610b38860de24e2de99a179ad61d535bdb',
+          withdrawal_credentials:
+            '0x010000000000000000000000d1e0bfc4b19c8310b71ae202dc7cb96a8733aebc',
+          amount: '32000000000',
+          signature: '0x01',
+        },
+      },
+      {
+        proof: [],
+        data: {
+          pubkey:
+            '0xa1202e8dec943df62a030f6d8226393c9914d12d6a03edfbeac2979326f63daa104bc6aacbffb39747db0552497065a4',
+          withdrawal_credentials:
+            '0x010000000000000000000000d1e0bfc4b19c8310b71ae202dc7cb96a8733aebc',
+          amount: '32000000000',
+          signature: '0x02',
+        },
+      },
+    ]);
+
+    // This assertion verifies body deposits are uniquely identified inside their
+    // slot by source plus response position, without relying on pubkey uniqueness.
+    expect(slotStorage.saveBodyDeposits).toHaveBeenCalledWith(456, [
+      {
+        slot: 456,
+        source: 'd',
+        pubkey:
+          '0x95bfbd34770dcf14d605342f8141ff54c5737af55edd3034dd3bc3beecef5c610b38860de24e2de99a179ad61d535bdb',
+        withdrawalCredentials: '0x010000000000000000000000d1e0bfc4b19c8310b71ae202dc7cb96a8733aebc',
+        amount: BigInt('32000000000'),
+        index: 0,
+      },
+      {
+        slot: 456,
+        source: 'd',
+        pubkey:
+          '0xa1202e8dec943df62a030f6d8226393c9914d12d6a03edfbeac2979326f63daa104bc6aacbffb39747db0552497065a4',
+        withdrawalCredentials: '0x010000000000000000000000d1e0bfc4b19c8310b71ae202dc7cb96a8733aebc',
+        amount: BigInt('32000000000'),
+        index: 1,
+      },
+    ]);
+  });
+
+  // This test protects repeated execution request deposit pubkeys in one slot.
+  it('stores execution request deposits with data source and request index', async () => {
+    // This storage mock returns an unprocessed slot and captures execution request deposits.
+    const slotStorage = {
+      getBaseSlot: vi.fn().mockResolvedValue({
+        slot: 789,
+        erDepositsFetched: false,
+      }),
+      saveValidatorDeposits: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // This controller only needs slot storage for execution request deposit processing.
+    const controller = new SlotController(
+      slotStorage as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    // This call mirrors slot 14366232: two request deposits share one pubkey but
+    // carry different request indexes and amounts.
+    await controller.processErDeposits(789, [
+      {
+        pubkey:
+          '0x81e4e336806f73d993b2148a3421f2bcf54bef9f358410826aec4833634d34da88bb57610f0d645a4cf8b3ffff2f77af',
+        withdrawal_credentials:
+          '0x02000000000000000000000085122eae301063fe709f8ae2411ef1a89e40a73e',
+        amount: '1100000000',
+        signature: '0x01',
+        index: '2479367',
+      },
+      {
+        pubkey:
+          '0x81e4e336806f73d993b2148a3421f2bcf54bef9f358410826aec4833634d34da88bb57610f0d645a4cf8b3ffff2f77af',
+        withdrawal_credentials:
+          '0x02000000000000000000000085122eae301063fe709f8ae2411ef1a89e40a73e',
+        amount: '2500000000',
+        signature: '0x02',
+        index: '2479368',
+      },
+    ]);
+
+    // This assertion verifies duplicate pubkeys are stored as separate request rows.
+    expect(slotStorage.saveValidatorDeposits).toHaveBeenCalledWith(789, [
+      {
+        slot: 789,
+        source: 'e',
+        pubkey:
+          '0x81e4e336806f73d993b2148a3421f2bcf54bef9f358410826aec4833634d34da88bb57610f0d645a4cf8b3ffff2f77af',
+        withdrawalCredentials: '0x02000000000000000000000085122eae301063fe709f8ae2411ef1a89e40a73e',
+        index: 2479367,
+        amount: BigInt('1100000000'),
+      },
+      {
+        slot: 789,
+        source: 'e',
+        pubkey:
+          '0x81e4e336806f73d993b2148a3421f2bcf54bef9f358410826aec4833634d34da88bb57610f0d645a4cf8b3ffff2f77af',
+        withdrawalCredentials: '0x02000000000000000000000085122eae301063fe709f8ae2411ef1a89e40a73e',
+        index: 2479368,
+        amount: BigInt('2500000000'),
+      },
+    ]);
+  });
 });

--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -285,12 +285,13 @@ export class SlotController extends SlotControllerHelpers {
 
     await this.slotStorage.saveBodyDeposits(
       baseSlot.slot,
-      deposits.map((deposit) => ({
+      deposits.map((deposit, depositIndex) => ({
         slot: baseSlot.slot,
+        source: 'd',
         pubkey: deposit.data.pubkey,
         withdrawalCredentials: deposit.data.withdrawal_credentials,
         amount: BigInt(deposit.data.amount),
-        index: undefined,
+        index: depositIndex,
       })),
     );
   }
@@ -355,6 +356,7 @@ export class SlotController extends SlotControllerHelpers {
       baseSlot.slot,
       deposits.map((deposit) => ({
         slot: baseSlot.slot,
+        source: 'e',
         pubkey: deposit.pubkey,
         withdrawalCredentials: deposit.withdrawal_credentials,
         index: Number(deposit.index),

--- a/packages/indexer/src/services/consensus/storage/slot.ts
+++ b/packages/indexer/src/services/consensus/storage/slot.ts
@@ -772,7 +772,7 @@ export class SlotStorage {
   async getValidatorDepositsForSlot(slot: number) {
     return this.prisma.validatorDeposits.findMany({
       where: { slot },
-      orderBy: { pubkey: 'asc' },
+      orderBy: [{ source: 'asc' }, { index: 'asc' }],
     });
   }
 

--- a/packages/indexer/src/services/consensus/storage/slot.ts
+++ b/packages/indexer/src/services/consensus/storage/slot.ts
@@ -358,7 +358,7 @@ export class SlotStorage {
           },
         });
       },
-      { timeout: ms('3m') },
+      { timeout: ms('5m') },
     );
   }
 


### PR DESCRIPTION
## Summary
- rekey validator deposits by slot, compact source, and index
- backfill existing deposit rows without deleting data
- tag new body deposits as source d and execution request deposits as source e
- extend attestation transaction timeout from 3m to 5m

## Root cause
Execution request deposits can contain repeated pubkeys in the same slot. The old primary key on validator_deposits used slot and pubkey, so distinct request deposits could collide.

## Validation
- DATABASE_URL='postgresql://user:pass@localhost:5432/db' pnpm --filter @beacon-indexer/db exec prisma validate --schema prisma/schema.prisma
- pnpm --filter @beacon-indexer/db run type-check
- pnpm --filter indexer run type-check
- pnpm --filter indexer run build
- pnpm --filter indexer run test -- --run