### PR TITLE
Fix validator consolidation request key

### DIFF
--- a/packages/db/prisma/migrations/20260526203500_rekey_validator_consolidation_requests/migration.sql
+++ b/packages/db/prisma/migrations/20260526203500_rekey_validator_consolidation_requests/migration.sql
@@ -1,0 +1,30 @@
+ALTER TABLE "public"."validator_request_consolidations"
+  ADD COLUMN "request_index" INTEGER,
+  ADD COLUMN "source_address" VARCHAR(42);
+
+WITH numbered_consolidations AS (
+  SELECT
+    "slot",
+    "source_pubkey",
+    "target_pubkey",
+    ROW_NUMBER() OVER (
+      PARTITION BY "slot"
+      ORDER BY "source_pubkey", "target_pubkey"
+    ) - 1 AS "backfilled_request_index"
+  FROM "public"."validator_request_consolidations"
+)
+UPDATE "public"."validator_request_consolidations" target
+SET "request_index" = numbered_consolidations."backfilled_request_index"::integer
+FROM numbered_consolidations
+WHERE target."slot" = numbered_consolidations."slot"
+  AND target."source_pubkey" = numbered_consolidations."source_pubkey"
+  AND target."target_pubkey" = numbered_consolidations."target_pubkey"
+  AND target."request_index" IS NULL;
+
+ALTER TABLE "public"."validator_request_consolidations"
+  ALTER COLUMN "request_index" SET NOT NULL,
+  DROP CONSTRAINT "validator_request_consolidations_pkey",
+  ADD CONSTRAINT "validator_request_consolidations_pkey" PRIMARY KEY ("slot", "request_index");
+
+CREATE INDEX "validator_request_consolidations_source_pubkey_slot_idx"
+  ON "public"."validator_request_consolidations"("source_pubkey", "slot" DESC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -199,11 +199,15 @@ model validatorWithdrawalsRequests {
 }
 
 model validatorConsolidationsRequests {
-  slot         Int    @map("slot")
-  sourcePubkey String @map("source_pubkey") @db.VarChar(98)
-  targetPubkey String @map("target_pubkey") @db.VarChar(98)
+  slot          Int     @map("slot")
+  // Execution request consolidations are identified by their array position in the block body.
+  requestIndex  Int     @map("request_index")
+  sourceAddress String? @map("source_address") @db.VarChar(42)
+  sourcePubkey  String  @map("source_pubkey") @db.VarChar(98)
+  targetPubkey  String  @map("target_pubkey") @db.VarChar(98)
 
-  @@id([slot, sourcePubkey, targetPubkey])
+  @@id([slot, requestIndex])
+  @@index([sourcePubkey, slot(sort: Desc)], map: "validator_request_consolidations_source_pubkey_slot_idx")
   @@map("validator_request_consolidations")
 }
 

--- a/packages/indexer/e2e/chainStats/chainStats.test.ts
+++ b/packages/indexer/e2e/chainStats/chainStats.test.ts
@@ -74,12 +74,12 @@ describe('Chain Stats', () => {
     const pad = (n: number) => '0x' + n.toString().padStart(96, '0');
     await prisma.validatorConsolidationsRequests.createMany({
       data: [
-        { slot: 1600, sourcePubkey: pad(1), targetPubkey: pad(10) },
-        { slot: 1610, sourcePubkey: pad(2), targetPubkey: pad(20) },
+        { slot: 1600, requestIndex: 0, sourcePubkey: pad(1), targetPubkey: pad(10) },
+        { slot: 1610, requestIndex: 0, sourcePubkey: pad(2), targetPubkey: pad(20) },
         // Same source as first, different slot - should NOT add to distinct count
-        { slot: 1605, sourcePubkey: pad(1), targetPubkey: pad(30) },
+        { slot: 1605, requestIndex: 0, sourcePubkey: pad(1), targetPubkey: pad(30) },
         // Outside slot range - should NOT be counted
-        { slot: 1616, sourcePubkey: pad(3), targetPubkey: pad(40) },
+        { slot: 1616, requestIndex: 0, sourcePubkey: pad(3), targetPubkey: pad(40) },
       ],
     });
 

--- a/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
+++ b/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
@@ -794,12 +794,16 @@ describe('Slot Processor E2E Tests', () => {
         // Expected consolidations from block_24672001.json
         const expectedConsolidations = [
           {
+            requestIndex: 0,
+            sourceAddress: '0xad786f8e975e4ac00b94e2eb1d7ab714c1a232f7',
             sourcePubkey:
               '0xb311b7458d61a0124060557cbce90d002473cfc301e0e7898f0f11ba52894cdb125214234258a710d041771e53e19ac5',
             targetPubkey:
               '0x84e8a653de922a22b844a78caec1de0a1891a5ba633ce4138d537424abe8853e586a3b5a1580c71d25671e733aaf1114',
           },
           {
+            requestIndex: 1,
+            sourceAddress: '0xad786f8e975e4ac00b94e2eb1d7ab714c1a232f7',
             sourcePubkey:
               '0xa0b865f5e3663fdb3a446f4d6eb1bac845988f834fea306c3708e827f5565f633b8a41c62b15a567c0aed5944e703ffa',
             targetPubkey:
@@ -814,15 +818,16 @@ describe('Slot Processor E2E Tests', () => {
         // Verify we have the correct number of consolidation requests
         expect(consolidationRequests.length).toBe(expectedConsolidations.length);
 
-        // Verify each consolidation request matches expected data
-        // Don't rely on order - find by sourcePubkey and then verify targetPubkey
+        // Verify each consolidation request matches the indexed execution request payload.
         for (const expected of expectedConsolidations) {
           const actual = consolidationRequests.find(
-            (req) => req.sourcePubkey === expected.sourcePubkey,
+            (req) => req.requestIndex === expected.requestIndex,
           );
 
           expect(actual).toBeDefined();
           expect(actual?.slot).toBe(slot24672001);
+          expect(actual?.requestIndex).toBe(expected.requestIndex);
+          expect(actual?.sourceAddress).toBe(expected.sourceAddress);
           expect(actual?.sourcePubkey).toBe(expected.sourcePubkey);
           expect(actual?.targetPubkey).toBe(expected.targetPubkey);
         }

--- a/packages/indexer/src/services/consensus/controllers/slot.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.test.ts
@@ -198,4 +198,67 @@ describe('SlotController', () => {
       },
     ]);
   });
+
+  // This test protects duplicate consolidation requests with the same source and target pubkeys.
+  it('preserves execution consolidation request order and source address', async () => {
+    // This storage mock returns an unprocessed slot and captures consolidation request rows.
+    const slotStorage = {
+      getBaseSlot: vi.fn().mockResolvedValue({
+        slot: 14417443,
+        erConsolidationsFetched: false,
+      }),
+      saveValidatorConsolidationsRequests: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // This controller only needs slot storage for execution consolidation request processing.
+    const controller = new SlotController(
+      slotStorage as never,
+      {} as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+    // This call mirrors slot 14417443: two valid consolidation requests have
+    // identical source address, source pubkey, and target pubkey.
+    await controller.processErConsolidations(14417443, [
+      {
+        source_address: '0xf692ff7984721182352ba275eae0d3f2dbaf3382',
+        source_pubkey:
+          '0xaf93aa9e3a10b0ff351fb9352b79cf5010bdd1755d90476ccdfec4f00882e0dcbf9d9f75db6371f97b0dbd3d982cef25',
+        target_pubkey:
+          '0x84c76421ffc9f8a2590acf39a46be555a0f0623629106cb326865ffb54867f33a86cbde9a7d705c723e62d8f18ce4e41',
+      },
+      {
+        source_address: '0xf692ff7984721182352ba275eae0d3f2dbaf3382',
+        source_pubkey:
+          '0xaf93aa9e3a10b0ff351fb9352b79cf5010bdd1755d90476ccdfec4f00882e0dcbf9d9f75db6371f97b0dbd3d982cef25',
+        target_pubkey:
+          '0x84c76421ffc9f8a2590acf39a46be555a0f0623629106cb326865ffb54867f33a86cbde9a7d705c723e62d8f18ce4e41',
+      },
+    ]);
+
+    // This assertion verifies identical consolidation payloads are stored as
+    // separate ordered requests instead of being collapsed by pubkey identity.
+    expect(slotStorage.saveValidatorConsolidationsRequests).toHaveBeenCalledWith(14417443, [
+      {
+        slot: 14417443,
+        requestIndex: 0,
+        sourceAddress: '0xf692ff7984721182352ba275eae0d3f2dbaf3382',
+        sourcePubkey:
+          '0xaf93aa9e3a10b0ff351fb9352b79cf5010bdd1755d90476ccdfec4f00882e0dcbf9d9f75db6371f97b0dbd3d982cef25',
+        targetPubkey:
+          '0x84c76421ffc9f8a2590acf39a46be555a0f0623629106cb326865ffb54867f33a86cbde9a7d705c723e62d8f18ce4e41',
+      },
+      {
+        slot: 14417443,
+        requestIndex: 1,
+        sourceAddress: '0xf692ff7984721182352ba275eae0d3f2dbaf3382',
+        sourcePubkey:
+          '0xaf93aa9e3a10b0ff351fb9352b79cf5010bdd1755d90476ccdfec4f00882e0dcbf9d9f75db6371f97b0dbd3d982cef25',
+        targetPubkey:
+          '0x84c76421ffc9f8a2590acf39a46be555a0f0623629106cb326865ffb54867f33a86cbde9a7d705c723e62d8f18ce4e41',
+      },
+    ]);
+  });
 });

--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -404,8 +404,10 @@ export class SlotController extends SlotControllerHelpers {
 
     await this.slotStorage.saveValidatorConsolidationsRequests(
       baseSlot.slot,
-      consolidations.map((consolidation) => ({
+      consolidations.map((consolidation, requestIndex) => ({
         slot: baseSlot.slot,
+        requestIndex,
+        sourceAddress: consolidation.source_address,
         sourcePubkey: consolidation.source_pubkey,
         targetPubkey: consolidation.target_pubkey,
       })),

--- a/packages/indexer/src/services/consensus/storage/slot.ts
+++ b/packages/indexer/src/services/consensus/storage/slot.ts
@@ -792,6 +792,7 @@ export class SlotStorage {
   async getValidatorConsolidationsRequestsForSlot(slot: number) {
     return this.prisma.validatorConsolidationsRequests.findMany({
       where: { slot },
+      orderBy: { requestIndex: 'asc' },
     });
   }
 }


### PR DESCRIPTION
## Summary
- rekey validator consolidation requests by slot and request index
- persist consolidation source address from execution requests
- add migration backfill and regression coverage for duplicate consolidation payloads

## Root cause
Slot 14417443 contains two valid execution consolidation requests with identical source address, source pubkey, and target pubkey. The previous primary key `(slot, source_pubkey, target_pubkey)` collapsed request identity and caused Prisma unique constraint failures.

## Validation
- `pnpm prisma:generate`
- `pnpm --filter indexer type-check`
- `pnpm --filter indexer test`
- `git diff --check`
- push hook: `pnpm -r run lint`