### PR TITLE
Remove hardcoded rewards prefetch endpoint

### DIFF
--- a/packages/indexer/src/services/consensus/beacon.test.ts
+++ b/packages/indexer/src/services/consensus/beacon.test.ts
@@ -171,6 +171,85 @@ describe('BeaconClient reward cache', () => {
     expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
+  // This test verifies normal block reward processing coalesces after joining a failed prefetch.
+  it('coalesces block reward requests after joining an in-flight failed prefetch', async () => {
+    // This client is configured far behind head so block reward prefetching is enabled.
+    const beaconClient = new BeaconClient({
+      fullNodeUrl: 'http://full-node',
+      fullNodeConcurrency: 1,
+      fullNodeRetries: 0,
+      archiveNodeUrl: 'http://archive-node',
+      archiveNodeConcurrency: 1,
+      archiveNodeRetries: 0,
+      baseDelay: 1,
+      slotStartIndexing: 1,
+      slotsPerEpoch: 32,
+    });
+
+    // This error simulates an archive node failure during the background prefetch.
+    const prefetchError = new AxiosError('Request failed with status code 500');
+    prefetchError.response = {
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: {},
+      config: {} as never,
+      data: { message: 'Internal Server Error' },
+    };
+
+    // This deferred rejection keeps the prefetch request in flight while normal callers join it.
+    let rejectPrefetchResponse: (error: unknown) => void;
+    const prefetchResponsePromise = new Promise((_resolve, reject) => {
+      rejectPrefetchResponse = reject;
+    });
+
+    // This spy makes the joined prefetch fail and the single strict cache fetch succeed afterward.
+    const axiosInstance = (beaconClient as unknown as { axiosInstance: { get: unknown } })
+      .axiosInstance;
+    const getSpy = vi
+      .spyOn(axiosInstance, 'get' as never)
+      .mockReturnValueOnce(prefetchResponsePromise as never)
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            proposer_index: '1',
+            total: '10',
+          },
+        },
+      } as never);
+
+    // This call starts a prefetch request that normal processing will join.
+    beaconClient.prefetchBlockRewards(1);
+
+    // This wait confirms the prefetch request is in flight before normal processing starts.
+    await vi.waitFor(() => expect(getSpy).toHaveBeenCalledTimes(1));
+
+    // These normal calls join the in-flight prefetch and should later share one strict fetch.
+    const firstRewardsPromise = beaconClient.getBlockRewards(1);
+    const secondRewardsPromise = beaconClient.getBlockRewards(1);
+
+    // This rejection makes the joined prefetch return no cache value.
+    rejectPrefetchResponse!(prefetchError);
+
+    // This assertion verifies both normal callers receive the strict request response.
+    await expect(Promise.all([firstRewardsPromise, secondRewardsPromise])).resolves.toEqual([
+      {
+        data: {
+          proposer_index: '1',
+          total: '10',
+        },
+      },
+      {
+        data: {
+          proposer_index: '1',
+          total: '10',
+        },
+      },
+    ]);
+
+    // This assertion verifies the strict fallback stayed coalesced through the cache.
+    expect(getSpy).toHaveBeenCalledTimes(2);
+  });
+
   // This test verifies prefetching committees warms the cache for normal processing.
   it('serves committees from a prefetched request', async () => {
     // This client exercises the committee prefetch cache path.
@@ -322,8 +401,8 @@ describe('BeaconClient reward cache', () => {
     expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
-  // This test verifies normal processing retries when it joins a failed committee prefetch.
-  it('fetches committees normally after joining an in-flight failed prefetch', async () => {
+  // This test verifies normal processing coalesces after joining a failed committee prefetch.
+  it('coalesces committee requests after joining an in-flight failed prefetch', async () => {
     // This client exercises the coalescing path for committee prefetch failures.
     const beaconClient = new BeaconClient({
       fullNodeUrl: 'http://full-node',
@@ -353,7 +432,7 @@ describe('BeaconClient reward cache', () => {
       rejectPrefetchResponse = reject;
     });
 
-    // This spy makes the in-flight prefetch fail and the retry succeed.
+    // This spy makes the in-flight prefetch fail and the single strict cache fetch succeed.
     const axiosInstance = (beaconClient as unknown as { axiosInstance: { get: unknown } })
       .axiosInstance;
     const getSpy = vi
@@ -377,22 +456,32 @@ describe('BeaconClient reward cache', () => {
     // This wait confirms the prefetch request is in flight.
     await vi.waitFor(() => expect(getSpy).toHaveBeenCalledTimes(1));
 
-    // This normal call joins the in-flight prefetch.
-    const committeesPromise = beaconClient.getCommittees(2, 64);
+    // These normal calls join the in-flight prefetch and should later share one strict fetch.
+    const firstCommitteesPromise = beaconClient.getCommittees(2, 64);
+    const secondCommitteesPromise = beaconClient.getCommittees(2, 64);
 
     // This rejection makes the joined prefetch return no cache value.
     rejectPrefetchResponse!(prefetchError);
 
-    // This assertion verifies normal processing retries and receives fresh committees.
-    await expect(committeesPromise).resolves.toEqual([
-      {
-        index: '0',
-        slot: '64',
-        validators: ['1'],
-      },
+    // This assertion verifies both normal callers receive fresh committees.
+    await expect(Promise.all([firstCommitteesPromise, secondCommitteesPromise])).resolves.toEqual([
+      [
+        {
+          index: '0',
+          slot: '64',
+          validators: ['1'],
+        },
+      ],
+      [
+        {
+          index: '0',
+          slot: '64',
+          validators: ['1'],
+        },
+      ],
     ]);
 
-    // This assertion verifies the retry made a second configured-node request.
+    // This assertion verifies the strict fallback stayed coalesced through the cache.
     expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
@@ -740,20 +829,28 @@ describe('BeaconClient reward cache', () => {
     // This wait confirms the prefetch request is in flight before normal processing starts.
     await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
 
-    // This normal processing call starts while prefetch is still unresolved.
-    const rewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
+    // These normal processing calls start while prefetch is still unresolved.
+    const firstRewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
+    const secondRewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
 
     // This rejection completes the prefetch skipped-slot path.
     rejectPrefetchResponse!(skippedSlotError);
 
-    // This assertion verifies normal processing receives the strict request response.
-    await expect(rewardsPromise).resolves.toEqual({
-      data: [{ validator_index: '1', reward: '10' }],
-      execution_optimistic: false,
-      finalized: true,
-    });
+    // This assertion verifies both normal callers receive the strict request response.
+    await expect(Promise.all([firstRewardsPromise, secondRewardsPromise])).resolves.toEqual([
+      {
+        data: [{ validator_index: '1', reward: '10' }],
+        execution_optimistic: false,
+        finalized: true,
+      },
+      {
+        data: [{ validator_index: '1', reward: '10' }],
+        execution_optimistic: false,
+        finalized: true,
+      },
+    ]);
 
-    // This assertion verifies normal processing made a configured-node request after prefetch 404.
+    // This assertion verifies the strict fallback stayed coalesced through the cache.
     expect(postSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/indexer/src/services/consensus/beacon.test.ts
+++ b/packages/indexer/src/services/consensus/beacon.test.ts
@@ -110,7 +110,7 @@ describe('BeaconClient reward cache', () => {
       fullNodeRetries: 0,
       archiveNodeUrl: 'http://archive-node',
       archiveNodeConcurrency: 1,
-      archiveNodeRetries: 0,
+      archiveNodeRetries: 1,
       baseDelay: 1,
       slotStartIndexing: 1,
       slotsPerEpoch: 32,
@@ -146,6 +146,12 @@ describe('BeaconClient reward cache', () => {
 
     // This wait confirms the prefetch request reached the configured archive endpoint.
     await vi.waitFor(() => expect(getSpy).toHaveBeenCalledTimes(1));
+
+    // This wait covers the normal retry window; prefetch failures must not retry.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // This assertion verifies the failed prefetch did not make a retry attempt.
+    expect(getSpy).toHaveBeenCalledTimes(1);
 
     // This tick lets the rejected prefetch promise settle before normal processing starts.
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -251,7 +257,7 @@ describe('BeaconClient reward cache', () => {
       fullNodeRetries: 0,
       archiveNodeUrl: 'http://archive-node',
       archiveNodeConcurrency: 1,
-      archiveNodeRetries: 0,
+      archiveNodeRetries: 1,
       baseDelay: 1,
       slotStartIndexing: 1,
       slotsPerEpoch: 32,
@@ -288,8 +294,14 @@ describe('BeaconClient reward cache', () => {
     // This call starts a fire-and-forget prefetch that should fail silently.
     beaconClient.prefetchCommittees(2, 64);
 
-    // This wait confirms the prefetch request reached the temporary endpoint.
+    // This wait confirms the prefetch request reached the configured archive endpoint.
     await vi.waitFor(() => expect(getSpy).toHaveBeenCalledTimes(1));
+
+    // This wait covers the normal retry window; prefetch failures must not retry.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // This assertion verifies the failed prefetch did not make a retry attempt.
+    expect(getSpy).toHaveBeenCalledTimes(1);
 
     // This tick lets the rejected prefetch promise settle before normal processing starts.
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -572,8 +584,8 @@ describe('BeaconClient reward cache', () => {
     expect(postSpy).not.toHaveBeenCalled();
   });
 
-  // This test verifies sync committee prefetch uses configured reliable retries.
-  it('retries sync committee prefetch errors through the configured request client', async () => {
+  // This test verifies sync committee prefetch errors do not enter the normal retry loop.
+  it('does not retry sync committee prefetch errors', async () => {
     // This client is configured far behind head so sync committee prefetching is enabled.
     const beaconClient = new BeaconClient({
       fullNodeUrl: 'http://full-node',
@@ -602,14 +614,17 @@ describe('BeaconClient reward cache', () => {
       .axiosInstance;
     const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockRejectedValue(prefetchError);
 
-    // This call starts a fire-and-forget prefetch that should use normal retry behavior.
+    // This call starts a fire-and-forget prefetch that should stop after the first failure.
     beaconClient.prefetchSyncCommitteeRewards(1, ['1']);
 
     // This wait lets the fire-and-forget prefetch make the initial request.
     await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
 
-    // This assertion verifies prefetch no longer bypasses makeReliableRequest retry behavior.
-    await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(2));
+    // This wait covers the retry delay that would run for normal archive requests.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // This assertion verifies prefetch treated the failed response as final.
+    expect(postSpy).toHaveBeenCalledTimes(1);
   });
 
   // This test verifies normal processing can join a successful in-flight sync committee prefetch.

--- a/packages/indexer/src/services/consensus/beacon.test.ts
+++ b/packages/indexer/src/services/consensus/beacon.test.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import { AxiosError } from 'axios';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { BeaconClient } from './beacon.js';
@@ -65,13 +65,10 @@ describe('BeaconClient reward cache', () => {
       slotsPerEpoch: 32,
     });
 
-    // This spy verifies normal processing does not issue its own configured-node request.
+    // This spy verifies prefetch and normal processing share the configured-node request path.
     const axiosInstance = (beaconClient as unknown as { axiosInstance: { get: unknown } })
       .axiosInstance;
-    const normalGetSpy = vi.spyOn(axiosInstance, 'get' as never);
-
-    // This spy resolves the dedicated prefetch request without depending on its temporary base URL.
-    const prefetchGetSpy = vi.spyOn(axios, 'get' as never).mockResolvedValue({
+    const getSpy = vi.spyOn(axiosInstance, 'get' as never).mockResolvedValue({
       data: {
         data: {
           proposer_index: '1',
@@ -94,11 +91,14 @@ describe('BeaconClient reward cache', () => {
       },
     });
 
-    // This assertion verifies the prefetch path made the rewards request.
-    expect(prefetchGetSpy).toHaveBeenCalledTimes(1);
+    // This assertion verifies the configured archive node served the prefetch request.
+    expect(getSpy).toHaveBeenCalledWith(
+      'http://archive-node/eth/v1/beacon/rewards/blocks/1',
+      expect.any(Object),
+    );
 
     // This assertion verifies normal processing joined the in-flight prefetch instead of fetching again.
-    expect(normalGetSpy).not.toHaveBeenCalled();
+    expect(getSpy).toHaveBeenCalledTimes(1);
   });
 
   // This test verifies failed block reward prefetches do not poison normal processing.
@@ -116,7 +116,7 @@ describe('BeaconClient reward cache', () => {
       slotsPerEpoch: 32,
     });
 
-    // This error simulates an auth failure from the temporary prefetch endpoint.
+    // This error simulates an auth failure from the configured archive endpoint during prefetch.
     const prefetchError = new AxiosError('Request failed with status code 401');
     prefetchError.response = {
       status: 401,
@@ -126,26 +126,26 @@ describe('BeaconClient reward cache', () => {
       data: { message: 'Unauthorized' },
     };
 
-    // This spy makes the dedicated prefetch endpoint fail.
-    const prefetchGetSpy = vi.spyOn(axios, 'get' as never).mockRejectedValue(prefetchError);
-
-    // This spy makes the configured normal endpoint succeed after prefetch failure.
+    // This spy makes prefetch fail and the strict normal request succeed afterward.
     const axiosInstance = (beaconClient as unknown as { axiosInstance: { get: unknown } })
       .axiosInstance;
-    const normalGetSpy = vi.spyOn(axiosInstance, 'get' as never).mockResolvedValue({
-      data: {
+    const getSpy = vi
+      .spyOn(axiosInstance, 'get' as never)
+      .mockRejectedValueOnce(prefetchError)
+      .mockResolvedValueOnce({
         data: {
-          proposer_index: '1',
-          total: '10',
+          data: {
+            proposer_index: '1',
+            total: '10',
+          },
         },
-      },
-    } as never);
+      } as never);
 
     // This call starts a fire-and-forget prefetch that should fail silently.
     beaconClient.prefetchBlockRewards(1);
 
-    // This wait confirms the prefetch request reached the temporary endpoint.
-    await vi.waitFor(() => expect(prefetchGetSpy).toHaveBeenCalledTimes(1));
+    // This wait confirms the prefetch request reached the configured archive endpoint.
+    await vi.waitFor(() => expect(getSpy).toHaveBeenCalledTimes(1));
 
     // This tick lets the rejected prefetch promise settle before normal processing starts.
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -162,7 +162,7 @@ describe('BeaconClient reward cache', () => {
     });
 
     // This assertion verifies normal processing made a fresh configured-node request.
-    expect(normalGetSpy).toHaveBeenCalledTimes(1);
+    expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
   // This test verifies prefetching committees warms the cache for normal processing.
@@ -572,8 +572,8 @@ describe('BeaconClient reward cache', () => {
     expect(postSpy).not.toHaveBeenCalled();
   });
 
-  // This test verifies sync committee prefetch does not retry failed responses.
-  it('does not retry sync committee prefetch errors', async () => {
+  // This test verifies sync committee prefetch uses configured reliable retries.
+  it('retries sync committee prefetch errors through the configured request client', async () => {
     // This client is configured far behind head so sync committee prefetching is enabled.
     const beaconClient = new BeaconClient({
       fullNodeUrl: 'http://full-node',
@@ -597,20 +597,19 @@ describe('BeaconClient reward cache', () => {
       data: { message: 'Internal Server Error' },
     };
 
-    // This spy makes every dedicated prefetch attempt receive the failed response.
-    const postSpy = vi.spyOn(axios, 'post' as never).mockRejectedValue(prefetchError);
+    // This spy makes every configured archive attempt receive the failed response.
+    const axiosInstance = (beaconClient as unknown as { axiosInstance: { post: unknown } })
+      .axiosInstance;
+    const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockRejectedValue(prefetchError);
 
-    // This call starts a prefetch that should stop on error without retrying.
+    // This call starts a fire-and-forget prefetch that should use normal retry behavior.
     beaconClient.prefetchSyncCommitteeRewards(1, ['1']);
 
     // This wait lets the fire-and-forget prefetch make the initial request.
     await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
 
-    // This wait covers the retry delay that would run for normal archive requests.
-    await new Promise((resolve) => setTimeout(resolve, 1200));
-
-    // This assertion verifies prefetch treated the failed response as final.
-    expect(postSpy).toHaveBeenCalledTimes(1);
+    // This assertion verifies prefetch no longer bypasses makeReliableRequest retry behavior.
+    await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(2));
   });
 
   // This test verifies normal processing can join a successful in-flight sync committee prefetch.
@@ -634,19 +633,16 @@ describe('BeaconClient reward cache', () => {
       resolveResponse = resolve;
     });
 
-    // This spy verifies normal processing does not issue its own configured-node request.
+    // This spy returns the same delayed configured-node response to expose duplicate requests.
     const axiosInstance = (beaconClient as unknown as { axiosInstance: { post: unknown } })
       .axiosInstance;
-    const normalPostSpy = vi.spyOn(axiosInstance, 'post' as never);
-
-    // This spy returns the same delayed prefetch response to expose duplicate requests.
-    const prefetchPostSpy = vi.spyOn(axios, 'post' as never).mockReturnValue(responsePromise);
+    const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockReturnValue(responsePromise);
 
     // This call starts the prefetch request for the slot and validators.
     beaconClient.prefetchSyncCommitteeRewards(1, ['1']);
 
     // This wait confirms the prefetch request is in flight before normal processing starts.
-    await vi.waitFor(() => expect(prefetchPostSpy).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
 
     // This call starts normal processing while prefetch is still unresolved.
     const rewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
@@ -668,10 +664,14 @@ describe('BeaconClient reward cache', () => {
     });
 
     // This assertion verifies prefetch and normal processing shared one HTTP call.
-    expect(prefetchPostSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy).toHaveBeenCalledWith(
+      'http://archive-node/eth/v1/beacon/rewards/sync_committee/1',
+      ['1'],
+      expect.any(Object),
+    );
 
     // This assertion verifies normal processing joined the in-flight prefetch instead of fetching again.
-    expect(normalPostSpy).not.toHaveBeenCalled();
+    expect(postSpy).toHaveBeenCalledTimes(1);
   });
 
   // This test verifies normal processing stays strict after an in-flight prefetch 404.
@@ -705,27 +705,25 @@ describe('BeaconClient reward cache', () => {
       rejectPrefetchResponse = reject;
     });
 
-    // This spy makes the dedicated prefetch request receive 404.
-    const prefetchPostSpy = vi
-      .spyOn(axios, 'post' as never)
-      .mockReturnValueOnce(prefetchResponsePromise as never);
-
-    // This spy makes normal processing receive rewards from the configured endpoint later.
+    // This spy makes prefetch receive 404 and normal processing receive rewards later.
     const axiosInstance = (beaconClient as unknown as { axiosInstance: { post: unknown } })
       .axiosInstance;
-    const normalPostSpy = vi.spyOn(axiosInstance, 'post' as never).mockResolvedValue({
-      data: {
-        data: [{ validator_index: '1', reward: '10' }],
-        execution_optimistic: false,
-        finalized: true,
-      },
-    } as never);
+    const postSpy = vi
+      .spyOn(axiosInstance, 'post' as never)
+      .mockReturnValueOnce(prefetchResponsePromise as never)
+      .mockResolvedValueOnce({
+        data: {
+          data: [{ validator_index: '1', reward: '10' }],
+          execution_optimistic: false,
+          finalized: true,
+        },
+      } as never);
 
     // This call starts a prefetch that should stop on 404 without filling the cache.
     beaconClient.prefetchSyncCommitteeRewards(1, ['1']);
 
     // This wait confirms the prefetch request is in flight before normal processing starts.
-    await vi.waitFor(() => expect(prefetchPostSpy).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
 
     // This normal processing call starts while prefetch is still unresolved.
     const rewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
@@ -741,6 +739,6 @@ describe('BeaconClient reward cache', () => {
     });
 
     // This assertion verifies normal processing made a configured-node request after prefetch 404.
-    expect(normalPostSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/indexer/src/services/consensus/beacon.test.ts
+++ b/packages/indexer/src/services/consensus/beacon.test.ts
@@ -171,85 +171,6 @@ describe('BeaconClient reward cache', () => {
     expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
-  // This test verifies normal block reward processing coalesces after joining a failed prefetch.
-  it('coalesces block reward requests after joining an in-flight failed prefetch', async () => {
-    // This client is configured far behind head so block reward prefetching is enabled.
-    const beaconClient = new BeaconClient({
-      fullNodeUrl: 'http://full-node',
-      fullNodeConcurrency: 1,
-      fullNodeRetries: 0,
-      archiveNodeUrl: 'http://archive-node',
-      archiveNodeConcurrency: 1,
-      archiveNodeRetries: 0,
-      baseDelay: 1,
-      slotStartIndexing: 1,
-      slotsPerEpoch: 32,
-    });
-
-    // This error simulates an archive node failure during the background prefetch.
-    const prefetchError = new AxiosError('Request failed with status code 500');
-    prefetchError.response = {
-      status: 500,
-      statusText: 'Internal Server Error',
-      headers: {},
-      config: {} as never,
-      data: { message: 'Internal Server Error' },
-    };
-
-    // This deferred rejection keeps the prefetch request in flight while normal callers join it.
-    let rejectPrefetchResponse: (error: unknown) => void;
-    const prefetchResponsePromise = new Promise((_resolve, reject) => {
-      rejectPrefetchResponse = reject;
-    });
-
-    // This spy makes the joined prefetch fail and the single strict cache fetch succeed afterward.
-    const axiosInstance = (beaconClient as unknown as { axiosInstance: { get: unknown } })
-      .axiosInstance;
-    const getSpy = vi
-      .spyOn(axiosInstance, 'get' as never)
-      .mockReturnValueOnce(prefetchResponsePromise as never)
-      .mockResolvedValueOnce({
-        data: {
-          data: {
-            proposer_index: '1',
-            total: '10',
-          },
-        },
-      } as never);
-
-    // This call starts a prefetch request that normal processing will join.
-    beaconClient.prefetchBlockRewards(1);
-
-    // This wait confirms the prefetch request is in flight before normal processing starts.
-    await vi.waitFor(() => expect(getSpy).toHaveBeenCalledTimes(1));
-
-    // These normal calls join the in-flight prefetch and should later share one strict fetch.
-    const firstRewardsPromise = beaconClient.getBlockRewards(1);
-    const secondRewardsPromise = beaconClient.getBlockRewards(1);
-
-    // This rejection makes the joined prefetch return no cache value.
-    rejectPrefetchResponse!(prefetchError);
-
-    // This assertion verifies both normal callers receive the strict request response.
-    await expect(Promise.all([firstRewardsPromise, secondRewardsPromise])).resolves.toEqual([
-      {
-        data: {
-          proposer_index: '1',
-          total: '10',
-        },
-      },
-      {
-        data: {
-          proposer_index: '1',
-          total: '10',
-        },
-      },
-    ]);
-
-    // This assertion verifies the strict fallback stayed coalesced through the cache.
-    expect(getSpy).toHaveBeenCalledTimes(2);
-  });
-
   // This test verifies prefetching committees warms the cache for normal processing.
   it('serves committees from a prefetched request', async () => {
     // This client exercises the committee prefetch cache path.
@@ -401,8 +322,8 @@ describe('BeaconClient reward cache', () => {
     expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
-  // This test verifies normal processing coalesces after joining a failed committee prefetch.
-  it('coalesces committee requests after joining an in-flight failed prefetch', async () => {
+  // This test verifies normal processing retries when it joins a failed committee prefetch.
+  it('fetches committees normally after joining an in-flight failed prefetch', async () => {
     // This client exercises the coalescing path for committee prefetch failures.
     const beaconClient = new BeaconClient({
       fullNodeUrl: 'http://full-node',
@@ -432,7 +353,7 @@ describe('BeaconClient reward cache', () => {
       rejectPrefetchResponse = reject;
     });
 
-    // This spy makes the in-flight prefetch fail and the single strict cache fetch succeed.
+    // This spy makes the in-flight prefetch fail and the retry succeed.
     const axiosInstance = (beaconClient as unknown as { axiosInstance: { get: unknown } })
       .axiosInstance;
     const getSpy = vi
@@ -456,32 +377,22 @@ describe('BeaconClient reward cache', () => {
     // This wait confirms the prefetch request is in flight.
     await vi.waitFor(() => expect(getSpy).toHaveBeenCalledTimes(1));
 
-    // These normal calls join the in-flight prefetch and should later share one strict fetch.
-    const firstCommitteesPromise = beaconClient.getCommittees(2, 64);
-    const secondCommitteesPromise = beaconClient.getCommittees(2, 64);
+    // This normal call joins the in-flight prefetch.
+    const committeesPromise = beaconClient.getCommittees(2, 64);
 
     // This rejection makes the joined prefetch return no cache value.
     rejectPrefetchResponse!(prefetchError);
 
-    // This assertion verifies both normal callers receive fresh committees.
-    await expect(Promise.all([firstCommitteesPromise, secondCommitteesPromise])).resolves.toEqual([
-      [
-        {
-          index: '0',
-          slot: '64',
-          validators: ['1'],
-        },
-      ],
-      [
-        {
-          index: '0',
-          slot: '64',
-          validators: ['1'],
-        },
-      ],
+    // This assertion verifies normal processing retries and receives fresh committees.
+    await expect(committeesPromise).resolves.toEqual([
+      {
+        index: '0',
+        slot: '64',
+        validators: ['1'],
+      },
     ]);
 
-    // This assertion verifies the strict fallback stayed coalesced through the cache.
+    // This assertion verifies the retry made a second configured-node request.
     expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
@@ -829,28 +740,20 @@ describe('BeaconClient reward cache', () => {
     // This wait confirms the prefetch request is in flight before normal processing starts.
     await vi.waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
 
-    // These normal processing calls start while prefetch is still unresolved.
-    const firstRewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
-    const secondRewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
+    // This normal processing call starts while prefetch is still unresolved.
+    const rewardsPromise = beaconClient.getSyncCommitteeRewards(1, ['1']);
 
     // This rejection completes the prefetch skipped-slot path.
     rejectPrefetchResponse!(skippedSlotError);
 
-    // This assertion verifies both normal callers receive the strict request response.
-    await expect(Promise.all([firstRewardsPromise, secondRewardsPromise])).resolves.toEqual([
-      {
-        data: [{ validator_index: '1', reward: '10' }],
-        execution_optimistic: false,
-        finalized: true,
-      },
-      {
-        data: [{ validator_index: '1', reward: '10' }],
-        execution_optimistic: false,
-        finalized: true,
-      },
-    ]);
+    // This assertion verifies normal processing receives the strict request response.
+    await expect(rewardsPromise).resolves.toEqual({
+      data: [{ validator_index: '1', reward: '10' }],
+      execution_optimistic: false,
+      finalized: true,
+    });
 
-    // This assertion verifies the strict fallback stayed coalesced through the cache.
+    // This assertion verifies normal processing made a configured-node request after prefetch 404.
     expect(postSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -450,7 +450,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch block rewards for a slot without using the prefetch cache.
    */
-  private fetchBlockRewards = async (slot: number): Promise<BlockRewards | 'SLOT MISSED'> => {
+  private async fetchBlockRewards(slot: number): Promise<BlockRewards | 'SLOT MISSED'> {
     return this.makeReliableRequest<BlockRewards | 'SLOT MISSED'>(
       async (url) => {
         const res = await this.axiosInstance.get<BlockRewards>(
@@ -464,12 +464,12 @@ export class BeaconClient extends ReliableRequestClient {
       this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
       (error) => this.handleSlotError(error),
     );
-  };
+  }
 
   /**
    * Fetch block rewards once for prefetch without converting 404 responses into cache entries.
    */
-  private fetchBlockRewardsForPrefetch = async (slot: number): Promise<BlockRewards> => {
+  private async fetchBlockRewardsForPrefetch(slot: number): Promise<BlockRewards> {
     return this.makePrefetchRequest<BlockRewards>(
       async (url) => {
         const res = await this.axiosInstance.get<BlockRewards>(
@@ -482,15 +482,15 @@ export class BeaconClient extends ReliableRequestClient {
       },
       this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
     );
-  };
+  }
 
   /**
    * Fetch sync committee rewards for one slot without using the prefetch cache.
    */
-  private fetchSyncCommitteeRewards = async (
+  private async fetchSyncCommitteeRewards(
     slot: number,
     validatorIndexes: string[],
-  ): Promise<SyncCommitteeRewards> => {
+  ): Promise<SyncCommitteeRewards> {
     return this.makeReliableRequest<SyncCommitteeRewards>(
       async (url) => {
         const res = await this.axiosInstance.post<SyncCommitteeRewards>(
@@ -504,15 +504,15 @@ export class BeaconClient extends ReliableRequestClient {
       },
       this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
     );
-  };
+  }
 
   /**
    * Fetch sync committee rewards once for prefetch, keeping all failures out of the cache.
    */
-  private fetchSyncCommitteeRewardsForPrefetch = async (
+  private async fetchSyncCommitteeRewardsForPrefetch(
     slot: number,
     validatorIndexes: string[],
-  ): Promise<SyncCommitteeRewards> => {
+  ): Promise<SyncCommitteeRewards> {
     return this.makePrefetchRequest<SyncCommitteeRewards>(
       async (url) => {
         const res = await this.axiosInstance.post<SyncCommitteeRewards>(
@@ -526,7 +526,7 @@ export class BeaconClient extends ReliableRequestClient {
       },
       this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
     );
-  };
+  }
 
   /**
    * Prefetch block rewards for a delayed slot without blocking slot processing.

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -253,7 +253,13 @@ export class BeaconClient extends ReliableRequestClient {
     const key = this.getCommitteesCacheKey(epoch, stateId);
     let committees = await this.committeesCache.fetch(key);
     if (committees === undefined) {
-      committees = await this.fetchCommittees(epoch, stateId);
+      // Normal processing can receive undefined when it joins a failed prefetch; re-enter
+      // the cache so strict callers share one request and the successful response is stored.
+      committees = await this.committeesCache.fetch(key);
+    }
+
+    if (committees === undefined) {
+      throw new Error(`Failed to fetch committees for epoch ${epoch}`);
     }
 
     this.committeesCache.delete(key);
@@ -559,7 +565,13 @@ export class BeaconClient extends ReliableRequestClient {
   getBlockRewards = async (slot: number): Promise<BlockRewards | 'SLOT MISSED'> => {
     let rewards = await this.blockRewardsCache.fetch(slot);
     if (rewards === undefined) {
-      rewards = await this.fetchBlockRewards(slot);
+      // Normal processing can receive undefined when it joins a failed prefetch; re-enter
+      // the cache so strict callers share one request and the successful response is stored.
+      rewards = await this.blockRewardsCache.fetch(slot);
+    }
+
+    if (rewards === undefined) {
+      throw new Error(`Failed to fetch block rewards for slot ${slot}`);
     }
 
     return rewards;
@@ -579,7 +591,13 @@ export class BeaconClient extends ReliableRequestClient {
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
     let rewards = await this.syncCommitteeRewardsCache.fetch(key);
     if (rewards === undefined) {
-      rewards = await this.fetchSyncCommitteeRewards(slot, validatorIndexes);
+      // Normal processing can receive undefined when it joins a failed prefetch; re-enter
+      // the cache so strict callers share one request and the successful response is stored.
+      rewards = await this.syncCommitteeRewardsCache.fetch(key);
+    }
+
+    if (rewards === undefined) {
+      throw new Error(`Failed to fetch sync committee rewards for slot ${slot}`);
     }
 
     return rewards;

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -253,13 +253,7 @@ export class BeaconClient extends ReliableRequestClient {
     const key = this.getCommitteesCacheKey(epoch, stateId);
     let committees = await this.committeesCache.fetch(key);
     if (committees === undefined) {
-      // Normal processing can receive undefined when it joins a failed prefetch; re-enter
-      // the cache so strict callers share one request and the successful response is stored.
-      committees = await this.committeesCache.fetch(key);
-    }
-
-    if (committees === undefined) {
-      throw new Error(`Failed to fetch committees for epoch ${epoch}`);
+      committees = await this.fetchCommittees(epoch, stateId);
     }
 
     this.committeesCache.delete(key);
@@ -565,13 +559,7 @@ export class BeaconClient extends ReliableRequestClient {
   getBlockRewards = async (slot: number): Promise<BlockRewards | 'SLOT MISSED'> => {
     let rewards = await this.blockRewardsCache.fetch(slot);
     if (rewards === undefined) {
-      // Normal processing can receive undefined when it joins a failed prefetch; re-enter
-      // the cache so strict callers share one request and the successful response is stored.
-      rewards = await this.blockRewardsCache.fetch(slot);
-    }
-
-    if (rewards === undefined) {
-      throw new Error(`Failed to fetch block rewards for slot ${slot}`);
+      rewards = await this.fetchBlockRewards(slot);
     }
 
     return rewards;
@@ -591,13 +579,7 @@ export class BeaconClient extends ReliableRequestClient {
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
     let rewards = await this.syncCommitteeRewardsCache.fetch(key);
     if (rewards === undefined) {
-      // Normal processing can receive undefined when it joins a failed prefetch; re-enter
-      // the cache so strict callers share one request and the successful response is stored.
-      rewards = await this.syncCommitteeRewardsCache.fetch(key);
-    }
-
-    if (rewards === undefined) {
-      throw new Error(`Failed to fetch sync committee rewards for slot ${slot}`);
+      rewards = await this.fetchSyncCommitteeRewards(slot, validatorIndexes);
     }
 
     return rewards;

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -19,9 +19,6 @@ import { getEpochSlots } from '@/src/services/consensus/utils/misc.js';
 import { ReliableRequestClient } from '@/src/services/consensus/utils/reliableRequestClient.js';
 import { getSlotNumberFromTimestamp } from '@/src/services/consensus/utils/time.deprecated.js';
 
-const PREFETCH_REWARDS_API_URL =
-  'https://ethereum-mainnet.core.chainstack.com/beacon/1663f40bb6b6a2af1d252c63a18e6d6f';
-
 // Extend Axios config to include metadata for nodeType
 interface ExtendedAxiosRequestConfig extends InternalAxiosRequestConfig {
   metadata?: {
@@ -60,81 +57,25 @@ export class BeaconClient extends ReliableRequestClient {
    * Caches block rewards fetched in advance for delayed slots, with a fallback to handle missed slots.
    * 'SLOT MISSED' is used to indicate that the slot was missed, allowing the caller to handle it accordingly.
    */
-  private readonly blockRewardsCache = new LRUCache<
-    number,
-    BlockRewards | 'SLOT MISSED',
-    { prefetch?: boolean } | undefined
-  >({
+  private readonly blockRewardsCache = new LRUCache<number, BlockRewards | 'SLOT MISSED'>({
     max: 8,
     ttl: ms('10m'),
     ttlAutopurge: true,
-    fetchMethod: async (slot, _staleValue, { context }) => {
-      if (context?.prefetch) {
-        try {
-          const res = await axios.get<BlockRewards>(
-            `${PREFETCH_REWARDS_API_URL}/eth/v1/beacon/rewards/blocks/${slot}`,
-            {
-              timeout: ms('1.5m'),
-            },
-          );
-          return res.data;
-        } catch {
-          return undefined;
-        }
-      }
-
-      return this.fetchBlockRewardsUncached(slot);
-    },
+    // Use the normal reliable request path so prefetch uses the configured beacon nodes.
+    fetchMethod: async (slot) => this.fetchBlockRewardsUncached(slot).catch(() => undefined),
   });
 
   /**
    * Caches sync committee rewards fetched in advance.
    */
-  private readonly syncCommitteeRewardsCache = new LRUCache<
-    string,
-    SyncCommitteeRewards,
-    { ignoreErrors?: boolean; prefetch?: boolean } | undefined
-  >({
+  private readonly syncCommitteeRewardsCache = new LRUCache<string, SyncCommitteeRewards>({
     max: 8,
     ttl: ms('10m'),
     ttlAutopurge: true,
-    fetchMethod: async (key, _staleValue, { context }) => {
+    // Use the normal reliable request path so sync reward prefetch cannot drift from chain config.
+    fetchMethod: async (key) => {
       const [slot, validatorIndexes] = this.parseSyncCommitteeRewardsCacheKey(key);
-      // null marks ignored prefetch errors as handled so makeReliableRequest does not retry.
-      const handleError = context?.ignoreErrors ? () => null : undefined;
-
-      if (context?.prefetch) {
-        try {
-          const res = await axios.post<SyncCommitteeRewards>(
-            `${PREFETCH_REWARDS_API_URL}/eth/v1/beacon/rewards/sync_committee/${slot}`,
-            validatorIndexes,
-            {
-              timeout: ms('1.5m'),
-            },
-          );
-          return res.data;
-        } catch {
-          return undefined;
-        }
-      }
-
-      const rewards = await this.makeReliableRequest<SyncCommitteeRewards | null>(
-        async (url) => {
-          const res = await this.axiosInstance.post<SyncCommitteeRewards>(
-            `${url}/eth/v1/beacon/rewards/sync_committee/${slot}`,
-            validatorIndexes,
-            {
-              timeout: ms('1.5m'),
-            },
-          );
-          return res.data;
-        },
-        this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
-        handleError,
-      );
-
-      // undefined prevents lru-cache from storing failed prefetch results.
-      return rewards ?? undefined;
+      return this.fetchSyncCommitteeRewardsUncached(slot, validatorIndexes).catch(() => undefined);
     },
   });
 
@@ -468,6 +409,28 @@ export class BeaconClient extends ReliableRequestClient {
   };
 
   /**
+   * Fetch sync committee rewards for one slot without using the prefetch cache.
+   */
+  private fetchSyncCommitteeRewardsUncached = async (
+    slot: number,
+    validatorIndexes: string[],
+  ): Promise<SyncCommitteeRewards> => {
+    return this.makeReliableRequest<SyncCommitteeRewards>(
+      async (url) => {
+        const res = await this.axiosInstance.post<SyncCommitteeRewards>(
+          `${url}/eth/v1/beacon/rewards/sync_committee/${slot}`,
+          validatorIndexes,
+          {
+            timeout: ms('1.5m'),
+          },
+        );
+        return res.data;
+      },
+      this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
+    );
+  };
+
+  /**
    * Prefetch block rewards for a delayed slot without blocking slot processing.
    */
   prefetchBlockRewards(slot: number): void {
@@ -475,24 +438,8 @@ export class BeaconClient extends ReliableRequestClient {
       return;
     }
 
-    void this.blockRewardsCache.fetch(slot, { context: { prefetch: true } }).catch(() => undefined);
+    void this.blockRewardsCache.fetch(slot).catch(() => undefined);
   }
-
-  /**
-   * Get block rewards for a specific slot using the prefetch cache.
-   */
-  getBlockRewards = async (slot: number): Promise<BlockRewards | 'SLOT MISSED'> => {
-    let rewards = await this.blockRewardsCache.fetch(slot);
-    if (rewards === undefined) {
-      rewards = await this.blockRewardsCache.fetch(slot);
-    }
-
-    if (rewards === undefined) {
-      throw new Error(`Failed to fetch block rewards for slot ${slot} from cache.`);
-    }
-
-    return rewards;
-  };
 
   /**
    * Prefetch sync committee rewards for a delayed slot without blocking slot processing.
@@ -503,10 +450,20 @@ export class BeaconClient extends ReliableRequestClient {
     }
 
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
-    void this.syncCommitteeRewardsCache
-      .fetch(key, { context: { ignoreErrors: true, prefetch: true } })
-      .catch(() => undefined);
+    void this.syncCommitteeRewardsCache.fetch(key).catch(() => undefined);
   }
+
+  /**
+   * Get block rewards for a specific slot using the prefetch cache.
+   */
+  getBlockRewards = async (slot: number): Promise<BlockRewards | 'SLOT MISSED'> => {
+    let rewards = await this.blockRewardsCache.fetch(slot);
+    if (rewards === undefined) {
+      rewards = await this.fetchBlockRewardsUncached(slot);
+    }
+
+    return rewards;
+  };
 
   /**
    * Get sync committee rewards for specific validators in a slot using the prefetch cache.
@@ -522,11 +479,7 @@ export class BeaconClient extends ReliableRequestClient {
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
     let rewards = await this.syncCommitteeRewardsCache.fetch(key);
     if (rewards === undefined) {
-      rewards = await this.syncCommitteeRewardsCache.fetch(key);
-    }
-
-    if (rewards === undefined) {
-      throw new Error(`Failed to fetch sync committee rewards for slot ${slot} from cache.`);
+      rewards = await this.fetchSyncCommitteeRewardsUncached(slot, validatorIndexes);
     }
 
     return rewards;

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -69,10 +69,10 @@ export class BeaconClient extends ReliableRequestClient {
     ttlAutopurge: true,
     fetchMethod: async (slot, _staleValue, { context }) => {
       if (context?.prefetch) {
-        return this.fetchBlockRewardsPrefetch(slot).catch(() => undefined);
+        return this.preFetchBlockRewards(slot).catch(() => undefined);
       }
 
-      return this.fetchBlockRewardsUncached(slot);
+      return this.fetchBlockRewards(slot);
     },
   });
 
@@ -90,12 +90,10 @@ export class BeaconClient extends ReliableRequestClient {
     fetchMethod: async (key, _staleValue, { context }) => {
       const [slot, validatorIndexes] = this.parseSyncCommitteeRewardsCacheKey(key);
       if (context?.prefetch) {
-        return this.fetchSyncCommitteeRewardsPrefetch(slot, validatorIndexes).catch(
-          () => undefined,
-        );
+        return this.preFetchSyncCommitteeRewards(slot, validatorIndexes).catch(() => undefined);
       }
 
-      return this.fetchSyncCommitteeRewardsUncached(slot, validatorIndexes);
+      return this.fetchSyncCommitteeRewards(slot, validatorIndexes);
     },
   });
 
@@ -117,10 +115,10 @@ export class BeaconClient extends ReliableRequestClient {
       };
 
       if (context?.prefetch) {
-        return this.fetchCommitteesPrefetch(epoch, stateId).catch(() => undefined);
+        return this.preFetchCommittees(epoch, stateId).catch(() => undefined);
       }
 
-      return this.fetchCommitteesUncached(epoch, stateId);
+      return this.fetchCommittees(epoch, stateId);
     },
   });
 
@@ -253,7 +251,7 @@ export class BeaconClient extends ReliableRequestClient {
     const key = this.getCommitteesCacheKey(epoch, stateId);
     let committees = await this.committeesCache.fetch(key);
     if (committees === undefined) {
-      committees = await this.fetchCommitteesUncached(epoch, stateId);
+      committees = await this.fetchCommittees(epoch, stateId);
     }
 
     this.committeesCache.delete(key);
@@ -264,7 +262,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch committees for a specific epoch without using the prefetch cache.
    */
-  private fetchCommitteesUncached(
+  private fetchCommittees(
     epoch: number,
     stateId: string | number = 'head',
   ): Promise<GetCommittees['data']> {
@@ -285,7 +283,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch committees once for prefetch, leaving normal processing to handle failures and retries.
    */
-  private fetchCommitteesPrefetch(
+  private preFetchCommittees(
     epoch: number,
     stateId: string | number = 'head',
   ): Promise<GetCommittees['data']> {
@@ -450,9 +448,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch block rewards for a slot without using the prefetch cache.
    */
-  private fetchBlockRewardsUncached = async (
-    slot: number,
-  ): Promise<BlockRewards | 'SLOT MISSED'> => {
+  private fetchBlockRewards = async (slot: number): Promise<BlockRewards | 'SLOT MISSED'> => {
     return this.makeReliableRequest<BlockRewards | 'SLOT MISSED'>(
       async (url) => {
         const res = await this.axiosInstance.get<BlockRewards>(
@@ -471,7 +467,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch block rewards once for prefetch without converting 404 responses into cache entries.
    */
-  private fetchBlockRewardsPrefetch = async (slot: number): Promise<BlockRewards> => {
+  private preFetchBlockRewards = async (slot: number): Promise<BlockRewards> => {
     return this.makePrefetchRequest<BlockRewards>(
       async (url) => {
         const res = await this.axiosInstance.get<BlockRewards>(
@@ -489,7 +485,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch sync committee rewards for one slot without using the prefetch cache.
    */
-  private fetchSyncCommitteeRewardsUncached = async (
+  private fetchSyncCommitteeRewards = async (
     slot: number,
     validatorIndexes: string[],
   ): Promise<SyncCommitteeRewards> => {
@@ -511,7 +507,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch sync committee rewards once for prefetch, keeping all failures out of the cache.
    */
-  private fetchSyncCommitteeRewardsPrefetch = async (
+  private preFetchSyncCommitteeRewards = async (
     slot: number,
     validatorIndexes: string[],
   ): Promise<SyncCommitteeRewards> => {
@@ -561,7 +557,7 @@ export class BeaconClient extends ReliableRequestClient {
   getBlockRewards = async (slot: number): Promise<BlockRewards | 'SLOT MISSED'> => {
     let rewards = await this.blockRewardsCache.fetch(slot);
     if (rewards === undefined) {
-      rewards = await this.fetchBlockRewardsUncached(slot);
+      rewards = await this.fetchBlockRewards(slot);
     }
 
     return rewards;
@@ -581,7 +577,7 @@ export class BeaconClient extends ReliableRequestClient {
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
     let rewards = await this.syncCommitteeRewardsCache.fetch(key);
     if (rewards === undefined) {
-      rewards = await this.fetchSyncCommitteeRewardsUncached(slot, validatorIndexes);
+      rewards = await this.fetchSyncCommitteeRewards(slot, validatorIndexes);
     }
 
     return rewards;

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -69,7 +69,7 @@ export class BeaconClient extends ReliableRequestClient {
     ttlAutopurge: true,
     fetchMethod: async (slot, _staleValue, { context }) => {
       if (context?.prefetch) {
-        return this.preFetchBlockRewards(slot).catch(() => undefined);
+        return this.fetchBlockRewardsForPrefetch(slot).catch(() => undefined);
       }
 
       return this.fetchBlockRewards(slot);
@@ -90,7 +90,9 @@ export class BeaconClient extends ReliableRequestClient {
     fetchMethod: async (key, _staleValue, { context }) => {
       const [slot, validatorIndexes] = this.parseSyncCommitteeRewardsCacheKey(key);
       if (context?.prefetch) {
-        return this.preFetchSyncCommitteeRewards(slot, validatorIndexes).catch(() => undefined);
+        return this.fetchSyncCommitteeRewardsForPrefetch(slot, validatorIndexes).catch(
+          () => undefined,
+        );
       }
 
       return this.fetchSyncCommitteeRewards(slot, validatorIndexes);
@@ -115,7 +117,7 @@ export class BeaconClient extends ReliableRequestClient {
       };
 
       if (context?.prefetch) {
-        return this.preFetchCommittees(epoch, stateId).catch(() => undefined);
+        return this.fetchCommitteesForPrefetch(epoch, stateId).catch(() => undefined);
       }
 
       return this.fetchCommittees(epoch, stateId);
@@ -283,7 +285,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch committees once for prefetch, leaving normal processing to handle failures and retries.
    */
-  private preFetchCommittees(
+  private fetchCommitteesForPrefetch(
     epoch: number,
     stateId: string | number = 'head',
   ): Promise<GetCommittees['data']> {
@@ -467,7 +469,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch block rewards once for prefetch without converting 404 responses into cache entries.
    */
-  private preFetchBlockRewards = async (slot: number): Promise<BlockRewards> => {
+  private fetchBlockRewardsForPrefetch = async (slot: number): Promise<BlockRewards> => {
     return this.makePrefetchRequest<BlockRewards>(
       async (url) => {
         const res = await this.axiosInstance.get<BlockRewards>(
@@ -507,7 +509,7 @@ export class BeaconClient extends ReliableRequestClient {
   /**
    * Fetch sync committee rewards once for prefetch, keeping all failures out of the cache.
    */
-  private preFetchSyncCommitteeRewards = async (
+  private fetchSyncCommitteeRewardsForPrefetch = async (
     slot: number,
     validatorIndexes: string[],
   ): Promise<SyncCommitteeRewards> => {

--- a/packages/indexer/src/services/consensus/beacon.ts
+++ b/packages/indexer/src/services/consensus/beacon.ts
@@ -27,6 +27,8 @@ interface ExtendedAxiosRequestConfig extends InternalAxiosRequestConfig {
   };
 }
 
+type PrefetchCacheContext = { prefetch?: boolean } | undefined;
+
 /**
  * Configuration interface for BeaconClient
  */
@@ -57,42 +59,68 @@ export class BeaconClient extends ReliableRequestClient {
    * Caches block rewards fetched in advance for delayed slots, with a fallback to handle missed slots.
    * 'SLOT MISSED' is used to indicate that the slot was missed, allowing the caller to handle it accordingly.
    */
-  private readonly blockRewardsCache = new LRUCache<number, BlockRewards | 'SLOT MISSED'>({
+  private readonly blockRewardsCache = new LRUCache<
+    number,
+    BlockRewards | 'SLOT MISSED',
+    PrefetchCacheContext
+  >({
     max: 8,
     ttl: ms('10m'),
     ttlAutopurge: true,
-    // Use the normal reliable request path so prefetch uses the configured beacon nodes.
-    fetchMethod: async (slot) => this.fetchBlockRewardsUncached(slot).catch(() => undefined),
+    fetchMethod: async (slot, _staleValue, { context }) => {
+      if (context?.prefetch) {
+        return this.fetchBlockRewardsPrefetch(slot).catch(() => undefined);
+      }
+
+      return this.fetchBlockRewardsUncached(slot);
+    },
   });
 
   /**
    * Caches sync committee rewards fetched in advance.
    */
-  private readonly syncCommitteeRewardsCache = new LRUCache<string, SyncCommitteeRewards>({
+  private readonly syncCommitteeRewardsCache = new LRUCache<
+    string,
+    SyncCommitteeRewards,
+    PrefetchCacheContext
+  >({
     max: 8,
     ttl: ms('10m'),
     ttlAutopurge: true,
-    // Use the normal reliable request path so sync reward prefetch cannot drift from chain config.
-    fetchMethod: async (key) => {
+    fetchMethod: async (key, _staleValue, { context }) => {
       const [slot, validatorIndexes] = this.parseSyncCommitteeRewardsCacheKey(key);
-      return this.fetchSyncCommitteeRewardsUncached(slot, validatorIndexes).catch(() => undefined);
+      if (context?.prefetch) {
+        return this.fetchSyncCommitteeRewardsPrefetch(slot, validatorIndexes).catch(
+          () => undefined,
+        );
+      }
+
+      return this.fetchSyncCommitteeRewardsUncached(slot, validatorIndexes);
     },
   });
 
   /**
    * Caches committees fetched in advance for the next epoch.
    */
-  private readonly committeesCache = new LRUCache<string, GetCommittees['data']>({
+  private readonly committeesCache = new LRUCache<
+    string,
+    GetCommittees['data'],
+    PrefetchCacheContext
+  >({
     max: 3,
     ttl: ms('10m'),
     ttlAutopurge: true,
-    fetchMethod: async (key) => {
+    fetchMethod: async (key, _staleValue, { context }) => {
       const { epoch, stateId } = JSON.parse(key) as {
         epoch: number;
         stateId: string | number;
       };
 
-      return this.fetchCommitteesUncached(epoch, stateId).catch(() => undefined);
+      if (context?.prefetch) {
+        return this.fetchCommitteesPrefetch(epoch, stateId).catch(() => undefined);
+      }
+
+      return this.fetchCommitteesUncached(epoch, stateId);
     },
   });
 
@@ -205,6 +233,17 @@ export class BeaconClient extends ReliableRequestClient {
   }
 
   /**
+   * Run one configured-node request for prefetch so background warming never enters retry loops.
+   */
+  private makePrefetchRequest<T>(
+    callEndpoint: (url: string) => Promise<T>,
+    nodeType: 'full' | 'archive',
+  ): Promise<T> {
+    const url = nodeType === 'full' ? this.fullNodeUrl : this.archiveNodeUrl;
+    return this.callAPI(callEndpoint, 0, url, nodeType);
+  }
+
+  /**
    * Get committees for a specific epoch
    */
   async getCommittees(
@@ -244,6 +283,27 @@ export class BeaconClient extends ReliableRequestClient {
   }
 
   /**
+   * Fetch committees once for prefetch, leaving normal processing to handle failures and retries.
+   */
+  private fetchCommitteesPrefetch(
+    epoch: number,
+    stateId: string | number = 'head',
+  ): Promise<GetCommittees['data']> {
+    return this.makePrefetchRequest(
+      async (url) => {
+        const res = await this.axiosInstance.get<GetCommittees>(
+          `${url}/eth/v1/beacon/states/${stateId}/committees?epoch=${epoch}`,
+          {
+            timeout: ms('1.5m'),
+          },
+        );
+        return res.data.data;
+      },
+      this.isIndexerDelayed({ value: epoch, type: 'epoch' }) ? 'archive' : 'full',
+    );
+  }
+
+  /**
    * Prefetch committees for the next epoch without blocking epoch processing.
    */
   prefetchCommittees(epoch: number, stateId: string | number = 'head'): void {
@@ -252,7 +312,7 @@ export class BeaconClient extends ReliableRequestClient {
     }
 
     const key = this.getCommitteesCacheKey(epoch, stateId);
-    void this.committeesCache.fetch(key).catch(() => undefined);
+    void this.committeesCache.fetch(key, { context: { prefetch: true } }).catch(() => undefined);
   }
 
   /**
@@ -409,6 +469,24 @@ export class BeaconClient extends ReliableRequestClient {
   };
 
   /**
+   * Fetch block rewards once for prefetch without converting 404 responses into cache entries.
+   */
+  private fetchBlockRewardsPrefetch = async (slot: number): Promise<BlockRewards> => {
+    return this.makePrefetchRequest<BlockRewards>(
+      async (url) => {
+        const res = await this.axiosInstance.get<BlockRewards>(
+          `${url}/eth/v1/beacon/rewards/blocks/${slot}`,
+          {
+            timeout: ms('1.5m'),
+          },
+        );
+        return res.data;
+      },
+      this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
+    );
+  };
+
+  /**
    * Fetch sync committee rewards for one slot without using the prefetch cache.
    */
   private fetchSyncCommitteeRewardsUncached = async (
@@ -431,6 +509,28 @@ export class BeaconClient extends ReliableRequestClient {
   };
 
   /**
+   * Fetch sync committee rewards once for prefetch, keeping all failures out of the cache.
+   */
+  private fetchSyncCommitteeRewardsPrefetch = async (
+    slot: number,
+    validatorIndexes: string[],
+  ): Promise<SyncCommitteeRewards> => {
+    return this.makePrefetchRequest<SyncCommitteeRewards>(
+      async (url) => {
+        const res = await this.axiosInstance.post<SyncCommitteeRewards>(
+          `${url}/eth/v1/beacon/rewards/sync_committee/${slot}`,
+          validatorIndexes,
+          {
+            timeout: ms('1.5m'),
+          },
+        );
+        return res.data;
+      },
+      this.isIndexerDelayed({ value: slot, type: 'slot' }) ? 'archive' : 'full',
+    );
+  };
+
+  /**
    * Prefetch block rewards for a delayed slot without blocking slot processing.
    */
   prefetchBlockRewards(slot: number): void {
@@ -438,7 +538,7 @@ export class BeaconClient extends ReliableRequestClient {
       return;
     }
 
-    void this.blockRewardsCache.fetch(slot).catch(() => undefined);
+    void this.blockRewardsCache.fetch(slot, { context: { prefetch: true } }).catch(() => undefined);
   }
 
   /**
@@ -450,7 +550,9 @@ export class BeaconClient extends ReliableRequestClient {
     }
 
     const key = this.getSyncCommitteeRewardsCacheKey(slot, validatorIndexes);
-    void this.syncCommitteeRewardsCache.fetch(key).catch(() => undefined);
+    void this.syncCommitteeRewardsCache
+      .fetch(key, { context: { prefetch: true } })
+      .catch(() => undefined);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Remove the hardcoded Chainstack rewards prefetch endpoint.
- Route block and sync committee rewards prefetches through the configured reliable beacon client path.
- Update cache tests to assert prefetch uses configured archive/full nodes.

## Root Cause
Rewards prefetch had a separate hardcoded Ethereum mainnet endpoint, so it bypassed chain config, auth headers, logging, retries, concurrency limits, and could cache the wrong chain data.

## Validation
- pnpm --filter indexer exec vitest run src/services/consensus/beacon.test.ts
- pnpm --filter indexer type-check
- pnpm --filter indexer exec eslint src/services/consensus/beacon.ts src/services/consensus/beacon.test.ts --max-warnings=0
- pre-push hook: pnpm -r run lint