### PR TITLE
Compact daily archive detail cleanup

### DIFF
--- a/packages/indexer/e2e/archive/dailyArchiveDetailCleanup.test.ts
+++ b/packages/indexer/e2e/archive/dailyArchiveDetailCleanup.test.ts
@@ -9,6 +9,7 @@ describe('Daily Archive Detail Cleanup Process', () => {
   let cleanupController: DailyArchiveDetailCleanupController;
 
   const ARCHIVED_DAY = new Date('2025-12-16T00:00:00.000Z');
+  const OLDEST_DAY = new Date('2025-11-30T00:00:00.000Z');
   const OLD_DAY = new Date('2025-12-01T00:00:00.000Z');
   const RETAINED_DAY = new Date('2025-12-02T00:00:00.000Z');
 
@@ -27,7 +28,6 @@ describe('Daily Archive Detail Cleanup Process', () => {
       new DailyArchiveDetailCleanupStorage(prisma, 14),
       {
         batchSize: 2,
-        maxBatchesPerRun: 2,
       },
     );
   });
@@ -152,24 +152,24 @@ describe('Daily Archive Detail Cleanup Process', () => {
   }
 
   /**
-   * CLEANUP BUDGET: Cleans old daily JSON detail in bounded batches.
+   * CLEANUP COMPLETION: Cleans one old daily partition in bounded batches.
    *
-   * The cleanup worker runs independently from daily archiving. Each run has a
-   * maximum number of batches so a backlog cannot monopolize the database.
+   * The cleanup worker runs independently from daily archiving. Each wake fully
+   * clears one selected day before vacuuming that partition.
    */
-  it('cleans old daily JSON detail using the configured batch budget', async () => {
+  it('cleans one old daily partition completely using bounded batches', async () => {
     // Create old rows outside the 14-day retention window.
     await createDailyArchiveRows(OLD_DAY, 5);
 
     // Create retained rows exactly at the cutoff so they must keep JSON detail.
     await createDailyArchiveRows(RETAINED_DAY, 3);
 
-    // Run one cleanup pass with batchSize=2 and maxBatchesPerRun=2.
+    // Run one cleanup pass with batchSize=2 so the day needs three committed batches.
     const result = await cleanupController.cleanupOldDailyDetails();
-    expect(result).toEqual({ batches: 2, rows: 4 });
+    expect(result).toEqual({ batches: 3, rows: 5, vacuumedPartitions: 1 });
 
-    // Verify only four old rows were cleaned by this pass.
-    await expect(countDetailRows(OLD_DAY)).resolves.toEqual({ cleaned: 4, remaining: 1 });
+    // Verify the whole old partition was cleaned by this wake.
+    await expect(countDetailRows(OLD_DAY)).resolves.toEqual({ cleaned: 5, remaining: 0 });
 
     // Verify rows inside the retention window still keep JSON detail.
     await expect(countDetailRows(RETAINED_DAY)).resolves.toEqual({ cleaned: 0, remaining: 3 });
@@ -188,19 +188,25 @@ describe('Daily Archive Detail Cleanup Process', () => {
   });
 
   /**
-   * CLEANUP CONVERGENCE: Repeated cleanup runs eventually remove all old detail.
+   * ONE-DAY SCOPE: Each cleanup wake finishes one day and leaves later old days for later wakes.
    */
-  it('continues cleanup on later runs until no old daily JSON detail remains', async () => {
-    // Create one more old row than a single cleanup run can process.
-    await createDailyArchiveRows(OLD_DAY, 5);
+  it('continues cleanup on later runs with the next old daily partition', async () => {
+    // Create two old daily partitions so the test can observe one-day-per-wake behavior.
+    await createDailyArchiveRows(OLDEST_DAY, 3);
+    await createDailyArchiveRows(OLD_DAY, 2);
 
-    // Run two cleanup passes so the second pass finishes the remaining row.
-    await cleanupController.cleanupOldDailyDetails();
+    // Run the first cleanup pass so only the oldest partition is completed and vacuumed.
+    const firstResult = await cleanupController.cleanupOldDailyDetails();
+    expect(firstResult).toEqual({ batches: 2, rows: 3, vacuumedPartitions: 1 });
+    await expect(countDetailRows(OLDEST_DAY)).resolves.toEqual({ cleaned: 3, remaining: 0 });
+    await expect(countDetailRows(OLD_DAY)).resolves.toEqual({ cleaned: 0, remaining: 2 });
+
+    // Run the second cleanup pass so the next old partition is processed.
     const result = await cleanupController.cleanupOldDailyDetails();
 
-    // Verify the second pass processed only the leftover old row.
-    expect(result).toEqual({ batches: 1, rows: 1 });
-    await expect(countDetailRows(OLD_DAY)).resolves.toEqual({ cleaned: 5, remaining: 0 });
+    // Verify later wakes continue from the next old partition, not from already-vacuumed days.
+    expect(result).toEqual({ batches: 1, rows: 2, vacuumedPartitions: 1 });
+    await expect(countDetailRows(OLD_DAY)).resolves.toEqual({ cleaned: 2, remaining: 0 });
   });
 
   /**
@@ -215,7 +221,7 @@ describe('Daily Archive Detail Cleanup Process', () => {
 
     // Run cleanup so only parent-visible rows are eligible.
     const result = await cleanupController.cleanupOldDailyDetails();
-    expect(result).toEqual({ batches: 1, rows: 2 });
+    expect(result).toEqual({ batches: 1, rows: 2, vacuumedPartitions: 1 });
 
     // Verify published rows were cleaned normally.
     await expect(countDetailRows(OLD_DAY)).resolves.toEqual({ cleaned: 2, remaining: 0 });

--- a/packages/indexer/src/services/consensus/controllers/dailyArchiveDetailCleanup.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/dailyArchiveDetailCleanup.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DailyArchiveDetailCleanupController } from './dailyArchiveDetailCleanup.js';
+
+import {
+  DailyArchiveDetailCleanupStorage,
+  DailyArchiveDetailCleanupTarget,
+} from '@/src/services/consensus/storage/dailyArchiveDetailCleanup.js';
+
+describe('DailyArchiveDetailCleanupController', () => {
+  /**
+   * Scenario: one old daily partition still has JSON detail across several batches.
+   * The controller must keep cleaning the selected day until the partition is done,
+   * then vacuum that exact partition once so PostgreSQL releases the dead tuple space.
+   */
+  it('cleans one daily partition to completion and vacuums it', async () => {
+    // This target represents the oldest daily archive partition outside the detail retention window.
+    const target: DailyArchiveDetailCleanupTarget = {
+      targetDay: new Date('2025-12-01T00:00:00.000Z'),
+      partitionName: 'validator_daily_archive_20251201',
+    };
+
+    // The first two batches are full and the third is partial, proving the controller continues
+    // within the same wake until the selected day has no more detail rows to clear.
+    const cleanDailyArchiveDetailBatch = vi
+      .fn()
+      .mockResolvedValueOnce(5_000)
+      .mockResolvedValueOnce(5_000)
+      .mockResolvedValueOnce(250);
+
+    // This storage fake exposes only the cleanup methods used by the controller.
+    const storage = {
+      findDailyArchiveDetailCleanupTarget: vi.fn().mockResolvedValue(target),
+      cleanDailyArchiveDetailBatch,
+      vacuumDailyArchivePartition: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DailyArchiveDetailCleanupStorage;
+
+    // Run one cleanup wake with the production default batch size.
+    const controller = new DailyArchiveDetailCleanupController(storage);
+    const result = await controller.cleanupOldDailyDetails();
+
+    // The result reports only batches that updated rows and confirms one partition was vacuumed.
+    expect(result).toEqual({ batches: 3, rows: 10_250, vacuumedPartitions: 1 });
+
+    // Every batch targets the same day and uses the 5k default batch size.
+    expect(cleanDailyArchiveDetailBatch).toHaveBeenCalledTimes(3);
+    expect(cleanDailyArchiveDetailBatch).toHaveBeenNthCalledWith(1, target.targetDay, 5_000);
+    expect(cleanDailyArchiveDetailBatch).toHaveBeenNthCalledWith(2, target.targetDay, 5_000);
+    expect(cleanDailyArchiveDetailBatch).toHaveBeenNthCalledWith(3, target.targetDay, 5_000);
+
+    // The partition is vacuumed after every JSON detail batch for the day has committed.
+    expect(storage.vacuumDailyArchivePartition).toHaveBeenCalledWith(target.partitionName);
+  });
+
+  /**
+   * Scenario: the selected partition has no remaining JSON detail by the time the batch runs.
+   * The controller must not loop; it can vacuum the selected partition immediately.
+   */
+  it('vacuums the selected partition when the first batch updates zero rows', async () => {
+    // This target was selected by the storage scan before the batch found no rows left to update.
+    const target: DailyArchiveDetailCleanupTarget = {
+      targetDay: new Date('2025-12-01T00:00:00.000Z'),
+      partitionName: 'validator_daily_archive_20251201',
+    };
+
+    // Returning zero simulates a scan racing with rows that were already cleared.
+    const storage = {
+      findDailyArchiveDetailCleanupTarget: vi.fn().mockResolvedValue(target),
+      cleanDailyArchiveDetailBatch: vi.fn().mockResolvedValue(0),
+      vacuumDailyArchivePartition: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DailyArchiveDetailCleanupStorage;
+
+    // Run the cleanup wake against a selected partition that no longer has detail rows.
+    const controller = new DailyArchiveDetailCleanupController(storage);
+    const result = await controller.cleanupOldDailyDetails();
+
+    // Zero updated rows should not count as a batch, but the partition still needs compaction.
+    expect(result).toEqual({ batches: 0, rows: 0, vacuumedPartitions: 1 });
+    expect(storage.vacuumDailyArchivePartition).toHaveBeenCalledWith(target.partitionName);
+  });
+
+  /**
+   * Scenario: there is no old daily partition outside the configured retention window.
+   * The controller must do no database work beyond asking storage for a target.
+   */
+  it('does nothing when no daily partition is eligible', async () => {
+    // A null target means retention has not expired for any daily archive partition.
+    const storage = {
+      findDailyArchiveDetailCleanupTarget: vi.fn().mockResolvedValue(null),
+      cleanDailyArchiveDetailBatch: vi.fn(),
+      vacuumDailyArchivePartition: vi.fn(),
+    } as unknown as DailyArchiveDetailCleanupStorage;
+
+    // Run one cleanup wake against an empty eligibility set.
+    const controller = new DailyArchiveDetailCleanupController(storage);
+    const result = await controller.cleanupOldDailyDetails();
+
+    // No rows or partitions are changed when there is no eligible target.
+    expect(result).toEqual({ batches: 0, rows: 0, vacuumedPartitions: 0 });
+    expect(storage.cleanDailyArchiveDetailBatch).not.toHaveBeenCalled();
+    expect(storage.vacuumDailyArchivePartition).not.toHaveBeenCalled();
+  });
+});

--- a/packages/indexer/src/services/consensus/controllers/dailyArchiveDetailCleanup.ts
+++ b/packages/indexer/src/services/consensus/controllers/dailyArchiveDetailCleanup.ts
@@ -3,43 +3,46 @@ import { DailyArchiveDetailCleanupStorage } from '../storage/dailyArchiveDetailC
 export type DailyArchiveDetailCleanupResult = {
   batches: number;
   rows: number;
+  vacuumedPartitions: number;
 };
 
 export type DailyArchiveDetailCleanupOptions = {
   batchSize: number;
-  maxBatchesPerRun: number;
 };
 
-const DEFAULT_BATCH_SIZE = 10_000;
-const DEFAULT_MAX_BATCHES_PER_RUN = 100;
+const DEFAULT_BATCH_SIZE = 5_000;
 
 /**
  * DailyArchiveDetailCleanupController - Coordinates old daily archive JSON cleanup.
  */
 export class DailyArchiveDetailCleanupController {
   private readonly batchSize: number;
-  private readonly maxBatchesPerRun: number;
 
   constructor(
     private readonly storage: DailyArchiveDetailCleanupStorage,
     options: Partial<DailyArchiveDetailCleanupOptions> = {},
   ) {
     this.batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
-    this.maxBatchesPerRun = options.maxBatchesPerRun ?? DEFAULT_MAX_BATCHES_PER_RUN;
   }
 
   /**
-   * Run cleanup batches until there is no work or this wake reaches its budget.
+   * Clean one eligible daily partition completely and vacuum it.
    *
-   * The budget prevents a large backlog from turning one cleanup wake into a
-   * long database job. Later wakes continue from rows that still have JSON.
+   * Each batch commits independently through storage. The target is selected by
+   * scanning current archive rows, so a restarted worker starts from database state.
    */
   async cleanupOldDailyDetails(): Promise<DailyArchiveDetailCleanupResult> {
+    const target = await this.storage.findDailyArchiveDetailCleanupTarget();
+    if (!target) {
+      return { batches: 0, rows: 0, vacuumedPartitions: 0 };
+    }
+
     let batches = 0;
     let rows = 0;
+    let cleaned = this.batchSize;
 
-    for (let batch = 0; batch < this.maxBatchesPerRun; batch++) {
-      const cleaned = await this.storage.cleanOldDailyArchiveDetailBatch(this.batchSize);
+    while (cleaned === this.batchSize) {
+      cleaned = await this.storage.cleanDailyArchiveDetailBatch(target.targetDay, this.batchSize);
       if (cleaned === 0) {
         break;
       }
@@ -52,6 +55,8 @@ export class DailyArchiveDetailCleanupController {
       }
     }
 
-    return { batches, rows };
+    await this.storage.vacuumDailyArchivePartition(target.partitionName);
+
+    return { batches, rows, vacuumedPartitions: 1 };
   }
 }

--- a/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.test.ts
+++ b/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.test.ts
@@ -4,6 +4,30 @@ import { DailyArchiveDetailCleanupStorage } from './dailyArchiveDetailCleanup.js
 
 describe('DailyArchiveDetailCleanupStorage', () => {
   /**
+   * Scenario: PostgreSQL unexpectedly returns no COUNT row for a cleanup batch.
+   * The storage method should treat the missing result as zero cleaned rows so
+   * the controller can finish the wake without crashing.
+   */
+  it('returns zero when a cleanup batch query returns no count row', async () => {
+    // This Prisma stub simulates an unexpected empty result from the raw COUNT query.
+    const prisma = {
+      $queryRaw: vi.fn().mockResolvedValue([]),
+    };
+
+    // This storage instance exercises the defensive result handling in the batch cleanup path.
+    const storage = new DailyArchiveDetailCleanupStorage(prisma as never, 14);
+
+    // Run one cleanup batch against a daily archive timestamp.
+    const cleaned = await storage.cleanDailyArchiveDetailBatch(
+      new Date('2025-12-01T00:00:00.000Z'),
+      5_000,
+    );
+
+    // A missing COUNT row means no rows can be reported as cleaned.
+    expect(cleaned).toBe(0);
+  });
+
+  /**
    * Scenario: VACUUM FULL receives the expected published daily archive partition.
    * The storage layer must quote the partition name as a PostgreSQL identifier before
    * executing raw SQL because table names cannot be passed as bind parameters.

--- a/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.test.ts
+++ b/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DailyArchiveDetailCleanupStorage } from './dailyArchiveDetailCleanup.js';
+
+describe('DailyArchiveDetailCleanupStorage', () => {
+  /**
+   * Scenario: VACUUM FULL receives the expected published daily archive partition.
+   * The storage layer must quote the partition name as a PostgreSQL identifier before
+   * executing raw SQL because table names cannot be passed as bind parameters.
+   */
+  it('vacuums a validator daily archive partition with the expected table format', async () => {
+    // This Prisma stub captures the raw VACUUM statement without touching a real database.
+    const prisma = {
+      $executeRawUnsafe: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // This storage instance exercises only the partition-name validation and SQL construction path.
+    const storage = new DailyArchiveDetailCleanupStorage(prisma as never, 14);
+
+    // Run VACUUM FULL against a valid daily archive partition name.
+    await storage.vacuumDailyArchivePartition('validator_daily_archive_20251201');
+
+    // The raw SQL targets the quoted partition identifier exactly.
+    expect(prisma.$executeRawUnsafe).toHaveBeenCalledWith(
+      'VACUUM FULL "validator_daily_archive_20251201"',
+    );
+  });
+
+  /**
+   * Scenario: VACUUM FULL receives a table name that is not one of our daily archive partitions.
+   * The storage layer must reject it before constructing raw SQL so cleanup cannot compact an
+   * unexpected table if catalog data or caller input is wrong.
+   */
+  it('rejects partition names outside the validator_daily_archive_yyyymmdd format', async () => {
+    // This Prisma stub proves invalid input is rejected before raw SQL execution.
+    const prisma = {
+      $executeRawUnsafe: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // This storage instance exercises only the partition-name validation path.
+    const storage = new DailyArchiveDetailCleanupStorage(prisma as never, 14);
+
+    // Try a syntactically safe but wrong archive table prefix.
+    await expect(
+      storage.vacuumDailyArchivePartition('validator_hourly_archive_2025120100'),
+    ).rejects.toThrow('Unsafe daily archive partition name: validator_hourly_archive_2025120100');
+
+    // Try a daily archive-like table with the wrong date width.
+    await expect(
+      storage.vacuumDailyArchivePartition('validator_daily_archive_202512'),
+    ).rejects.toThrow('Unsafe daily archive partition name: validator_daily_archive_202512');
+
+    // No raw SQL should run for rejected names.
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+});

--- a/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.ts
+++ b/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.ts
@@ -1,6 +1,11 @@
 import { PrismaClient } from '@beacon-indexer/db';
 import { subDays } from 'date-fns';
 
+export type DailyArchiveDetailCleanupTarget = {
+  targetDay: Date;
+  partitionName: string;
+};
+
 /**
  * DailyArchiveDetailCleanupStorage - Database operations for daily archive JSON cleanup.
  */
@@ -38,24 +43,57 @@ export class DailyArchiveDetailCleanupStorage {
   }
 
   /**
-   * Clear JSON detail from one bounded set of old daily archive rows.
+   * Find the oldest daily partition with JSON detail outside retention.
    *
-   * The batch size limits row locks per cleanup pass. The query only targets
-   * rows that still have JSON detail, so already-cleaned rows are skipped.
+   * Cleanup is intentionally stateless. If the process restarts, the next wake
+   * scans the archive table again and picks the oldest day that still has JSON.
    */
-  async cleanOldDailyArchiveDetailBatch(batchSize: number): Promise<number> {
+  async findDailyArchiveDetailCleanupTarget(): Promise<DailyArchiveDetailCleanupTarget | null> {
     const cleanupCutoff = await this.getCleanupCutoff();
     if (!cleanupCutoff) {
-      return 0;
+      return null;
     }
 
+    const [target] = await this.prisma.$queryRaw<
+      Array<{
+        target_day: Date;
+        partition_name: string;
+      }>
+    >`
+      SELECT
+        archive."timestamp" AS target_day,
+        archive.tableoid::regclass::text AS partition_name
+      FROM validator_daily_archive archive
+      WHERE archive."timestamp" < ${cleanupCutoff}::timestamp
+        AND (archive.data_by_slot IS NOT NULL OR archive.data_by_epoch IS NOT NULL)
+      ORDER BY archive."timestamp" ASC, archive.validator_index ASC
+      LIMIT 1
+    `;
+
+    if (!target) {
+      return null;
+    }
+
+    return {
+      targetDay: target.target_day,
+      partitionName: target.partition_name,
+    };
+  }
+
+  /**
+   * Clear JSON detail from one bounded set of rows for a single daily partition.
+   *
+   * The batch size limits row locks per cleanup pass. The query only targets
+   * rows that still have JSON detail, so restarted cleanup skips null rows.
+   */
+  async cleanDailyArchiveDetailBatch(targetDay: Date, batchSize: number): Promise<number> {
     const [result] = await this.prisma.$queryRaw<Array<{ cleaned: number }>>`
       WITH rows_to_clean AS (
         SELECT tableoid, ctid
         FROM validator_daily_archive
-        WHERE "timestamp" < ${cleanupCutoff}::timestamp
+        WHERE "timestamp" = ${targetDay}::timestamp
           AND (data_by_slot IS NOT NULL OR data_by_epoch IS NOT NULL)
-        ORDER BY "timestamp" ASC, validator_index ASC
+        ORDER BY validator_index ASC
         LIMIT ${batchSize}
       ),
       updated_rows AS (
@@ -71,4 +109,22 @@ export class DailyArchiveDetailCleanupStorage {
 
     return result.cleaned;
   }
+
+  /**
+   * Run VACUUM FULL on the finished daily archive partition.
+   */
+  async vacuumDailyArchivePartition(partitionName: string): Promise<void> {
+    await this.prisma.$executeRawUnsafe(`VACUUM FULL ${quotePostgresIdentifier(partitionName)}`);
+  }
+}
+
+/**
+ * Quote a daily archive partition identifier after rejecting unsafe table names.
+ */
+function quotePostgresIdentifier(identifier: string): string {
+  if (!/^validator_daily_archive_\d{8}$/.test(identifier)) {
+    throw new Error(`Unsafe daily archive partition name: ${identifier}`);
+  }
+
+  return `"${identifier.replaceAll('"', '""')}"`;
 }

--- a/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.ts
+++ b/packages/indexer/src/services/consensus/storage/dailyArchiveDetailCleanup.ts
@@ -107,7 +107,7 @@ export class DailyArchiveDetailCleanupStorage {
       SELECT COUNT(*)::int AS cleaned FROM updated_rows
     `;
 
-    return result.cleaned;
+    return result?.cleaned ?? 0;
   }
 
   /**

--- a/packages/indexer/src/xstate/archive/dailyArchiveDetailCleanup.machine.test.ts
+++ b/packages/indexer/src/xstate/archive/dailyArchiveDetailCleanup.machine.test.ts
@@ -21,7 +21,9 @@ describe('dailyArchiveDetailCleanupMachine', () => {
     vi.useFakeTimers();
 
     // Expose only the controller method that the machine should invoke.
-    const cleanupOldDailyDetails = vi.fn().mockResolvedValue({ batches: 0, rows: 0 });
+    const cleanupOldDailyDetails = vi
+      .fn()
+      .mockResolvedValue({ batches: 0, rows: 0, vacuumedPartitions: 0 });
 
     // Start the actor with the cleanup controller dependency.
     const actor = createActor(dailyArchiveDetailCleanupMachine, {
@@ -48,12 +50,16 @@ describe('dailyArchiveDetailCleanupMachine', () => {
     // Use fake timers to trigger multiple wakeups without waiting.
     vi.useFakeTimers();
 
-    let resolveCleanup!: (value: { batches: number; rows: number }) => void;
+    let resolveCleanup!: (value: {
+      batches: number;
+      rows: number;
+      vacuumedPartitions: number;
+    }) => void;
 
     // Keep the first cleanup pending so the second timer cannot overlap it.
     const cleanupOldDailyDetails = vi.fn(
       () =>
-        new Promise<{ batches: number; rows: number }>((resolve) => {
+        new Promise<{ batches: number; rows: number; vacuumedPartitions: number }>((resolve) => {
           resolveCleanup = resolve;
         }),
     );
@@ -77,7 +83,7 @@ describe('dailyArchiveDetailCleanupMachine', () => {
     expect(cleanupOldDailyDetails).toHaveBeenCalledTimes(1);
 
     // Resolve the first pass and let the machine return to waiting.
-    resolveCleanup({ batches: 1, rows: 10_000 });
+    resolveCleanup({ batches: 1, rows: 10_000, vacuumedPartitions: 1 });
     await vi.waitFor(() => expect(actor.getSnapshot().value).toBe('waiting'));
 
     actor.stop();

--- a/packages/indexer/src/xstate/archive/dailyArchiveDetailCleanup.machine.ts
+++ b/packages/indexer/src/xstate/archive/dailyArchiveDetailCleanup.machine.ts
@@ -68,7 +68,7 @@ export const dailyArchiveDetailCleanupMachine = setup({
           actions: [
             pinoLog(({ event }) => {
               const result = event.output;
-              return `Daily archive detail cleanup completed: batches=${result.batches} rows=${result.rows}`;
+              return `Daily archive detail cleanup completed: batches=${result.batches} rows=${result.rows} vacuumedPartitions=${result.vacuumedPartitions}`;
             }, LOGGER_CONTEXT),
           ],
         },


### PR DESCRIPTION
## Summary

- Clean one eligible daily archive detail partition completely per cleanup wake.
- Use 5k row batches and run VACUUM FULL on the cleaned daily partition.
- Keep cleanup stateless and validate VACUUM targets against validator_daily_archive_YYYYMMDD.

## Validation

- pnpm --filter indexer exec vitest run src/services/consensus/storage/dailyArchiveDetailCleanup.test.ts src/services/consensus/controllers/dailyArchiveDetailCleanup.test.ts src/xstate/archive/dailyArchiveDetailCleanup.machine.test.ts
- pnpm --filter indexer lint
- pnpm --filter indexer type-check
- pnpm test:e2e:local indexer
