### PR TITLE
Refine cluster summary user metrics

### DIFF
--- a/packages/api/src/routers/cluster/schemas.ts
+++ b/packages/api/src/routers/cluster/schemas.ts
@@ -246,13 +246,42 @@ export const ClusterSummaryItemSchema = z.object({
 });
 
 /**
+ * Count and validator totals for one user category in the summary response.
+ */
+export const ClusterSummaryMetricSchema = z.object({
+  total: z.number(),
+  totalUniqueValidators: z.number(),
+  tokenAmount: z.string(),
+});
+
+/**
+ * Active user totals plus category breakdowns that may overlap by design.
+ */
+export const ActiveUsersSummarySchema = ClusterSummaryMetricSchema.extend({
+  details: z.object({
+    telegram: ClusterSummaryMetricSchema,
+    lido: ClusterSummaryMetricSchema,
+    annon: ClusterSummaryMetricSchema,
+  }),
+});
+
+/**
+ * Counts users with no cluster that currently has loaded validators.
+ */
+export const InactiveUsersSummarySchema = z.object({
+  total: z.number(),
+  annon: z.number(),
+  tg: z.number(),
+});
+
+/**
  * Cross-user cluster summary response schema.
  */
 export const ClusterSummarySchema = z.object({
   totalClusters: z.number(),
-  totalUsers: z.number(),
-  totalUniqueValidators: z.number(),
-  totalTokenAmount: z.string(),
+  activeUsers: ActiveUsersSummarySchema,
+  tgBlockedUsers: ClusterSummaryMetricSchema,
+  inactiveUsers: InactiveUsersSummarySchema,
   clusters: z.array(ClusterSummaryItemSchema),
 });
 

