### PR TITLE
Add API user claim endpoint

### DIFF
--- a/packages/api/e2e/server.ts
+++ b/packages/api/e2e/server.ts
@@ -12,6 +12,7 @@ import { createLogger } from '@/lib/logger.js';
 import { createPrisma, disconnectPrisma } from '@/lib/prisma.js';
 import { createRouter } from '@/routers/index.js';
 import { createHttpServer } from '@/server.js';
+import { createGnosisClaimWithdrawalsService } from '@/services/gnosis/claim-withdrawals.js';
 import { AnalyticsStorage } from '@/storage/analytics.js';
 import { BlockStorage } from '@/storage/block.js';
 import { BotCommunicationsStorage } from '@/storage/bot-communications.js';
@@ -33,6 +34,9 @@ interface E2EServerOverrides {
   databaseUrl?: string;
   executionRpcUrl?: string;
   nativeTokenDecimals?: number;
+  nodeSentinelPrivateKey?: `0x${string}`;
+  blockchainScDepositAddress?: string;
+  executionExplorerUrl?: string;
   telegramBotToken?: string;
   telegramInitDataMaxAgeSeconds?: number;
   tokenPriceApiUrl?: string;
@@ -138,6 +142,11 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     NATIVE_TOKEN_DECIMALS: String(
       overrides.nativeTokenDecimals ?? process.env.NATIVE_TOKEN_DECIMALS ?? 18,
     ),
+    NODE_SENTINEL_PRIVATE_KEY:
+      overrides.nodeSentinelPrivateKey ?? process.env.NODE_SENTINEL_PRIVATE_KEY,
+    BLOCKCHAIN_SC_DEPOSIT_ADDRESS:
+      overrides.blockchainScDepositAddress ?? process.env.BLOCKCHAIN_SC_DEPOSIT_ADDRESS,
+    EXECUTION_EXPLORER_URL: overrides.executionExplorerUrl ?? process.env.EXECUTION_EXPLORER_URL,
     NODE_ENV: process.env.NODE_ENV ?? 'test',
     TELEGRAM_BOT_TOKEN: overrides.telegramBotToken ?? process.env.TELEGRAM_BOT_TOKEN!,
     TELEGRAM_INIT_DATA_MAX_AGE_SECONDS: String(
@@ -188,6 +197,12 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     botNotificationsStorage: new BotNotificationsStorage(prisma),
     botUsersStorage: new BotUsersStorage(prisma),
     chain: env.CHAIN,
+    claimWithdrawalsService: createGnosisClaimWithdrawalsService({
+      depositContractAddress: env.BLOCKCHAIN_SC_DEPOSIT_ADDRESS,
+      executionExplorerUrl: env.EXECUTION_EXPLORER_URL,
+      privateKey: env.NODE_SENTINEL_PRIVATE_KEY,
+      rpcUrl: env.EXECUTION_RPC_URL,
+    }),
     clusterStorage: new ClusterStorage(prisma),
     executionRpcUrl: env.EXECUTION_RPC_URL,
     incidentStorage: new IncidentStorage(prisma),

--- a/packages/api/e2e/server.ts
+++ b/packages/api/e2e/server.ts
@@ -35,7 +35,6 @@ interface E2EServerOverrides {
   executionRpcUrl?: string;
   nativeTokenDecimals?: number;
   nodeSentinelPrivateKey?: `0x${string}`;
-  executionExplorerUrl?: string;
   telegramBotToken?: string;
   telegramInitDataMaxAgeSeconds?: number;
   tokenPriceApiUrl?: string;
@@ -143,7 +142,6 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     ),
     NODE_SENTINEL_PRIVATE_KEY:
       overrides.nodeSentinelPrivateKey ?? process.env.NODE_SENTINEL_PRIVATE_KEY,
-    EXECUTION_EXPLORER_URL: overrides.executionExplorerUrl ?? process.env.EXECUTION_EXPLORER_URL,
     NODE_ENV: process.env.NODE_ENV ?? 'test',
     TELEGRAM_BOT_TOKEN: overrides.telegramBotToken ?? process.env.TELEGRAM_BOT_TOKEN!,
     TELEGRAM_INIT_DATA_MAX_AGE_SECONDS: String(
@@ -196,7 +194,7 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     chain: env.CHAIN,
     claimWithdrawalsService: createGnosisClaimWithdrawalsService({
       depositContractAddress: beaconHelpers.chainConfig.blockchain.scDepositAddress,
-      executionExplorerUrl: env.EXECUTION_EXPLORER_URL,
+      executionExplorerUrl: beaconHelpers.chainConfig.blockchain.executionExplorerUrl,
       privateKey: env.NODE_SENTINEL_PRIVATE_KEY,
       rpcUrl: env.EXECUTION_RPC_URL,
     }),

--- a/packages/api/e2e/server.ts
+++ b/packages/api/e2e/server.ts
@@ -35,7 +35,6 @@ interface E2EServerOverrides {
   executionRpcUrl?: string;
   nativeTokenDecimals?: number;
   nodeSentinelPrivateKey?: `0x${string}`;
-  blockchainScDepositAddress?: string;
   executionExplorerUrl?: string;
   telegramBotToken?: string;
   telegramInitDataMaxAgeSeconds?: number;
@@ -144,8 +143,6 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     ),
     NODE_SENTINEL_PRIVATE_KEY:
       overrides.nodeSentinelPrivateKey ?? process.env.NODE_SENTINEL_PRIVATE_KEY,
-    BLOCKCHAIN_SC_DEPOSIT_ADDRESS:
-      overrides.blockchainScDepositAddress ?? process.env.BLOCKCHAIN_SC_DEPOSIT_ADDRESS,
     EXECUTION_EXPLORER_URL: overrides.executionExplorerUrl ?? process.env.EXECUTION_EXPLORER_URL,
     NODE_ENV: process.env.NODE_ENV ?? 'test',
     TELEGRAM_BOT_TOKEN: overrides.telegramBotToken ?? process.env.TELEGRAM_BOT_TOKEN!,
@@ -198,7 +195,7 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     botUsersStorage: new BotUsersStorage(prisma),
     chain: env.CHAIN,
     claimWithdrawalsService: createGnosisClaimWithdrawalsService({
-      depositContractAddress: env.BLOCKCHAIN_SC_DEPOSIT_ADDRESS,
+      depositContractAddress: beaconHelpers.chainConfig.blockchain.scDepositAddress,
       executionExplorerUrl: env.EXECUTION_EXPLORER_URL,
       privateKey: env.NODE_SENTINEL_PRIVATE_KEY,
       rpcUrl: env.EXECUTION_RPC_URL,

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -37,7 +37,6 @@ const serverEnv = {
     .string()
     .regex(/^0x[0-9a-fA-F]{64}$/, 'Private key must be a 0x-prefixed 32-byte hex string')
     .optional(),
-  EXECUTION_EXPLORER_URL: z.string().url().optional(),
 };
 
 /**

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -1,4 +1,5 @@
 import { createEnv } from '@t3-oss/env-core';
+import { isAddress } from 'viem';
 import { z } from 'zod';
 
 const serverEnv = {
@@ -31,6 +32,17 @@ const serverEnv = {
   // Coingecko
   COINGECKO_TOKEN_PRICE_API_URL: z.string().url(),
   COINGECKO_TOKEN_NAME: z.string().min(1),
+
+  // Gnosis claim execution
+  NODE_SENTINEL_PRIVATE_KEY: z
+    .string()
+    .regex(/^0x[0-9a-fA-F]{64}$/, 'Private key must be a 0x-prefixed 32-byte hex string')
+    .optional(),
+  BLOCKCHAIN_SC_DEPOSIT_ADDRESS: z
+    .string()
+    .refine(isAddress, 'Invalid deposit contract address')
+    .optional(),
+  EXECUTION_EXPLORER_URL: z.string().url().optional(),
 };
 
 /**

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -1,5 +1,4 @@
 import { createEnv } from '@t3-oss/env-core';
-import { isAddress } from 'viem';
 import { z } from 'zod';
 
 const serverEnv = {
@@ -37,10 +36,6 @@ const serverEnv = {
   NODE_SENTINEL_PRIVATE_KEY: z
     .string()
     .regex(/^0x[0-9a-fA-F]{64}$/, 'Private key must be a 0x-prefixed 32-byte hex string')
-    .optional(),
-  BLOCKCHAIN_SC_DEPOSIT_ADDRESS: z
-    .string()
-    .refine(isAddress, 'Invalid deposit contract address')
     .optional(),
   EXECUTION_EXPLORER_URL: z.string().url().optional(),
 };

--- a/packages/api/src/constants/claim.ts
+++ b/packages/api/src/constants/claim.ts
@@ -1,0 +1,2 @@
+/** Number of days a Telegram user must wait between successful claim transactions. */
+export const CLAIM_COOLDOWN_DAYS = 7;

--- a/packages/api/src/dependencies.ts
+++ b/packages/api/src/dependencies.ts
@@ -4,6 +4,7 @@ import type { ApiProcedures } from '@/auth/middleware.js';
 import type { SystemConfigController } from '@/controllers/systemConfig.js';
 import type { ValidatorController } from '@/controllers/validator.js';
 import type { Logger } from '@/lib/logger.js';
+import type { ClaimWithdrawalsService } from '@/services/gnosis/claim-withdrawals.js';
 import type { AnalyticsStorage } from '@/storage/analytics.js';
 import type { BlockStorage } from '@/storage/block.js';
 import type { BotCommunicationsStorage } from '@/storage/bot-communications.js';
@@ -42,4 +43,5 @@ export interface ApiDependencies {
   validatorController: ValidatorController;
   validatorStorage: ValidatorStorage;
   chain: 'ethereum' | 'gnosis';
+  claimWithdrawalsService: ClaimWithdrawalsService | null;
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -77,7 +77,7 @@ async function main() {
     chain: env.CHAIN,
     claimWithdrawalsService: createGnosisClaimWithdrawalsService({
       depositContractAddress: beaconHelpers.chainConfig.blockchain.scDepositAddress,
-      executionExplorerUrl: env.EXECUTION_EXPLORER_URL,
+      executionExplorerUrl: beaconHelpers.chainConfig.blockchain.executionExplorerUrl,
       privateKey: env.NODE_SENTINEL_PRIVATE_KEY,
       rpcUrl: env.EXECUTION_RPC_URL,
     }),

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -76,7 +76,7 @@ async function main() {
     botUsersStorage: new BotUsersStorage(prisma),
     chain: env.CHAIN,
     claimWithdrawalsService: createGnosisClaimWithdrawalsService({
-      depositContractAddress: env.BLOCKCHAIN_SC_DEPOSIT_ADDRESS,
+      depositContractAddress: beaconHelpers.chainConfig.blockchain.scDepositAddress,
       executionExplorerUrl: env.EXECUTION_EXPLORER_URL,
       privateKey: env.NODE_SENTINEL_PRIVATE_KEY,
       rpcUrl: env.EXECUTION_RPC_URL,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -11,6 +11,7 @@ import { createLogger } from './lib/logger.js';
 import { createPrisma, disconnectPrisma } from './lib/prisma.js';
 import { createRouter } from './routers/index.js';
 import { createHttpServer } from './server.js';
+import { createGnosisClaimWithdrawalsService } from './services/gnosis/claim-withdrawals.js';
 import { AnalyticsStorage } from './storage/analytics.js';
 import { BlockStorage } from './storage/block.js';
 import { BotCommunicationsStorage } from './storage/bot-communications.js';
@@ -74,6 +75,12 @@ async function main() {
     botNotificationsStorage: new BotNotificationsStorage(prisma),
     botUsersStorage: new BotUsersStorage(prisma),
     chain: env.CHAIN,
+    claimWithdrawalsService: createGnosisClaimWithdrawalsService({
+      depositContractAddress: env.BLOCKCHAIN_SC_DEPOSIT_ADDRESS,
+      executionExplorerUrl: env.EXECUTION_EXPLORER_URL,
+      privateKey: env.NODE_SENTINEL_PRIVATE_KEY,
+      rpcUrl: env.EXECUTION_RPC_URL,
+    }),
     clusterStorage: new ClusterStorage(prisma),
     executionRpcUrl: env.EXECUTION_RPC_URL,
     incidentStorage: new IncidentStorage(prisma),

--- a/packages/api/src/routers/user/claim.test.ts
+++ b/packages/api/src/routers/user/claim.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createUserClaimRoute, executeUserClaim } from './claim.js';
+
+const NOW = new Date('2026-01-10T12:00:00.000Z');
+const RECENT_CLAIM = new Date('2026-01-05T12:00:00.000Z');
+const OLD_CLAIM = new Date('2025-12-01T12:00:00.000Z');
+
+const ADDRESS_ONE = '0x0000000000000000000000000000000000000001';
+const ADDRESS_TWO = '0x0000000000000000000000000000000000000002';
+const TRANSACTION_HASH = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TRANSACTION_URL = `https://gnosis.example/tx/${TRANSACTION_HASH}`;
+
+/**
+ * Builds the minimum oRPC procedure chain needed to unit-test route registration.
+ */
+function createProcedureHarness() {
+  const handlers: Record<string, (params: unknown) => Promise<unknown>> = {};
+  const securedProcedure = {
+    route({ path }: { path: string }) {
+      return {
+        output() {
+          return {
+            handler(handler: (params: unknown) => Promise<unknown>) {
+              handlers[path] = handler;
+              return handler;
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { handlers, securedProcedure };
+}
+
+describe('executeUserClaim', () => {
+  it('rejects anonymous users before reading claim addresses', async () => {
+    // This scenario protects claim execution from anonymous browser sessions.
+    const userStorage = {
+      findClaimUserById: vi.fn().mockResolvedValue({
+        id: 'user-a',
+        telegramId: null,
+        lastClaimed: null,
+      }),
+      listOwnedClusterFeeRecipientAddresses: vi.fn(),
+      updateLastClaimed: vi.fn(),
+    };
+    const claimWithdrawalsService = {
+      claimWithdrawals: vi.fn(),
+    };
+
+    // Attempts to claim with a persisted user that has no Telegram id.
+    const response = await executeUserClaim({
+      chain: 'gnosis',
+      claimWithdrawalsService,
+      now: NOW,
+      userId: 'user-a',
+      userStorage,
+    });
+
+    // Confirms non-Telegram users cannot trigger address lookup or transactions.
+    expect(response).toMatchObject({
+      success: false,
+      error: {
+        code: 'CLAIM_TELEGRAM_REQUIRED',
+      },
+    });
+    expect(userStorage.listOwnedClusterFeeRecipientAddresses).not.toHaveBeenCalled();
+    expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
+    expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
+  });
+
+  it('rejects Ethereum deployments as not implemented', async () => {
+    // This scenario documents that claim support is Gnosis-only.
+    const userStorage = {
+      findClaimUserById: vi.fn(),
+      listOwnedClusterFeeRecipientAddresses: vi.fn(),
+      updateLastClaimed: vi.fn(),
+    };
+    const claimWithdrawalsService = {
+      claimWithdrawals: vi.fn(),
+    };
+
+    // Attempts to claim on an Ethereum API deployment.
+    const claimAttempt = executeUserClaim({
+      chain: 'ethereum',
+      claimWithdrawalsService,
+      now: NOW,
+      userId: 'user-a',
+      userStorage,
+    });
+
+    // Confirms the route throws before touching user state or sending a transaction.
+    await expect(claimAttempt).rejects.toThrow('Claiming is not implemented for Ethereum');
+    expect(userStorage.findClaimUserById).not.toHaveBeenCalled();
+    expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
+  });
+
+  it('rejects users whose claim cooldown is still active', async () => {
+    // This scenario preserves the old bot cooldown rule based on User.lastClaimed.
+    const userStorage = {
+      findClaimUserById: vi.fn().mockResolvedValue({
+        id: 'user-a',
+        telegramId: 123n,
+        lastClaimed: RECENT_CLAIM,
+      }),
+      listOwnedClusterFeeRecipientAddresses: vi.fn(),
+      updateLastClaimed: vi.fn(),
+    };
+    const claimWithdrawalsService = {
+      claimWithdrawals: vi.fn(),
+    };
+
+    // Attempts to claim five days after the previous successful claim.
+    const response = await executeUserClaim({
+      chain: 'gnosis',
+      claimWithdrawalsService,
+      now: NOW,
+      userId: 'user-a',
+      userStorage,
+    });
+
+    // Confirms the user must wait until seven days have passed.
+    expect(response).toMatchObject({
+      success: false,
+      error: {
+        code: 'CLAIM_COOLDOWN_ACTIVE',
+        details: {
+          nextClaimAt: '2026-01-12T12:00:00.000Z',
+        },
+      },
+    });
+    expect(userStorage.listOwnedClusterFeeRecipientAddresses).not.toHaveBeenCalled();
+    expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
+    expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
+  });
+
+  it('rejects Telegram users without owned cluster fee recipients', async () => {
+    // This scenario covers users with clusters that have no claimable fee-recipient address.
+    const userStorage = {
+      findClaimUserById: vi.fn().mockResolvedValue({
+        id: 'user-a',
+        telegramId: 123n,
+        lastClaimed: OLD_CLAIM,
+      }),
+      listOwnedClusterFeeRecipientAddresses: vi.fn().mockResolvedValue([]),
+      updateLastClaimed: vi.fn(),
+    };
+    const claimWithdrawalsService = {
+      claimWithdrawals: vi.fn(),
+    };
+
+    // Attempts to claim after cooldown with no addresses to pass to the contract.
+    const response = await executeUserClaim({
+      chain: 'gnosis',
+      claimWithdrawalsService,
+      now: NOW,
+      userId: 'user-a',
+      userStorage,
+    });
+
+    // Confirms an empty address list does not produce an empty on-chain call.
+    expect(response).toMatchObject({
+      success: false,
+      error: {
+        code: 'CLAIM_ADDRESSES_EMPTY',
+      },
+    });
+    expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
+    expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
+  });
+
+  it('claims all distinct owned cluster fee recipients and updates cooldown after success', async () => {
+    // This scenario verifies one transaction claims every unique fee recipient across the user clusters.
+    const userStorage = {
+      findClaimUserById: vi.fn().mockResolvedValue({
+        id: 'user-a',
+        telegramId: 123n,
+        lastClaimed: OLD_CLAIM,
+      }),
+      listOwnedClusterFeeRecipientAddresses: vi
+        .fn()
+        .mockResolvedValue([ADDRESS_ONE, ADDRESS_ONE, ADDRESS_TWO]),
+      updateLastClaimed: vi.fn().mockResolvedValue(undefined),
+    };
+    const claimWithdrawalsService = {
+      claimWithdrawals: vi.fn().mockResolvedValue({
+        transactionHash: TRANSACTION_HASH,
+        transactionUrl: TRANSACTION_URL,
+      }),
+    };
+
+    // Claims after cooldown with two unique fee-recipient addresses.
+    const response = await executeUserClaim({
+      chain: 'gnosis',
+      claimWithdrawalsService,
+      now: NOW,
+      userId: 'user-a',
+      userStorage,
+    });
+
+    // Confirms the contract receives one deduplicated address list.
+    expect(claimWithdrawalsService.claimWithdrawals).toHaveBeenCalledWith([
+      ADDRESS_ONE,
+      ADDRESS_TWO,
+    ]);
+    // Confirms cooldown is updated only after the transaction service succeeds.
+    expect(userStorage.updateLastClaimed).toHaveBeenCalledWith('user-a', NOW);
+    expect(response).toEqual({
+      success: true,
+      data: {
+        claimedAddresses: [ADDRESS_ONE, ADDRESS_TWO],
+        nextClaimAt: '2026-01-17T12:00:00.000Z',
+        transactionHash: TRANSACTION_HASH,
+        transactionUrl: TRANSACTION_URL,
+      },
+      meta: { timestamp: expect.any(String) },
+    });
+  });
+
+  it('does not update cooldown when the on-chain claim fails', async () => {
+    // This scenario preserves old bot behavior where failed transactions do not consume cooldown.
+    const userStorage = {
+      findClaimUserById: vi.fn().mockResolvedValue({
+        id: 'user-a',
+        telegramId: 123n,
+        lastClaimed: OLD_CLAIM,
+      }),
+      listOwnedClusterFeeRecipientAddresses: vi.fn().mockResolvedValue([ADDRESS_ONE]),
+      updateLastClaimed: vi.fn(),
+    };
+    const claimWithdrawalsService = {
+      claimWithdrawals: vi.fn().mockRejectedValue(new Error('RPC timeout')),
+    };
+
+    // Attempts a claim whose transaction submission fails.
+    const response = await executeUserClaim({
+      chain: 'gnosis',
+      claimWithdrawalsService,
+      now: NOW,
+      userId: 'user-a',
+      userStorage,
+    });
+
+    // Confirms failed on-chain work is reported and does not change the cooldown timestamp.
+    expect(response).toMatchObject({
+      success: false,
+      error: {
+        code: 'CLAIM_TX_ERROR',
+        message: 'RPC timeout',
+      },
+    });
+    expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
+  });
+});
+
+describe('createUserClaimRoute', () => {
+  it('registers the user claim route under the current user resource', () => {
+    // This scenario verifies REST and RPC expose claim as a user-owned action.
+    const { handlers, securedProcedure } = createProcedureHarness();
+
+    // Creates the route with the minimum dependencies needed for registration.
+    const createdRoute = createUserClaimRoute({
+      chain: 'gnosis',
+      claimWithdrawalsService: { claimWithdrawals: vi.fn() },
+      procedures: { securedProcedure } as never,
+      userStorage: {
+        findClaimUserById: vi.fn(),
+        listOwnedClusterFeeRecipientAddresses: vi.fn(),
+        updateLastClaimed: vi.fn(),
+      },
+    });
+
+    // Confirms the route is registered at POST /users/me/claim and returned to the router.
+    expect(createdRoute).toBe(handlers['/users/me/claim']);
+    expect(handlers['/users/me/claim']).toBeDefined();
+  });
+});

--- a/packages/api/src/routers/user/claim.ts
+++ b/packages/api/src/routers/user/claim.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ORPCError } from '@orpc/server';
+import { addDays, isAfter } from 'date-fns';
+import { z } from 'zod';
+
+import { ClaimUserResponseSchema } from './schemas.js';
+
+import type { ApiProcedures } from '@/auth/middleware.js';
+import { CLAIM_COOLDOWN_DAYS } from '@/constants/claim.js';
+import type { ClaimWithdrawalsService } from '@/services/gnosis/claim-withdrawals.js';
+import type { ApiResponse } from '@/utils/response.js';
+import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
+
+type Chain = 'ethereum' | 'gnosis';
+
+interface ClaimUser {
+  id: string;
+  telegramId: bigint | null;
+  lastClaimed: Date | null;
+}
+
+interface UserClaimStorage {
+  findClaimUserById: (userId: string) => Promise<ClaimUser | null>;
+  listOwnedClusterFeeRecipientAddresses: (userId: string) => Promise<string[]>;
+  updateLastClaimed: (userId: string, claimedAt: Date) => Promise<unknown>;
+}
+
+interface ExecuteUserClaimParams {
+  chain: Chain;
+  claimWithdrawalsService: ClaimWithdrawalsService | null;
+  now: Date;
+  userId: string;
+  userStorage: UserClaimStorage;
+}
+
+const ClaimUserApiResponseSchema = ApiResponseSchema(ClaimUserResponseSchema);
+type ClaimUserResponse = z.infer<typeof ClaimUserResponseSchema>;
+type ClaimUserApiResponse = z.infer<typeof ClaimUserApiResponseSchema>;
+
+/** Removes repeated addresses while preserving the first occurrence order. */
+function uniqueAddresses(addresses: string[]): string[] {
+  const seen = new Set<string>();
+
+  return addresses.filter((address) => {
+    const key = address.toLowerCase();
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+/** Calculates the next time the user may claim based on the last successful claim. */
+function getNextClaimAt(claimedAt: Date): Date {
+  return addDays(claimedAt, CLAIM_COOLDOWN_DAYS);
+}
+
+/** Produces a typed claim error so transport handlers keep one response shape. */
+function claimError(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+): ApiResponse<ClaimUserResponse> {
+  return errorResponse(code, message, details) as ApiResponse<ClaimUserResponse>;
+}
+
+/** Runs the claim business rules independently from the oRPC transport wrapper. */
+export async function executeUserClaim(
+  params: ExecuteUserClaimParams,
+): Promise<ApiResponse<ClaimUserResponse>> {
+  if (params.chain === 'ethereum') {
+    throw new ORPCError('NOT_IMPLEMENTED', {
+      message: 'Claiming is not implemented for Ethereum',
+    });
+  }
+
+  if (!params.claimWithdrawalsService) {
+    return claimError('CLAIM_UNAVAILABLE', 'Claiming is not available for this deployment');
+  }
+
+  const user = await params.userStorage.findClaimUserById(params.userId);
+  if (!user?.telegramId) {
+    return claimError('CLAIM_TELEGRAM_REQUIRED', 'Telegram authentication is required to claim');
+  }
+
+  if (user.lastClaimed) {
+    const nextClaimAt = getNextClaimAt(user.lastClaimed);
+    if (isAfter(nextClaimAt, params.now)) {
+      return claimError('CLAIM_COOLDOWN_ACTIVE', 'Claim cooldown is still active', {
+        nextClaimAt: nextClaimAt.toISOString(),
+      });
+    }
+  }
+
+  const claimedAddresses = uniqueAddresses(
+    await params.userStorage.listOwnedClusterFeeRecipientAddresses(params.userId),
+  );
+  if (claimedAddresses.length === 0) {
+    return claimError('CLAIM_ADDRESSES_EMPTY', 'No cluster fee recipient addresses to claim');
+  }
+
+  try {
+    const transaction = await params.claimWithdrawalsService.claimWithdrawals(claimedAddresses);
+    await params.userStorage.updateLastClaimed(params.userId, params.now);
+
+    return successResponse({
+      claimedAddresses,
+      nextClaimAt: getNextClaimAt(params.now).toISOString(),
+      transactionHash: transaction.transactionHash,
+      transactionUrl: transaction.transactionUrl,
+    });
+  } catch (error) {
+    return claimError(
+      'CLAIM_TX_ERROR',
+      error instanceof Error ? error.message : 'Failed to send claim transaction',
+    );
+  }
+}
+
+/** Creates the current-user claim route. */
+export function createUserClaimRoute(params: {
+  chain: Chain;
+  claimWithdrawalsService: ClaimWithdrawalsService | null;
+  procedures: ApiProcedures;
+  userStorage: UserClaimStorage;
+}) {
+  const { securedProcedure } = params.procedures;
+
+  return securedProcedure
+    .route({ method: 'POST', path: '/users/me/claim' })
+    .output(ClaimUserApiResponseSchema)
+    .handler(async ({ context }: any) => {
+      if (!context.user) {
+        return errorResponse(
+          'UNAUTHORIZED',
+          'User authentication required',
+        ) as ClaimUserApiResponse;
+      }
+
+      return executeUserClaim({
+        chain: params.chain,
+        claimWithdrawalsService: params.claimWithdrawalsService,
+        now: new Date(),
+        userId: context.user.id,
+        userStorage: params.userStorage,
+      }) as Promise<ClaimUserApiResponse>;
+    });
+}

--- a/packages/api/src/routers/user/index.ts
+++ b/packages/api/src/routers/user/index.ts
@@ -1,15 +1,20 @@
 import { createAnonymousUserRoute } from './anonymous.js';
+import { createUserClaimRoute } from './claim.js';
 import { createMeRoute } from './me.js';
 
 /**
  * Creates the user router.
  */
 export function createUserRouter(params: {
+  chain: Parameters<typeof createUserClaimRoute>[0]['chain'];
+  claimWithdrawalsService: Parameters<typeof createUserClaimRoute>[0]['claimWithdrawalsService'];
   procedures: Parameters<typeof createAnonymousUserRoute>[0]['procedures'];
-  userStorage: Parameters<typeof createAnonymousUserRoute>[0]['userStorage'];
+  userStorage: Parameters<typeof createAnonymousUserRoute>[0]['userStorage'] &
+    Parameters<typeof createUserClaimRoute>[0]['userStorage'];
 }) {
   return {
     anonymous: createAnonymousUserRoute(params),
+    claim: createUserClaimRoute(params),
     me: createMeRoute(params),
   };
 }

--- a/packages/api/src/routers/user/schemas.ts
+++ b/packages/api/src/routers/user/schemas.ts
@@ -18,3 +18,15 @@ export const UserResponseSchema = z.object({
 });
 
 export type UserResponse = z.infer<typeof UserResponseSchema>;
+
+/**
+ * Response returned after a successful Telegram user claim transaction.
+ */
+export const ClaimUserResponseSchema = z.object({
+  claimedAddresses: z.array(z.string()),
+  nextClaimAt: z.string(),
+  transactionHash: z.string(),
+  transactionUrl: z.string(),
+});
+
+export type ClaimUserResponse = z.infer<typeof ClaimUserResponseSchema>;

--- a/packages/api/src/services/gnosis/claim-withdrawals.test.ts
+++ b/packages/api/src/services/gnosis/claim-withdrawals.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createPublicClient,
+  createWalletClient,
+  getAddress,
+  http,
+  privateKeyToAccount,
+  waitForTransactionReceipt,
+  writeContract,
+} = vi.hoisted(() => ({
+  createPublicClient: vi.fn(),
+  createWalletClient: vi.fn(),
+  getAddress: vi.fn((address: string) => address),
+  http: vi.fn((url: string) => ({ url })),
+  privateKeyToAccount: vi.fn(() => ({ address: '0x0000000000000000000000000000000000000001' })),
+  waitForTransactionReceipt: vi.fn(),
+  writeContract: vi.fn(),
+}));
+
+vi.mock('viem', () => ({
+  createPublicClient,
+  createWalletClient,
+  getAddress,
+  http,
+}));
+
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount,
+}));
+
+vi.mock('viem/chains', () => ({
+  gnosis: { id: 100, name: 'Gnosis' },
+}));
+
+import { createGnosisClaimWithdrawalsService } from './claim-withdrawals.js';
+
+// Private key used only to exercise the wallet factory path in tests.
+const PRIVATE_KEY = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+// Gnosis deposit-contract address used to verify contract write parameters.
+const DEPOSIT_CONTRACT_ADDRESS = '0x0B98057eA310F4d31F2a452B414647007d1645d9';
+// Explorer URL used to verify the returned transaction URL formatting.
+const EXECUTION_EXPLORER_URL = 'https://gnosisscan.io';
+// Fee recipient address passed to the claim transaction.
+const FEE_RECIPIENT_ADDRESS = '0x0000000000000000000000000000000000000002';
+// Transaction hash returned by the mocked wallet client after broadcast.
+const TRANSACTION_HASH = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+describe('createGnosisClaimWithdrawalsService', () => {
+  // These tests cover service initialization and transaction broadcast behavior for Gnosis claims.
+  beforeEach(() => {
+    // Reset every viem mock so each test starts from an isolated client factory state.
+    vi.clearAllMocks();
+    createPublicClient.mockReturnValue({ waitForTransactionReceipt });
+    createWalletClient.mockReturnValue({ writeContract });
+    writeContract.mockResolvedValue(TRANSACTION_HASH);
+  });
+
+  it('does not create a claim service without an execution RPC URL', () => {
+    // This scenario prevents creating viem clients with an unusable empty RPC transport.
+    const service = createGnosisClaimWithdrawalsService({
+      depositContractAddress: DEPOSIT_CONTRACT_ADDRESS,
+      executionExplorerUrl: EXECUTION_EXPLORER_URL,
+      privateKey: PRIVATE_KEY,
+      rpcUrl: '',
+    });
+
+    // The factory should fail closed and avoid constructing any wallet or public client.
+    expect(service).toBeNull();
+    expect(createPublicClient).not.toHaveBeenCalled();
+    expect(createWalletClient).not.toHaveBeenCalled();
+  });
+
+  it('returns the broadcast transaction hash without waiting for the receipt', async () => {
+    // This scenario keeps the HTTP claim request from blocking on chain confirmation.
+    const service = createGnosisClaimWithdrawalsService({
+      depositContractAddress: DEPOSIT_CONTRACT_ADDRESS,
+      executionExplorerUrl: EXECUTION_EXPLORER_URL,
+      privateKey: PRIVATE_KEY,
+      rpcUrl: 'https://rpc.gnosischain.com',
+    });
+
+    // Broadcast a claim for one fee recipient through the service returned by the factory.
+    const result = await service?.claimWithdrawals([FEE_RECIPIENT_ADDRESS]);
+
+    // The wallet client should broadcast one claimWithdrawals transaction with normalized addresses.
+    expect(writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: DEPOSIT_CONTRACT_ADDRESS,
+        functionName: 'claimWithdrawals',
+        args: [[FEE_RECIPIENT_ADDRESS]],
+      }),
+    );
+    // The service should return immediately after broadcast and leave confirmation monitoring out of band.
+    expect(waitForTransactionReceipt).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      transactionHash: TRANSACTION_HASH,
+      transactionUrl: `${EXECUTION_EXPLORER_URL}/tx/${TRANSACTION_HASH}`,
+    });
+  });
+});

--- a/packages/api/src/services/gnosis/claim-withdrawals.ts
+++ b/packages/api/src/services/gnosis/claim-withdrawals.ts
@@ -1,5 +1,5 @@
 import type { Address, Hex } from 'viem';
-import { createPublicClient, createWalletClient, getAddress, http } from 'viem';
+import { createWalletClient, getAddress, http } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { gnosis } from 'viem/chains';
 
@@ -25,22 +25,23 @@ interface CreateGnosisClaimWithdrawalsServiceParams {
   depositContractAddress?: string;
   executionExplorerUrl?: string;
   privateKey?: string;
-  rpcUrl: string;
+  rpcUrl?: string;
 }
 
 /** Creates a claim service only when every signing-related setting is available. */
 export function createGnosisClaimWithdrawalsService(
   params: CreateGnosisClaimWithdrawalsServiceParams,
 ): ClaimWithdrawalsService | null {
-  if (!params.privateKey || !params.depositContractAddress || !params.executionExplorerUrl) {
+  if (
+    !params.privateKey ||
+    !params.depositContractAddress ||
+    !params.executionExplorerUrl ||
+    !params.rpcUrl
+  ) {
     return null;
   }
 
   const account = privateKeyToAccount(params.privateKey as Hex);
-  const publicClient = createPublicClient({
-    chain: gnosis,
-    transport: http(params.rpcUrl),
-  });
   const walletClient = createWalletClient({
     account,
     chain: gnosis,
@@ -50,7 +51,7 @@ export function createGnosisClaimWithdrawalsService(
   const explorerUrl = params.executionExplorerUrl.replace(/\/$/, '');
 
   return {
-    /** Sends the claim transaction and waits for the receipt before returning the explorer URL. */
+    /** Sends the claim transaction and returns the broadcast hash without waiting for confirmation. */
     async claimWithdrawals(addresses: string[]) {
       const normalizedAddresses = addresses.map((address) => getAddress(address) as Address);
       const transactionHash = await walletClient.writeContract({
@@ -59,8 +60,6 @@ export function createGnosisClaimWithdrawalsService(
         functionName: 'claimWithdrawals',
         args: [normalizedAddresses],
       });
-
-      await publicClient.waitForTransactionReceipt({ hash: transactionHash });
 
       return {
         transactionHash,

--- a/packages/api/src/services/gnosis/claim-withdrawals.ts
+++ b/packages/api/src/services/gnosis/claim-withdrawals.ts
@@ -1,0 +1,71 @@
+import type { Address, Hex } from 'viem';
+import { createPublicClient, createWalletClient, getAddress, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { gnosis } from 'viem/chains';
+
+const GNOSIS_DEPOSIT_ABI = [
+  {
+    inputs: [{ internalType: 'address[]', name: '_addresses', type: 'address[]' }],
+    name: 'claimWithdrawals',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+export interface ClaimWithdrawalsService {
+  /** Sends one Gnosis deposit-contract claim transaction for the provided fee recipients. */
+  claimWithdrawals(addresses: string[]): Promise<{
+    transactionHash: Hex;
+    transactionUrl: string;
+  }>;
+}
+
+interface CreateGnosisClaimWithdrawalsServiceParams {
+  depositContractAddress?: string;
+  executionExplorerUrl?: string;
+  privateKey?: string;
+  rpcUrl: string;
+}
+
+/** Creates a claim service only when every signing-related setting is available. */
+export function createGnosisClaimWithdrawalsService(
+  params: CreateGnosisClaimWithdrawalsServiceParams,
+): ClaimWithdrawalsService | null {
+  if (!params.privateKey || !params.depositContractAddress || !params.executionExplorerUrl) {
+    return null;
+  }
+
+  const account = privateKeyToAccount(params.privateKey as Hex);
+  const publicClient = createPublicClient({
+    chain: gnosis,
+    transport: http(params.rpcUrl),
+  });
+  const walletClient = createWalletClient({
+    account,
+    chain: gnosis,
+    transport: http(params.rpcUrl),
+  });
+  const contractAddress = getAddress(params.depositContractAddress);
+  const explorerUrl = params.executionExplorerUrl.replace(/\/$/, '');
+
+  return {
+    /** Sends the claim transaction and waits for the receipt before returning the explorer URL. */
+    async claimWithdrawals(addresses: string[]) {
+      const normalizedAddresses = addresses.map((address) => getAddress(address) as Address);
+      const transactionHash = await walletClient.writeContract({
+        address: contractAddress,
+        abi: GNOSIS_DEPOSIT_ABI,
+        functionName: 'claimWithdrawals',
+        args: [normalizedAddresses],
+      });
+
+      await publicClient.waitForTransactionReceipt({ hash: transactionHash });
+
+      return {
+        transactionHash,
+        transactionUrl: `${explorerUrl}/tx/${transactionHash}`,
+      };
+    },
+  };
+}

--- a/packages/api/src/storage/user.test.ts
+++ b/packages/api/src/storage/user.test.ts
@@ -22,3 +22,65 @@ describe('UserStorage user context', () => {
     );
   });
 });
+
+describe('UserStorage claim data', () => {
+  it('selects Telegram id and cooldown fields for claim checks', async () => {
+    // This scenario verifies claim logic reads only the user fields needed for eligibility.
+    const claimUser = { id: 'user-a', telegramId: 123n, lastClaimed: null };
+    const findUnique = vi.fn().mockResolvedValue(claimUser);
+    const storage = new UserStorage({ user: { findUnique } } as never);
+
+    // Loads the claim-specific user state by the authenticated API user id.
+    const result = await storage.findClaimUserById('user-a');
+
+    // Confirms claim checks can distinguish Telegram users from anonymous users.
+    expect(result).toEqual(claimUser);
+    // Confirms Prisma does not read unrelated user columns for this route.
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-a' },
+      select: { id: true, telegramId: true, lastClaimed: true },
+    });
+  });
+
+  it('lists distinct fee recipient addresses from clusters owned by the user', async () => {
+    // This scenario verifies claim addresses come from owned cluster fee recipients.
+    const findMany = vi
+      .fn()
+      .mockResolvedValue([
+        { feeRecipientAddress: '0x0000000000000000000000000000000000000001' },
+        { feeRecipientAddress: '0x0000000000000000000000000000000000000002' },
+      ]);
+    const storage = new UserStorage({ cluster: { findMany } } as never);
+
+    // Loads all non-null fee recipient addresses for the authenticated user clusters.
+    const result = await storage.listOwnedClusterFeeRecipientAddresses('user-a');
+
+    // Confirms storage returns the address strings consumed by the claim service.
+    expect(result).toEqual([
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+    ]);
+    // Confirms Prisma applies owner scoping, null filtering, and distinct address selection.
+    expect(findMany).toHaveBeenCalledWith({
+      where: { ownerId: 'user-a', feeRecipientAddress: { not: null } },
+      select: { feeRecipientAddress: true },
+      distinct: ['feeRecipientAddress'],
+    });
+  });
+
+  it('updates lastClaimed after a successful claim transaction', async () => {
+    // This scenario verifies cooldown state is written only through an explicit claim method.
+    const claimedAt = new Date('2026-01-10T12:00:00.000Z');
+    const update = vi.fn().mockResolvedValue(undefined);
+    const storage = new UserStorage({ user: { update } } as never);
+
+    // Records the timestamp of a successful transaction for the current user.
+    await storage.updateLastClaimed('user-a', claimedAt);
+
+    // Confirms the storage write is scoped by user id and only changes lastClaimed.
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'user-a' },
+      data: { lastClaimed: claimedAt },
+    });
+  });
+});

--- a/packages/api/src/storage/user.ts
+++ b/packages/api/src/storage/user.ts
@@ -61,4 +61,37 @@ export class UserStorage {
       select: this.userContextSelect,
     });
   }
+
+  /**
+   * Finds the fields required to decide whether a user can claim.
+   */
+  async findClaimUserById(userId: string) {
+    return this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, telegramId: true, lastClaimed: true },
+    });
+  }
+
+  /**
+   * Lists unique fee recipient addresses configured on clusters owned by the user.
+   */
+  async listOwnedClusterFeeRecipientAddresses(userId: string): Promise<string[]> {
+    const rows = await this.prisma.cluster.findMany({
+      where: { ownerId: userId, feeRecipientAddress: { not: null } },
+      select: { feeRecipientAddress: true },
+      distinct: ['feeRecipientAddress'],
+    });
+
+    return rows.map((row) => row.feeRecipientAddress as string);
+  }
+
+  /**
+   * Stores the timestamp of the last successful claim for cooldown enforcement.
+   */
+  async updateLastClaimed(userId: string, claimedAt: Date) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: { lastClaimed: claimedAt },
+    });
+  }
 }

--- a/packages/beacon-utils/src/config/chain.ts
+++ b/packages/beacon-utils/src/config/chain.ts
@@ -9,6 +9,7 @@ export type ChainConfig = {
   // Blockchain Configuration
   blockchain: {
     chainId: number;
+    executionExplorerUrl?: string;
     scDepositAddress?: string;
   };
 
@@ -29,6 +30,7 @@ export type ChainConfig = {
 export const ethereumConfig: ChainConfig = {
   blockchain: {
     chainId: 1,
+    executionExplorerUrl: 'https://etherscan.io',
   },
   beacon: {
     genesisTimestamp: ms('1606824023s'), // 1606824023
@@ -46,6 +48,7 @@ export const ethereumConfig: ChainConfig = {
 export const gnosisConfig: ChainConfig = {
   blockchain: {
     chainId: 100,
+    executionExplorerUrl: 'https://gnosisscan.io',
     scDepositAddress: '0x0B98057eA310F4d31F2a452B414647007d1645d9',
   },
   beacon: {


### PR DESCRIPTION
## Summary
- add API user.claim / POST /users/me/claim for Gnosis claims
- collect distinct owned cluster fee-recipient addresses into one claim tx
- keep Telegram-only access and User.lastClaimed cooldown behavior
- move claim deposit address and explorer URL to chain config

## Verification
- pnpm --filter @beacon-indexer/api lint
- pnpm --filter @beacon-indexer/api typecheck
- pnpm --filter @beacon-indexer/api test
- pnpm --filter @beacon-indexer/api build
- pnpm --filter @beacon-indexer/beacon-utils lint
- pnpm --filter @beacon-indexer/beacon-utils typecheck
- pnpm --filter @beacon-indexer/beacon-utils test