### PR TITLE
Parallelize validator state fetches

### DIFF
--- a/packages/indexer/src/services/consensus/controllers/validators.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/validators.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ValidatorsController } from './validators.js';
+
+// This suite verifies validator controller batching before data is persisted.
+describe('ValidatorsController', () => {
+  // This test covers mainnet-scale validator snapshots where up to one epoch of
+  // pending deposits can create new validator records after the stored max
+  // index. The controller should fetch the known range plus the protocol
+  // pending-deposit lookahead while keeping requests under the provider limit.
+  it('fetches validator state with a 16-validator lookahead in 100k batches', async () => {
+    // This storage mock represents validators 0 through 500,000 as already
+    // known locally, so the controller must request those validators plus 16
+    // possible new validators from the next epoch.
+    const validatorsStorage = {
+      getMaxValidatorIndex: vi.fn().mockResolvedValue(500_000),
+      getFinalValidatorIndexes: vi.fn().mockResolvedValue([]),
+      saveValidatorsForEpoch: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // These counters capture how many Beacon API requests are in flight at the
+    // same time, proving the controller batches concurrently rather than
+    // awaiting each request before starting the next.
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    const requestedBatchSizes: number[] = [];
+
+    // This Beacon client mock delays each request long enough for concurrent
+    // calls in the same group to overlap while returning no rows to keep the
+    // test focused on request scheduling instead of validator data shape.
+    const beaconClient = {
+      getValidators: vi.fn(async (_slot: number, validatorIndexes: string[]) => {
+        activeRequests++;
+        maxActiveRequests = Math.max(maxActiveRequests, activeRequests);
+        requestedBatchSizes.push(validatorIndexes.length);
+
+        await new Promise((resolve) => setTimeout(resolve, 5));
+
+        activeRequests--;
+        return [];
+      }),
+    };
+
+    // This controller only needs Beacon client fetches and validator storage for
+    // epoch validator state snapshots.
+    const controller = new ValidatorsController(
+      beaconClient as never,
+      validatorsStorage as never,
+      {} as never,
+    );
+
+    // This action fetches one epoch snapshot from the supplied slot.
+    await controller.fetchValidatorsState(123_456, 3_858);
+
+    // This assertion verifies every request stays below the provider POST body
+    // limit while the final request contains only the 16-validator lookahead
+    // plus the known max validator index.
+    expect(requestedBatchSizes).toEqual([100_000, 100_000, 100_000, 100_000, 100_000, 17]);
+
+    // This assertion verifies five Beacon API requests run together for the
+    // first wave, leaving the small lookahead batch for the second wave.
+    expect(maxActiveRequests).toBe(5);
+
+    // This assertion verifies the epoch fetched flag remains tied to the single
+    // final storage call instead of being marked per partial request.
+    expect(validatorsStorage.saveValidatorsForEpoch).toHaveBeenCalledTimes(1);
+    expect(validatorsStorage.saveValidatorsForEpoch).toHaveBeenCalledWith([], 3_858);
+  });
+});

--- a/packages/indexer/src/services/consensus/controllers/validators.ts
+++ b/packages/indexer/src/services/consensus/controllers/validators.ts
@@ -180,10 +180,12 @@ export class ValidatorsController {
     const finalStateValidatorsSet = new Set(finalStateValidatorIndexes);
 
     const maxValidatorIndexToFetch = maxValidatorIndex + MAX_PENDING_DEPOSITS_PER_EPOCH;
-    const allValidatorIndexes = Array.from(
-      { length: maxValidatorIndexToFetch + 1 },
-      (_, i) => i,
-    ).filter((id) => !finalStateValidatorsSet.has(id));
+    const allValidatorIndexes: number[] = [];
+    for (let id = 0; id <= maxValidatorIndexToFetch; id++) {
+      if (!finalStateValidatorsSet.has(id)) {
+        allValidatorIndexes.push(id);
+      }
+    }
 
     const batches = chunk(allValidatorIndexes, VALIDATOR_STATE_FETCH_BATCH_SIZE);
     const batchGroups = chunk(batches, VALIDATOR_STATE_FETCH_CONCURRENCY);

--- a/packages/indexer/src/services/consensus/controllers/validators.ts
+++ b/packages/indexer/src/services/consensus/controllers/validators.ts
@@ -8,6 +8,10 @@ import { BeaconClient } from '@/src/services/consensus/beacon.js';
 import { ValidatorsStorage } from '@/src/services/consensus/storage/validators.js';
 import type { GetValidators } from '@/src/services/consensus/types.js';
 
+const VALIDATOR_STATE_FETCH_BATCH_SIZE = 100_000;
+const VALIDATOR_STATE_FETCH_CONCURRENCY = 5;
+const MAX_PENDING_DEPOSITS_PER_EPOCH = 16;
+
 export class ValidatorsController {
   private readonly logger = createLogger('ValidatorsController');
 
@@ -167,30 +171,34 @@ export class ValidatorsController {
    * The caller must provide the epoch corresponding to the slot to avoid coupling with time utils.
    */
   async fetchValidatorsState(slot: number, epoch: number) {
-    const totalValidators = await this.validatorsStorage.getMaxValidatorIndex();
-    if (totalValidators === 0) {
+    const maxValidatorIndex = await this.validatorsStorage.getMaxValidatorIndex();
+    if (maxValidatorIndex === 0) {
       return;
     }
 
     const finalStateValidatorIndexes = await this.validatorsStorage.getFinalValidatorIndexes();
     const finalStateValidatorsSet = new Set(finalStateValidatorIndexes);
 
-    const allValidatorIndexes = Array.from({ length: totalValidators + 1 }, (_, i) => i).filter(
-      (id) => !finalStateValidatorsSet.has(id),
-    );
+    const maxValidatorIndexToFetch = maxValidatorIndex + MAX_PENDING_DEPOSITS_PER_EPOCH;
+    const allValidatorIndexes = Array.from(
+      { length: maxValidatorIndexToFetch + 1 },
+      (_, i) => i,
+    ).filter((id) => !finalStateValidatorsSet.has(id));
 
-    const batchSize = 1_000_000;
-    const batches = chunk(allValidatorIndexes, batchSize);
+    const batches = chunk(allValidatorIndexes, VALIDATOR_STATE_FETCH_BATCH_SIZE);
+    const batchGroups = chunk(batches, VALIDATOR_STATE_FETCH_CONCURRENCY);
     let allValidatorsData: GetValidators['data'] = [];
 
-    for (const batchIds of batches) {
-      const batchResult = await this.beaconClient.getValidators(slot, batchIds.map(String), null);
+    // Run a fixed-size wave of requests so each POST body stays below provider
+    // limits while covering the protocol maximum of new validators per epoch.
+    for (const batchGroup of batchGroups) {
+      const batchResults = await Promise.all(
+        batchGroup.map((batchIds) =>
+          this.beaconClient.getValidators(slot, batchIds.map(String), null),
+        ),
+      );
 
-      allValidatorsData = [...allValidatorsData, ...batchResult];
-
-      if (batchResult.length < batchSize) {
-        break;
-      }
+      allValidatorsData = allValidatorsData.concat(...batchResults);
     }
 
     await this.validatorsStorage.saveValidatorsForEpoch(allValidatorsData, epoch);


### PR DESCRIPTION
## Summary
- Fetch validator state in 100k ID batches to stay under provider POST body limits.
- Run validator-state fetch batches in waves of five concurrent requests.
- Include a 16-validator lookahead based on the Electra pending deposits per epoch limit.
- Add controller coverage for batching, lookahead, and concurrency.

## Validation
- pnpm --filter indexer test -- src/services/consensus/controllers/validators.test.ts --run
- pnpm --filter indexer type-check
- pnpm --filter indexer lint
- git push pre-push hook: pnpm -r run lint