--- a/packages/api/src/routers/cluster/summary.test.ts
+++ b/packages/api/src/routers/cluster/summary.test.ts
@@ -46,13 +46,43 @@ function createTestRoute(params: {
 }
 
 describe('createClusterSummaryRoute', () => {
-  it('formats summary effective balances with the configured Ethereum chain', async () => {
+  // Verifies the route formats the storage summary without changing user-category semantics.
+  it('formats categorized summary balances with the configured Ethereum chain', async () => {
     // This scenario verifies the API response exposes token amounts instead of raw gwei.
     const getSummary = vi.fn().mockResolvedValue({
       totalClusters: 2,
-      totalUsers: 2,
-      totalUniqueValidators: 4,
-      totalEffectiveBalance: 127_500_000_000n,
+      activeUsers: {
+        total: 2,
+        totalUniqueValidators: 4,
+        totalEffectiveBalance: 157_500_000_000n,
+        details: {
+          telegram: {
+            total: 1,
+            totalUniqueValidators: 3,
+            totalEffectiveBalance: 95_500_000_000n,
+          },
+          lido: {
+            total: 1,
+            totalUniqueValidators: 1,
+            totalEffectiveBalance: 32_000_000_000n,
+          },
+          annon: {
+            total: 1,
+            totalUniqueValidators: 2,
+            totalEffectiveBalance: 62_000_000_000n,
+          },
+        },
+      },
+      tgBlockedUsers: {
+        total: 1,
+        totalUniqueValidators: 1,
+        totalEffectiveBalance: 31_000_000_000n,
+      },
+      inactiveUsers: {
+        total: 2,
+        annon: 1,
+        tg: 1,
+      },
       clusters: [
         {
           id: 'cluster-a',
@@ -82,9 +112,38 @@ describe('createClusterSummaryRoute', () => {
       success: true,
       data: {
         totalClusters: 2,
-        totalUsers: 2,
-        totalUniqueValidators: 4,
-        totalTokenAmount: '127.5',
+        activeUsers: {
+          total: 2,
+          totalUniqueValidators: 4,
+          tokenAmount: '157.5',
+          details: {
+            telegram: {
+              total: 1,
+              totalUniqueValidators: 3,
+              tokenAmount: '95.5',
+            },
+            lido: {
+              total: 1,
+              totalUniqueValidators: 1,
+              tokenAmount: '32',
+            },
+            annon: {
+              total: 1,
+              totalUniqueValidators: 2,
+              tokenAmount: '62',
+            },
+          },
+        },
+        tgBlockedUsers: {
+          total: 1,
+          totalUniqueValidators: 1,
+          tokenAmount: '31',
+        },
+        inactiveUsers: {
+          total: 2,
+          annon: 1,
+          tg: 1,
+        },
         clusters: [
           {
             id: 'cluster-a',
@@ -114,9 +173,38 @@ describe('createClusterSummaryRoute', () => {
     // This scenario verifies Gnosis deployments use the same chain-aware balance formatter.
     const getSummary = vi.fn().mockResolvedValue({
       totalClusters: 1,
-      totalUsers: 1,
-      totalUniqueValidators: 32,
-      totalEffectiveBalance: 32_000_000_000n,
+      activeUsers: {
+        total: 1,
+        totalUniqueValidators: 32,
+        totalEffectiveBalance: 32_000_000_000n,
+        details: {
+          telegram: {
+            total: 1,
+            totalUniqueValidators: 32,
+            totalEffectiveBalance: 32_000_000_000n,
+          },
+          lido: {
+            total: 0,
+            totalUniqueValidators: 0,
+            totalEffectiveBalance: 0n,
+          },
+          annon: {
+            total: 0,
+            totalUniqueValidators: 0,
+            totalEffectiveBalance: 0n,
+          },
+        },
+      },
+      tgBlockedUsers: {
+        total: 0,
+        totalUniqueValidators: 0,
+        totalEffectiveBalance: 0n,
+      },
+      inactiveUsers: {
+        total: 0,
+        annon: 0,
+        tg: 0,
+      },
       clusters: [
         {
           id: 'cluster-a',
@@ -138,9 +226,38 @@ describe('createClusterSummaryRoute', () => {
       success: true,
       data: {
         totalClusters: 1,
-        totalUsers: 1,
-        totalUniqueValidators: 32,
-        totalTokenAmount: '1',
+        activeUsers: {
+          total: 1,
+          totalUniqueValidators: 32,
+          tokenAmount: '1',
+          details: {
+            telegram: {
+              total: 1,
+              totalUniqueValidators: 32,
+              tokenAmount: '1',
+            },
+            lido: {
+              total: 0,
+              totalUniqueValidators: 0,
+              tokenAmount: '0',
+            },
+            annon: {
+              total: 0,
+              totalUniqueValidators: 0,
+              tokenAmount: '0',
+            },
+          },
+        },
+        tgBlockedUsers: {
+          total: 0,
+          totalUniqueValidators: 0,
+          tokenAmount: '0',
+        },
+        inactiveUsers: {
+          total: 0,
+          annon: 0,
+          tg: 0,
+        },
         clusters: [
           {
             id: 'cluster-a',

--- a/packages/api/src/routers/cluster/summary.ts
+++ b/packages/api/src/routers/cluster/summary.ts
@@ -11,6 +11,26 @@ import { formatBalance } from '@/utils/tokenFormat.js';
 const ClusterSummaryResponseSchema = ApiResponseSchema(ClusterSummarySchema);
 type ClusterSummaryResponse = z.infer<typeof ClusterSummaryResponseSchema>;
 
+interface RawClusterSummaryMetric {
+  total: number;
+  totalUniqueValidators: number;
+  totalEffectiveBalance: bigint;
+}
+
+/**
+ * Formats a raw bigint-backed summary metric for API consumers.
+ */
+function formatSummaryMetric(
+  metric: RawClusterSummaryMetric,
+  chain: Chain,
+): Omit<RawClusterSummaryMetric, 'totalEffectiveBalance'> & { tokenAmount: string } {
+  return {
+    total: metric.total,
+    totalUniqueValidators: metric.totalUniqueValidators,
+    tokenAmount: formatBalance(metric.totalEffectiveBalance, chain),
+  };
+}
+
 /**
  * Creates the cluster summary route.
  */
@@ -30,9 +50,16 @@ export function createClusterSummaryRoute(params: {
 
         return successResponse({
           totalClusters: summary.totalClusters,
-          totalUsers: summary.totalUsers,
-          totalUniqueValidators: summary.totalUniqueValidators,
-          totalTokenAmount: formatBalance(summary.totalEffectiveBalance, params.chain),
+          activeUsers: {
+            ...formatSummaryMetric(summary.activeUsers, params.chain),
+            details: {
+              telegram: formatSummaryMetric(summary.activeUsers.details.telegram, params.chain),
+              lido: formatSummaryMetric(summary.activeUsers.details.lido, params.chain),
+              annon: formatSummaryMetric(summary.activeUsers.details.annon, params.chain),
+            },
+          },
+          tgBlockedUsers: formatSummaryMetric(summary.tgBlockedUsers, params.chain),
+          inactiveUsers: summary.inactiveUsers,
           clusters: summary.clusters.map((cluster: any) => ({
             id: cluster.id,
             name: cluster.name,

--- a/packages/api/src/storage/cluster.test.ts
+++ b/packages/api/src/storage/cluster.test.ts
@@ -16,88 +16,176 @@ const migrationUrl = new URL(
 );
 
 describe('ClusterStorage.getSummary', () => {
-  it('returns total cluster count, validator count, and effective balance per cluster', async () => {
+  // Verifies the API-key summary keeps inactive and blocked users out of active metrics.
+  it('groups active, blocked, inactive, Telegram, anonymous, and Lido user metrics', async () => {
     // This case verifies the compact cluster summary used by the API key endpoint.
     const findMany = vi.fn().mockResolvedValue([
       {
         id: 'cluster-a',
-        name: 'Main cluster',
-        ownerId: 'user-a',
+        name: 'Telegram cluster',
+        ownerId: 'user-tg-active',
         createdAt: new Date('2026-04-22T10:00:00.000Z'),
-        owner: { username: 'alice', telegramId: 123n },
+        lidoOperatorId: null,
+        owner: { username: 'alice', telegramId: 123n, hasBlockedBot: false },
         validators: [
-          { validator: { effectiveBalance: 32_000_000_000n } },
-          { validator: { effectiveBalance: 31_500_000_000n } },
-          { validator: { effectiveBalance: null } },
-        ],
-        _count: { validators: 3 },
-      },
-      {
-        id: 'cluster-b',
-        name: 'Backup cluster',
-        ownerId: 'user-b',
-        createdAt: new Date('2026-04-21T10:00:00.000Z'),
-        owner: { username: 'anon:session-b', telegramId: null },
-        validators: [
-          { validator: { effectiveBalance: 32_000_000_000n } },
-          { validator: { effectiveBalance: 32_000_000_000n } },
+          { validatorIndex: 1, validator: { effectiveBalance: 32_000_000_000n } },
+          { validatorIndex: 2, validator: { effectiveBalance: 31_500_000_000n } },
         ],
         _count: { validators: 2 },
       },
+      {
+        id: 'cluster-b',
+        name: 'Telegram Lido cluster',
+        ownerId: 'user-tg-active',
+        createdAt: new Date('2026-04-21T10:00:00.000Z'),
+        lidoOperatorId: '42',
+        owner: { username: 'alice', telegramId: 123n, hasBlockedBot: false },
+        validators: [{ validatorIndex: 3, validator: { effectiveBalance: 32_000_000_000n } }],
+        _count: { validators: 1 },
+      },
+      {
+        id: 'cluster-c',
+        name: 'Anonymous cluster',
+        ownerId: 'user-anon-active',
+        createdAt: new Date('2026-04-20T10:00:00.000Z'),
+        lidoOperatorId: null,
+        owner: { username: 'anon:session-c', telegramId: null, hasBlockedBot: false },
+        validators: [
+          { validatorIndex: 3, validator: { effectiveBalance: 32_000_000_000n } },
+          { validatorIndex: 4, validator: { effectiveBalance: 30_000_000_000n } },
+        ],
+        _count: { validators: 2 },
+      },
+      {
+        id: 'cluster-d',
+        name: 'Blocked Telegram cluster',
+        ownerId: 'user-tg-blocked',
+        createdAt: new Date('2026-04-19T10:00:00.000Z'),
+        lidoOperatorId: null,
+        owner: { username: 'blocked', telegramId: 456n, hasBlockedBot: true },
+        validators: [{ validatorIndex: 5, validator: { effectiveBalance: 31_000_000_000n } }],
+        _count: { validators: 1 },
+      },
+      {
+        id: 'cluster-e',
+        name: 'Empty Telegram cluster',
+        ownerId: 'user-tg-inactive',
+        createdAt: new Date('2026-04-18T10:00:00.000Z'),
+        lidoOperatorId: null,
+        owner: { username: 'idle', telegramId: 789n, hasBlockedBot: false },
+        validators: [],
+        _count: { validators: 0 },
+      },
     ]);
-    const groupBy = vi
-      .fn()
-      .mockResolvedValue([
-        { validatorIndex: 1 },
-        { validatorIndex: 2 },
-        { validatorIndex: 3 },
-        { validatorIndex: 4 },
-      ]);
-    const count = vi.fn().mockResolvedValue(2);
+    const userFindMany = vi.fn().mockResolvedValue([
+      // This Telegram user has active validator-loaded clusters and should count as active.
+      { id: 'user-tg-active', telegramId: 123n },
+      // This anonymous user has an active validator-loaded cluster and should count as active.
+      { id: 'user-anon-active', telegramId: null },
+      // This Telegram user has validators but blocked the bot, so active metrics must exclude it.
+      { id: 'user-tg-blocked', telegramId: 456n },
+      // This Telegram user has only an empty cluster and should count as inactive.
+      { id: 'user-tg-inactive', telegramId: 789n },
+      // This anonymous user has no clusters and should count as inactive.
+      { id: 'user-anon-inactive', telegramId: null },
+    ]);
 
     // Provides only the Prisma delegate used by the method under test.
     const storage = new ClusterStorage({
       cluster: { findMany },
-      clusterValidator: { groupBy },
-      user: { count },
+      user: { findMany: userFindMany },
     } as never);
 
-    // Gets the cross-user cluster summary.
+    // Gets the cross-user cluster summary from the mocked Prisma delegates.
     const summary = await storage.getSummary();
 
     // Confirms the summary reports all clusters returned by storage.
-    expect(summary.totalClusters).toBe(2);
-    // Confirms the summary reports the total number of users.
-    expect(summary.totalUsers).toBe(2);
-    // Confirms the summary counts validators once across all clusters.
-    expect(summary.totalUniqueValidators).toBe(4);
-    // Confirms the summary includes the raw total effective balance across clusters.
-    expect(summary.totalEffectiveBalance).toBe(127_500_000_000n);
+    expect(summary.totalClusters).toBe(5);
+    // Confirms active users exclude blocked Telegram users and users without loaded validators.
+    expect(summary.activeUsers).toEqual({
+      total: 2,
+      totalUniqueValidators: 4,
+      totalEffectiveBalance: 157_500_000_000n,
+      details: {
+        telegram: {
+          total: 1,
+          totalUniqueValidators: 3,
+          totalEffectiveBalance: 95_500_000_000n,
+        },
+        lido: {
+          total: 1,
+          totalUniqueValidators: 1,
+          totalEffectiveBalance: 32_000_000_000n,
+        },
+        annon: {
+          total: 1,
+          totalUniqueValidators: 2,
+          totalEffectiveBalance: 62_000_000_000n,
+        },
+      },
+    });
+    // Confirms blocked Telegram users are reported separately from active users.
+    expect(summary.tgBlockedUsers).toEqual({
+      total: 1,
+      totalUniqueValidators: 1,
+      totalEffectiveBalance: 31_000_000_000n,
+    });
+    // Confirms users with no validator-loaded clusters are counted by auth mode only.
+    expect(summary.inactiveUsers).toEqual({
+      total: 2,
+      annon: 1,
+      tg: 1,
+    });
     // Confirms each cluster includes the validator membership count.
     expect(summary.clusters).toEqual([
       {
         id: 'cluster-a',
-        name: 'Main cluster',
-        ownerId: 'user-a',
+        name: 'Telegram cluster',
+        ownerId: 'user-tg-active',
         ownerUsername: 'alice',
-        validatorCount: 3,
+        validatorCount: 2,
         effectiveBalance: 63_500_000_000n,
       },
       {
         id: 'cluster-b',
-        name: 'Backup cluster',
-        ownerId: 'user-b',
+        name: 'Telegram Lido cluster',
+        ownerId: 'user-tg-active',
+        ownerUsername: 'alice',
+        validatorCount: 1,
+        effectiveBalance: 32_000_000_000n,
+      },
+      {
+        id: 'cluster-c',
+        name: 'Anonymous cluster',
+        ownerId: 'user-anon-active',
         ownerUsername: 'annon',
         validatorCount: 2,
-        effectiveBalance: 64_000_000_000n,
+        effectiveBalance: 62_000_000_000n,
+      },
+      {
+        id: 'cluster-d',
+        name: 'Blocked Telegram cluster',
+        ownerId: 'user-tg-blocked',
+        ownerUsername: 'blocked',
+        validatorCount: 1,
+        effectiveBalance: 31_000_000_000n,
+      },
+      {
+        id: 'cluster-e',
+        name: 'Empty Telegram cluster',
+        ownerId: 'user-tg-inactive',
+        ownerUsername: 'idle',
+        validatorCount: 0,
+        effectiveBalance: 0n,
       },
     ]);
-    // Confirms Prisma counts validators without loading validator rows.
+    // Confirms Prisma loads the user and validator data required for summary categorization.
     expect(findMany).toHaveBeenCalledWith({
       include: {
-        owner: { select: { username: true, telegramId: true } },
+        owner: { select: { username: true, telegramId: true, hasBlockedBot: true } },
         validators: {
           select: {
+            validatorIndex: true,
             validator: {
               select: {
                 effectiveBalance: true,
@@ -109,12 +197,10 @@ describe('ClusterStorage.getSummary', () => {
       },
       orderBy: { createdAt: 'desc' },
     });
-    // Confirms duplicate validator memberships across clusters are counted once.
-    expect(groupBy).toHaveBeenCalledWith({
-      by: ['validatorIndex'],
+    // Confirms inactive users are computed from all user IDs and auth modes.
+    expect(userFindMany).toHaveBeenCalledWith({
+      select: { id: true, telegramId: true },
     });
-    // Confirms users are counted without loading user rows.
-    expect(count).toHaveBeenCalledWith();
   });
 });
 

--- a/packages/api/src/storage/cluster.test.ts
+++ b/packages/api/src/storage/cluster.test.ts
@@ -18,85 +18,144 @@ const migrationUrl = new URL(
 describe('ClusterStorage.getSummary', () => {
   // Verifies the API-key summary keeps inactive and blocked users out of active metrics.
   it('groups active, blocked, inactive, Telegram, anonymous, and Lido user metrics', async () => {
-    // This case verifies the compact cluster summary used by the API key endpoint.
-    const findMany = vi.fn().mockResolvedValue([
+    // This query result includes repeated summary columns plus one row per cluster.
+    const queryRaw = vi.fn().mockResolvedValue([
       {
-        id: 'cluster-a',
-        name: 'Telegram cluster',
-        ownerId: 'user-tg-active',
-        createdAt: new Date('2026-04-22T10:00:00.000Z'),
-        lidoOperatorId: null,
-        owner: { username: 'alice', telegramId: 123n, hasBlockedBot: false },
-        validators: [
-          { validatorIndex: 1, validator: { effectiveBalance: 32_000_000_000n } },
-          { validatorIndex: 2, validator: { effectiveBalance: 31_500_000_000n } },
-        ],
-        _count: { validators: 2 },
+        total_clusters: 5n,
+        active_total: 2n,
+        active_unique_validators: 4n,
+        active_effective_balance: 157_500_000_000n,
+        telegram_total: 1n,
+        telegram_unique_validators: 3n,
+        telegram_effective_balance: 95_500_000_000n,
+        lido_total: 1n,
+        lido_unique_validators: 1n,
+        lido_effective_balance: 32_000_000_000n,
+        annon_total: 1n,
+        annon_unique_validators: 2n,
+        annon_effective_balance: 62_000_000_000n,
+        blocked_total: 1n,
+        blocked_unique_validators: 1n,
+        blocked_effective_balance: 31_000_000_000n,
+        inactive_annon: 1n,
+        inactive_tg: 1n,
+        cluster_id: 'cluster-a',
+        cluster_name: 'Telegram cluster',
+        cluster_owner_id: 'user-tg-active',
+        cluster_owner_username: 'alice',
+        cluster_validator_count: 2n,
+        cluster_effective_balance: 63_500_000_000n,
       },
       {
-        id: 'cluster-b',
-        name: 'Telegram Lido cluster',
-        ownerId: 'user-tg-active',
-        createdAt: new Date('2026-04-21T10:00:00.000Z'),
-        lidoOperatorId: '42',
-        owner: { username: 'alice', telegramId: 123n, hasBlockedBot: false },
-        validators: [{ validatorIndex: 3, validator: { effectiveBalance: 32_000_000_000n } }],
-        _count: { validators: 1 },
+        total_clusters: 5n,
+        active_total: 2n,
+        active_unique_validators: 4n,
+        active_effective_balance: 157_500_000_000n,
+        telegram_total: 1n,
+        telegram_unique_validators: 3n,
+        telegram_effective_balance: 95_500_000_000n,
+        lido_total: 1n,
+        lido_unique_validators: 1n,
+        lido_effective_balance: 32_000_000_000n,
+        annon_total: 1n,
+        annon_unique_validators: 2n,
+        annon_effective_balance: 62_000_000_000n,
+        blocked_total: 1n,
+        blocked_unique_validators: 1n,
+        blocked_effective_balance: 31_000_000_000n,
+        inactive_annon: 1n,
+        inactive_tg: 1n,
+        cluster_id: 'cluster-b',
+        cluster_name: 'Telegram Lido cluster',
+        cluster_owner_id: 'user-tg-active',
+        cluster_owner_username: 'alice',
+        cluster_validator_count: 1n,
+        cluster_effective_balance: 32_000_000_000n,
       },
       {
-        id: 'cluster-c',
-        name: 'Anonymous cluster',
-        ownerId: 'user-anon-active',
-        createdAt: new Date('2026-04-20T10:00:00.000Z'),
-        lidoOperatorId: null,
-        owner: { username: 'anon:session-c', telegramId: null, hasBlockedBot: false },
-        validators: [
-          { validatorIndex: 3, validator: { effectiveBalance: 32_000_000_000n } },
-          { validatorIndex: 4, validator: { effectiveBalance: 30_000_000_000n } },
-        ],
-        _count: { validators: 2 },
+        total_clusters: 5n,
+        active_total: 2n,
+        active_unique_validators: 4n,
+        active_effective_balance: 157_500_000_000n,
+        telegram_total: 1n,
+        telegram_unique_validators: 3n,
+        telegram_effective_balance: 95_500_000_000n,
+        lido_total: 1n,
+        lido_unique_validators: 1n,
+        lido_effective_balance: 32_000_000_000n,
+        annon_total: 1n,
+        annon_unique_validators: 2n,
+        annon_effective_balance: 62_000_000_000n,
+        blocked_total: 1n,
+        blocked_unique_validators: 1n,
+        blocked_effective_balance: 31_000_000_000n,
+        inactive_annon: 1n,
+        inactive_tg: 1n,
+        cluster_id: 'cluster-c',
+        cluster_name: 'Anonymous cluster',
+        cluster_owner_id: 'user-anon-active',
+        cluster_owner_username: 'annon',
+        cluster_validator_count: 2n,
+        cluster_effective_balance: 62_000_000_000n,
       },
       {
-        id: 'cluster-d',
-        name: 'Blocked Telegram cluster',
-        ownerId: 'user-tg-blocked',
-        createdAt: new Date('2026-04-19T10:00:00.000Z'),
-        lidoOperatorId: null,
-        owner: { username: 'blocked', telegramId: 456n, hasBlockedBot: true },
-        validators: [{ validatorIndex: 5, validator: { effectiveBalance: 31_000_000_000n } }],
-        _count: { validators: 1 },
+        total_clusters: 5n,
+        active_total: 2n,
+        active_unique_validators: 4n,
+        active_effective_balance: 157_500_000_000n,
+        telegram_total: 1n,
+        telegram_unique_validators: 3n,
+        telegram_effective_balance: 95_500_000_000n,
+        lido_total: 1n,
+        lido_unique_validators: 1n,
+        lido_effective_balance: 32_000_000_000n,
+        annon_total: 1n,
+        annon_unique_validators: 2n,
+        annon_effective_balance: 62_000_000_000n,
+        blocked_total: 1n,
+        blocked_unique_validators: 1n,
+        blocked_effective_balance: 31_000_000_000n,
+        inactive_annon: 1n,
+        inactive_tg: 1n,
+        cluster_id: 'cluster-d',
+        cluster_name: 'Blocked Telegram cluster',
+        cluster_owner_id: 'user-tg-blocked',
+        cluster_owner_username: 'blocked',
+        cluster_validator_count: 1n,
+        cluster_effective_balance: 31_000_000_000n,
       },
       {
-        id: 'cluster-e',
-        name: 'Empty Telegram cluster',
-        ownerId: 'user-tg-inactive',
-        createdAt: new Date('2026-04-18T10:00:00.000Z'),
-        lidoOperatorId: null,
-        owner: { username: 'idle', telegramId: 789n, hasBlockedBot: false },
-        validators: [],
-        _count: { validators: 0 },
+        total_clusters: 5n,
+        active_total: 2n,
+        active_unique_validators: 4n,
+        active_effective_balance: 157_500_000_000n,
+        telegram_total: 1n,
+        telegram_unique_validators: 3n,
+        telegram_effective_balance: 95_500_000_000n,
+        lido_total: 1n,
+        lido_unique_validators: 1n,
+        lido_effective_balance: 32_000_000_000n,
+        annon_total: 1n,
+        annon_unique_validators: 2n,
+        annon_effective_balance: 62_000_000_000n,
+        blocked_total: 1n,
+        blocked_unique_validators: 1n,
+        blocked_effective_balance: 31_000_000_000n,
+        inactive_annon: 1n,
+        inactive_tg: 1n,
+        cluster_id: 'cluster-e',
+        cluster_name: 'Empty Telegram cluster',
+        cluster_owner_id: 'user-tg-inactive',
+        cluster_owner_username: 'idle',
+        cluster_validator_count: 0n,
+        cluster_effective_balance: 0n,
       },
     ]);
-    const userFindMany = vi.fn().mockResolvedValue([
-      // This Telegram user has active validator-loaded clusters and should count as active.
-      { id: 'user-tg-active', telegramId: 123n },
-      // This anonymous user has an active validator-loaded cluster and should count as active.
-      { id: 'user-anon-active', telegramId: null },
-      // This Telegram user has validators but blocked the bot, so active metrics must exclude it.
-      { id: 'user-tg-blocked', telegramId: 456n },
-      // This Telegram user has only an empty cluster and should count as inactive.
-      { id: 'user-tg-inactive', telegramId: 789n },
-      // This anonymous user has no clusters and should count as inactive.
-      { id: 'user-anon-inactive', telegramId: null },
-    ]);
 
-    // Provides only the Prisma delegate used by the method under test.
-    const storage = new ClusterStorage({
-      cluster: { findMany },
-      user: { findMany: userFindMany },
-    } as never);
+    // Provides only the raw-query delegate used by this reporting method.
+    const storage = new ClusterStorage({ $queryRaw: queryRaw } as never);
 
-    // Gets the cross-user cluster summary from the mocked Prisma delegates.
+    // Gets the cross-user cluster summary from the mocked raw query result.
     const summary = await storage.getSummary();
 
     // Confirms the summary reports all clusters returned by storage.
@@ -179,28 +238,8 @@ describe('ClusterStorage.getSummary', () => {
         effectiveBalance: 0n,
       },
     ]);
-    // Confirms Prisma loads the user and validator data required for summary categorization.
-    expect(findMany).toHaveBeenCalledWith({
-      include: {
-        owner: { select: { username: true, telegramId: true, hasBlockedBot: true } },
-        validators: {
-          select: {
-            validatorIndex: true,
-            validator: {
-              select: {
-                effectiveBalance: true,
-              },
-            },
-          },
-        },
-        _count: { select: { validators: true } },
-      },
-      orderBy: { createdAt: 'desc' },
-    });
-    // Confirms inactive users are computed from all user IDs and auth modes.
-    expect(userFindMany).toHaveBeenCalledWith({
-      select: { id: true, telegramId: true },
-    });
+    // Confirms the reporting endpoint does one database aggregation query.
+    expect(queryRaw).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -27,10 +27,62 @@ interface ClusterSummaryMetric {
   totalEffectiveBalance: bigint;
 }
 
-interface MutableClusterSummaryMetric {
-  userIds: Set<string>;
-  validatorIndexes: Set<number>;
-  totalEffectiveBalance: bigint;
+type NumericQueryValue = bigint | number | string | { toString(): string };
+
+interface ClusterSummaryQueryRow {
+  total_clusters: NumericQueryValue;
+  active_total: NumericQueryValue;
+  active_unique_validators: NumericQueryValue;
+  active_effective_balance: NumericQueryValue;
+  telegram_total: NumericQueryValue;
+  telegram_unique_validators: NumericQueryValue;
+  telegram_effective_balance: NumericQueryValue;
+  lido_total: NumericQueryValue;
+  lido_unique_validators: NumericQueryValue;
+  lido_effective_balance: NumericQueryValue;
+  annon_total: NumericQueryValue;
+  annon_unique_validators: NumericQueryValue;
+  annon_effective_balance: NumericQueryValue;
+  blocked_total: NumericQueryValue;
+  blocked_unique_validators: NumericQueryValue;
+  blocked_effective_balance: NumericQueryValue;
+  inactive_annon: NumericQueryValue;
+  inactive_tg: NumericQueryValue;
+  cluster_id: string | null;
+  cluster_name: string | null;
+  cluster_owner_id: string | null;
+  cluster_owner_username: string | null;
+  cluster_validator_count: NumericQueryValue | null;
+  cluster_effective_balance: NumericQueryValue | null;
+}
+
+/**
+ * Converts count values from raw SQL into JavaScript numbers.
+ */
+function queryNumber(value: NumericQueryValue | null | undefined): number {
+  return Number(value ?? 0);
+}
+
+/**
+ * Converts bigint-like raw SQL values into bigint storage totals.
+ */
+function queryBigInt(value: NumericQueryValue | null | undefined): bigint {
+  return BigInt((value ?? 0).toString());
+}
+
+/**
+ * Builds one storage summary metric from raw SQL aggregate columns.
+ */
+function createQueryMetric(params: {
+  total: NumericQueryValue;
+  totalUniqueValidators: NumericQueryValue;
+  totalEffectiveBalance: NumericQueryValue;
+}): ClusterSummaryMetric {
+  return {
+    total: queryNumber(params.total),
+    totalUniqueValidators: queryNumber(params.totalUniqueValidators),
+    totalEffectiveBalance: queryBigInt(params.totalEffectiveBalance),
+  };
 }
 
 /**
@@ -39,47 +91,6 @@ interface MutableClusterSummaryMetric {
  */
 export class ClusterStorage {
   constructor(private readonly prisma: PrismaClient) {}
-
-  /**
-   * Creates an empty accumulator for user-count, validator-count, and balance metrics.
-   */
-  private createSummaryMetric(): MutableClusterSummaryMetric {
-    return {
-      userIds: new Set<string>(),
-      validatorIndexes: new Set<number>(),
-      totalEffectiveBalance: BigInt(0),
-    };
-  }
-
-  /**
-   * Adds one user to a metric while keeping the user count distinct.
-   */
-  private addMetricUser(metric: MutableClusterSummaryMetric, userId: string): void {
-    metric.userIds.add(userId);
-  }
-
-  /**
-   * Adds one validator membership to a metric and keeps validator count distinct by index.
-   */
-  private addMetricValidator(
-    metric: MutableClusterSummaryMetric,
-    validatorIndex: number,
-    effectiveBalance: bigint,
-  ): void {
-    metric.validatorIndexes.add(validatorIndex);
-    metric.totalEffectiveBalance += effectiveBalance;
-  }
-
-  /**
-   * Converts a mutable metric accumulator into the API storage summary shape.
-   */
-  private finalizeSummaryMetric(metric: MutableClusterSummaryMetric): ClusterSummaryMetric {
-    return {
-      total: metric.userIds.size,
-      totalUniqueValidators: metric.validatorIndexes.size,
-      totalEffectiveBalance: metric.totalEffectiveBalance,
-    };
-  }
 
   /**
    * Removes duplicate validator indexes while preserving the first occurrence.
@@ -275,154 +286,182 @@ export class ClusterStorage {
    * Get a cross-user summary of clusters and validator membership counts.
    */
   async getSummary() {
-    const [clusters, users] = await Promise.all([
-      this.prisma.cluster.findMany({
-        include: {
-          owner: { select: { username: true, telegramId: true, hasBlockedBot: true } },
-          validators: {
-            select: {
-              validatorIndex: true,
-              validator: {
-                select: {
-                  effectiveBalance: true,
-                },
-              },
-            },
-          },
-          _count: { select: { validators: true } },
+    const rows = await this.prisma.$queryRaw<ClusterSummaryQueryRow[]>(Prisma.sql`
+      WITH cluster_memberships AS (
+        SELECT
+          c.id AS cluster_id,
+          c.name AS cluster_name,
+          c.owner_id AS cluster_owner_id,
+          c.created_at AS cluster_created_at,
+          c.lido_operator_id AS cluster_lido_operator_id,
+          CASE WHEN u.telegram_id IS NULL THEN 'annon' ELSE u.username END AS cluster_owner_username,
+          u.telegram_id AS owner_telegram_id,
+          u.has_blocked_bot AS owner_has_blocked_bot,
+          cv.validator_index AS validator_index,
+          COALESCE(v.effective_balance, 0)::bigint AS effective_balance
+        FROM "cluster" c
+        INNER JOIN "user" u ON u.id = c.owner_id
+        LEFT JOIN "cluster_validator" cv ON cv.cluster_id = c.id
+        LEFT JOIN "validator" v ON v.id = cv.validator_index
+      ),
+      cluster_summaries AS (
+        SELECT
+          cluster_id,
+          cluster_name,
+          cluster_owner_id,
+          cluster_created_at,
+          cluster_owner_username,
+          COUNT(validator_index)::bigint AS cluster_validator_count,
+          COALESCE(SUM(effective_balance), 0)::bigint AS cluster_effective_balance
+        FROM cluster_memberships
+        GROUP BY
+          cluster_id,
+          cluster_name,
+          cluster_owner_id,
+          cluster_created_at,
+          cluster_owner_username
+      ),
+      active_memberships AS (
+        SELECT *
+        FROM cluster_memberships
+        WHERE
+          validator_index IS NOT NULL
+          AND NOT (owner_telegram_id IS NOT NULL AND owner_has_blocked_bot)
+      ),
+      blocked_memberships AS (
+        SELECT *
+        FROM cluster_memberships
+        WHERE
+          validator_index IS NOT NULL
+          AND owner_telegram_id IS NOT NULL
+          AND owner_has_blocked_bot
+      ),
+      inactive_users AS (
+        SELECT
+          COUNT(*) FILTER (WHERE u.telegram_id IS NULL)::bigint AS inactive_annon,
+          COUNT(*) FILTER (WHERE u.telegram_id IS NOT NULL)::bigint AS inactive_tg
+        FROM "user" u
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM "cluster" c
+          INNER JOIN "cluster_validator" cv ON cv.cluster_id = c.id
+          WHERE c.owner_id = u.id
+        )
+      ),
+      summary AS (
+        SELECT
+          (SELECT COUNT(*)::bigint FROM "cluster") AS total_clusters,
+          (SELECT COUNT(DISTINCT cluster_owner_id)::bigint FROM active_memberships) AS active_total,
+          (SELECT COUNT(DISTINCT validator_index)::bigint FROM active_memberships) AS active_unique_validators,
+          (SELECT COALESCE(SUM(effective_balance), 0)::bigint FROM active_memberships) AS active_effective_balance,
+          (SELECT COUNT(DISTINCT cluster_owner_id)::bigint FROM active_memberships WHERE owner_telegram_id IS NOT NULL) AS telegram_total,
+          (SELECT COUNT(DISTINCT validator_index)::bigint FROM active_memberships WHERE owner_telegram_id IS NOT NULL) AS telegram_unique_validators,
+          (SELECT COALESCE(SUM(effective_balance), 0)::bigint FROM active_memberships WHERE owner_telegram_id IS NOT NULL) AS telegram_effective_balance,
+          (SELECT COUNT(DISTINCT cluster_owner_id)::bigint FROM active_memberships WHERE cluster_lido_operator_id IS NOT NULL) AS lido_total,
+          (SELECT COUNT(DISTINCT validator_index)::bigint FROM active_memberships WHERE cluster_lido_operator_id IS NOT NULL) AS lido_unique_validators,
+          (SELECT COALESCE(SUM(effective_balance), 0)::bigint FROM active_memberships WHERE cluster_lido_operator_id IS NOT NULL) AS lido_effective_balance,
+          (SELECT COUNT(DISTINCT cluster_owner_id)::bigint FROM active_memberships WHERE owner_telegram_id IS NULL) AS annon_total,
+          (SELECT COUNT(DISTINCT validator_index)::bigint FROM active_memberships WHERE owner_telegram_id IS NULL) AS annon_unique_validators,
+          (SELECT COALESCE(SUM(effective_balance), 0)::bigint FROM active_memberships WHERE owner_telegram_id IS NULL) AS annon_effective_balance,
+          (SELECT COUNT(DISTINCT cluster_owner_id)::bigint FROM blocked_memberships) AS blocked_total,
+          (SELECT COUNT(DISTINCT validator_index)::bigint FROM blocked_memberships) AS blocked_unique_validators,
+          (SELECT COALESCE(SUM(effective_balance), 0)::bigint FROM blocked_memberships) AS blocked_effective_balance,
+          inactive_users.inactive_annon,
+          inactive_users.inactive_tg
+        FROM inactive_users
+      )
+      SELECT
+        summary.total_clusters,
+        summary.active_total,
+        summary.active_unique_validators,
+        summary.active_effective_balance,
+        summary.telegram_total,
+        summary.telegram_unique_validators,
+        summary.telegram_effective_balance,
+        summary.lido_total,
+        summary.lido_unique_validators,
+        summary.lido_effective_balance,
+        summary.annon_total,
+        summary.annon_unique_validators,
+        summary.annon_effective_balance,
+        summary.blocked_total,
+        summary.blocked_unique_validators,
+        summary.blocked_effective_balance,
+        summary.inactive_annon,
+        summary.inactive_tg,
+        cluster_summaries.cluster_id,
+        cluster_summaries.cluster_name,
+        cluster_summaries.cluster_owner_id,
+        cluster_summaries.cluster_owner_username,
+        cluster_summaries.cluster_validator_count,
+        cluster_summaries.cluster_effective_balance
+      FROM summary
+      LEFT JOIN cluster_summaries ON TRUE
+      ORDER BY cluster_summaries.cluster_created_at DESC NULLS LAST
+    `);
+
+    const summaryRow = rows[0];
+
+    if (summaryRow === undefined) {
+      throw new Error('Cluster summary query returned no rows');
+    }
+
+    const clusterSummaries = rows.flatMap((row) => {
+      if (row.cluster_id === null) {
+        return [];
+      }
+
+      return [
+        {
+          id: row.cluster_id,
+          name: row.cluster_name ?? '',
+          ownerId: row.cluster_owner_id ?? '',
+          ownerUsername: row.cluster_owner_username ?? 'annon',
+          validatorCount: queryNumber(row.cluster_validator_count),
+          effectiveBalance: queryBigInt(row.cluster_effective_balance),
         },
-        orderBy: { createdAt: 'desc' },
-      }),
-      this.prisma.user.findMany({
-        select: { id: true, telegramId: true },
-      }),
-    ]);
-
-    const activeUsers = this.createSummaryMetric();
-    const telegramActiveUsers = this.createSummaryMetric();
-    const lidoActiveUsers = this.createSummaryMetric();
-    const annonActiveUsers = this.createSummaryMetric();
-    const tgBlockedUsers = this.createSummaryMetric();
-    const usersWithValidatorLoadedClusters = new Set<string>();
-
-    const clusterSummaries = clusters.map((cluster) => {
-      let effectiveBalance = BigInt(0);
-
-      for (const clusterValidator of cluster.validators) {
-        const validatorEffectiveBalance = clusterValidator.validator.effectiveBalance ?? BigInt(0);
-
-        effectiveBalance += validatorEffectiveBalance;
-      }
-
-      if (cluster.validators.length > 0) {
-        usersWithValidatorLoadedClusters.add(cluster.ownerId);
-
-        const ownerIsBlockedTelegram =
-          cluster.owner.telegramId !== null && cluster.owner.hasBlockedBot;
-        const ownerIsTelegram = cluster.owner.telegramId !== null;
-
-        if (ownerIsBlockedTelegram) {
-          this.addMetricUser(tgBlockedUsers, cluster.ownerId);
-        } else {
-          this.addMetricUser(activeUsers, cluster.ownerId);
-
-          if (ownerIsTelegram) {
-            this.addMetricUser(telegramActiveUsers, cluster.ownerId);
-          } else {
-            this.addMetricUser(annonActiveUsers, cluster.ownerId);
-          }
-
-          if (cluster.lidoOperatorId !== null) {
-            this.addMetricUser(lidoActiveUsers, cluster.ownerId);
-          }
-        }
-
-        // Validator totals are accumulated per category from each matching cluster.
-        for (const clusterValidator of cluster.validators) {
-          const validatorEffectiveBalance =
-            clusterValidator.validator.effectiveBalance ?? BigInt(0);
-
-          if (ownerIsBlockedTelegram) {
-            this.addMetricValidator(
-              tgBlockedUsers,
-              clusterValidator.validatorIndex,
-              validatorEffectiveBalance,
-            );
-          } else {
-            this.addMetricValidator(
-              activeUsers,
-              clusterValidator.validatorIndex,
-              validatorEffectiveBalance,
-            );
-
-            if (ownerIsTelegram) {
-              this.addMetricValidator(
-                telegramActiveUsers,
-                clusterValidator.validatorIndex,
-                validatorEffectiveBalance,
-              );
-            } else {
-              this.addMetricValidator(
-                annonActiveUsers,
-                clusterValidator.validatorIndex,
-                validatorEffectiveBalance,
-              );
-            }
-
-            if (cluster.lidoOperatorId !== null) {
-              this.addMetricValidator(
-                lidoActiveUsers,
-                clusterValidator.validatorIndex,
-                validatorEffectiveBalance,
-              );
-            }
-          }
-        }
-      }
-
-      const ownerUsername = cluster.owner.telegramId === null ? 'annon' : cluster.owner.username;
-
-      return {
-        id: cluster.id,
-        name: cluster.name,
-        ownerId: cluster.ownerId,
-        ownerUsername,
-        validatorCount: cluster._count.validators,
-        effectiveBalance,
-      };
+      ];
     });
 
-    const inactiveUsers = users.reduce(
-      (counts, user) => {
-        if (usersWithValidatorLoadedClusters.has(user.id)) {
-          return counts;
-        }
-
-        counts.total += 1;
-
-        if (user.telegramId === null) {
-          counts.annon += 1;
-        } else {
-          counts.tg += 1;
-        }
-
-        return counts;
-      },
-      { total: 0, annon: 0, tg: 0 },
-    );
+    const inactiveAnnon = queryNumber(summaryRow.inactive_annon);
+    const inactiveTg = queryNumber(summaryRow.inactive_tg);
 
     return {
-      totalClusters: clusters.length,
+      totalClusters: queryNumber(summaryRow.total_clusters),
       activeUsers: {
-        ...this.finalizeSummaryMetric(activeUsers),
+        ...createQueryMetric({
+          total: summaryRow.active_total,
+          totalUniqueValidators: summaryRow.active_unique_validators,
+          totalEffectiveBalance: summaryRow.active_effective_balance,
+        }),
         details: {
-          telegram: this.finalizeSummaryMetric(telegramActiveUsers),
-          lido: this.finalizeSummaryMetric(lidoActiveUsers),
-          annon: this.finalizeSummaryMetric(annonActiveUsers),
+          telegram: createQueryMetric({
+            total: summaryRow.telegram_total,
+            totalUniqueValidators: summaryRow.telegram_unique_validators,
+            totalEffectiveBalance: summaryRow.telegram_effective_balance,
+          }),
+          lido: createQueryMetric({
+            total: summaryRow.lido_total,
+            totalUniqueValidators: summaryRow.lido_unique_validators,
+            totalEffectiveBalance: summaryRow.lido_effective_balance,
+          }),
+          annon: createQueryMetric({
+            total: summaryRow.annon_total,
+            totalUniqueValidators: summaryRow.annon_unique_validators,
+            totalEffectiveBalance: summaryRow.annon_effective_balance,
+          }),
         },
       },
-      tgBlockedUsers: this.finalizeSummaryMetric(tgBlockedUsers),
-      inactiveUsers,
+      tgBlockedUsers: createQueryMetric({
+        total: summaryRow.blocked_total,
+        totalUniqueValidators: summaryRow.blocked_unique_validators,
+        totalEffectiveBalance: summaryRow.blocked_effective_balance,
+      }),
+      inactiveUsers: {
+        total: inactiveAnnon + inactiveTg,
+        annon: inactiveAnnon,
+        tg: inactiveTg,
+      },
       clusters: clusterSummaries,
     };
   }

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -21,12 +21,65 @@ interface UpdateClusterWithValidatorsData extends UpdateClusterData {
 
 type UpdateClusterWithLidoOperatorData = UpdateClusterWithValidatorsData;
 
+interface ClusterSummaryMetric {
+  total: number;
+  totalUniqueValidators: number;
+  totalEffectiveBalance: bigint;
+}
+
+interface MutableClusterSummaryMetric {
+  userIds: Set<string>;
+  validatorIndexes: Set<number>;
+  totalEffectiveBalance: bigint;
+}
+
 /**
  * ClusterStorage - Database persistence layer for cluster operations
  * Uses Prisma ORM for standard CRUD operations
  */
 export class ClusterStorage {
   constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Creates an empty accumulator for user-count, validator-count, and balance metrics.
+   */
+  private createSummaryMetric(): MutableClusterSummaryMetric {
+    return {
+      userIds: new Set<string>(),
+      validatorIndexes: new Set<number>(),
+      totalEffectiveBalance: BigInt(0),
+    };
+  }
+
+  /**
+   * Adds one user to a metric while keeping the user count distinct.
+   */
+  private addMetricUser(metric: MutableClusterSummaryMetric, userId: string): void {
+    metric.userIds.add(userId);
+  }
+
+  /**
+   * Adds one validator membership to a metric and keeps validator count distinct by index.
+   */
+  private addMetricValidator(
+    metric: MutableClusterSummaryMetric,
+    validatorIndex: number,
+    effectiveBalance: bigint,
+  ): void {
+    metric.validatorIndexes.add(validatorIndex);
+    metric.totalEffectiveBalance += effectiveBalance;
+  }
+
+  /**
+   * Converts a mutable metric accumulator into the API storage summary shape.
+   */
+  private finalizeSummaryMetric(metric: MutableClusterSummaryMetric): ClusterSummaryMetric {
+    return {
+      total: metric.userIds.size,
+      totalUniqueValidators: metric.validatorIndexes.size,
+      totalEffectiveBalance: metric.totalEffectiveBalance,
+    };
+  }
 
   /**
    * Removes duplicate validator indexes while preserving the first occurrence.
@@ -222,12 +275,13 @@ export class ClusterStorage {
    * Get a cross-user summary of clusters and validator membership counts.
    */
   async getSummary() {
-    const [clusters, uniqueValidators, totalUsers] = await Promise.all([
+    const [clusters, users] = await Promise.all([
       this.prisma.cluster.findMany({
         include: {
-          owner: { select: { username: true, telegramId: true } },
+          owner: { select: { username: true, telegramId: true, hasBlockedBot: true } },
           validators: {
             select: {
+              validatorIndex: true,
               validator: {
                 select: {
                   effectiveBalance: true,
@@ -239,36 +293,136 @@ export class ClusterStorage {
         },
         orderBy: { createdAt: 'desc' },
       }),
-      this.prisma.clusterValidator.groupBy({
-        by: ['validatorIndex'],
+      this.prisma.user.findMany({
+        select: { id: true, telegramId: true },
       }),
-      this.prisma.user.count(),
     ]);
-    let totalEffectiveBalance = BigInt(0);
+
+    const activeUsers = this.createSummaryMetric();
+    const telegramActiveUsers = this.createSummaryMetric();
+    const lidoActiveUsers = this.createSummaryMetric();
+    const annonActiveUsers = this.createSummaryMetric();
+    const tgBlockedUsers = this.createSummaryMetric();
+    const usersWithValidatorLoadedClusters = new Set<string>();
+
     const clusterSummaries = clusters.map((cluster) => {
       let effectiveBalance = BigInt(0);
 
       for (const clusterValidator of cluster.validators) {
-        effectiveBalance += clusterValidator.validator.effectiveBalance ?? BigInt(0);
+        const validatorEffectiveBalance = clusterValidator.validator.effectiveBalance ?? BigInt(0);
+
+        effectiveBalance += validatorEffectiveBalance;
       }
 
-      totalEffectiveBalance += effectiveBalance;
+      if (cluster.validators.length > 0) {
+        usersWithValidatorLoadedClusters.add(cluster.ownerId);
+
+        const ownerIsBlockedTelegram =
+          cluster.owner.telegramId !== null && cluster.owner.hasBlockedBot;
+        const ownerIsTelegram = cluster.owner.telegramId !== null;
+
+        if (ownerIsBlockedTelegram) {
+          this.addMetricUser(tgBlockedUsers, cluster.ownerId);
+        } else {
+          this.addMetricUser(activeUsers, cluster.ownerId);
+
+          if (ownerIsTelegram) {
+            this.addMetricUser(telegramActiveUsers, cluster.ownerId);
+          } else {
+            this.addMetricUser(annonActiveUsers, cluster.ownerId);
+          }
+
+          if (cluster.lidoOperatorId !== null) {
+            this.addMetricUser(lidoActiveUsers, cluster.ownerId);
+          }
+        }
+
+        // Validator totals are accumulated per category from each matching cluster.
+        for (const clusterValidator of cluster.validators) {
+          const validatorEffectiveBalance =
+            clusterValidator.validator.effectiveBalance ?? BigInt(0);
+
+          if (ownerIsBlockedTelegram) {
+            this.addMetricValidator(
+              tgBlockedUsers,
+              clusterValidator.validatorIndex,
+              validatorEffectiveBalance,
+            );
+          } else {
+            this.addMetricValidator(
+              activeUsers,
+              clusterValidator.validatorIndex,
+              validatorEffectiveBalance,
+            );
+
+            if (ownerIsTelegram) {
+              this.addMetricValidator(
+                telegramActiveUsers,
+                clusterValidator.validatorIndex,
+                validatorEffectiveBalance,
+              );
+            } else {
+              this.addMetricValidator(
+                annonActiveUsers,
+                clusterValidator.validatorIndex,
+                validatorEffectiveBalance,
+              );
+            }
+
+            if (cluster.lidoOperatorId !== null) {
+              this.addMetricValidator(
+                lidoActiveUsers,
+                clusterValidator.validatorIndex,
+                validatorEffectiveBalance,
+              );
+            }
+          }
+        }
+      }
+
+      const ownerUsername = cluster.owner.telegramId === null ? 'annon' : cluster.owner.username;
 
       return {
         id: cluster.id,
         name: cluster.name,
         ownerId: cluster.ownerId,
-        ownerUsername: cluster.owner.telegramId === null ? 'annon' : cluster.owner.username,
+        ownerUsername,
         validatorCount: cluster._count.validators,
         effectiveBalance,
       };
     });
 
+    const inactiveUsers = users.reduce(
+      (counts, user) => {
+        if (usersWithValidatorLoadedClusters.has(user.id)) {
+          return counts;
+        }
+
+        counts.total += 1;
+
+        if (user.telegramId === null) {
+          counts.annon += 1;
+        } else {
+          counts.tg += 1;
+        }
+
+        return counts;
+      },
+      { total: 0, annon: 0, tg: 0 },
+    );
+
     return {
       totalClusters: clusters.length,
-      totalUsers,
-      totalUniqueValidators: uniqueValidators.length,
-      totalEffectiveBalance,
+      activeUsers: {
+        ...this.finalizeSummaryMetric(activeUsers),
+        details: {
+          telegram: this.finalizeSummaryMetric(telegramActiveUsers),
+          lido: this.finalizeSummaryMetric(lidoActiveUsers),
+          annon: this.finalizeSummaryMetric(annonActiveUsers),
+        },
+      },
+      tgBlockedUsers: this.finalizeSummaryMetric(tgBlockedUsers),
+      inactiveUsers,
       clusters: clusterSummaries,
     };
   }


### PR DESCRIPTION
Summary
- Replaces noisy top-level user totals with active, blocked Telegram, and inactive user buckets.
- Keeps Telegram and anonymous active buckets inclusive of Lido stats while making the Lido bucket count only Lido clusters.
- Formats nested bigint balance totals into chain-aware token amounts in the summary route.

Validation
- pnpm --filter @beacon-indexer/api test -- src/storage/cluster.test.ts src/routers/cluster/summary.test.ts
- pnpm --filter @beacon-indexer/api typecheck
- pnpm --filter @beacon-indexer/api lint
- git push pre-push hook: pnpm -r run lint