### PR TITLE
Add Gnosis claimable rewards snapshot

### DIFF
--- a/packages/api/src/routers/cluster/schemas.ts
+++ b/packages/api/src/routers/cluster/schemas.ts
@@ -380,6 +380,7 @@ export const ClusterSnapshotSchema = z.object({
   avgAttestationDelayW: z.number().nullable(),
   avgAttestationDelayM: z.number().nullable(),
 
+  claimableRewards: z.string().nullable(),
   tokenPrice: z.number(),
 });
 

--- a/packages/api/src/routers/cluster/snapshot.test.ts
+++ b/packages/api/src/routers/cluster/snapshot.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createClusterSnapshotRoute } from './snapshot.js';
+
+vi.mock('@/utils/tokenPrice.js', () => ({
+  getTokenPrice: vi.fn().mockResolvedValue(42),
+}));
+
+/**
+ * Builds the minimum secured procedure chain needed to unit-test snapshot route handlers.
+ */
+function createProcedureHarness() {
+  const handlers: Record<string, (params: unknown) => Promise<unknown>> = {};
+  const securedProcedure = {
+    route({ path }: { path: string }) {
+      return {
+        input() {
+          return {
+            output() {
+              return {
+                handler(handler: (params: unknown) => Promise<unknown>) {
+                  handlers[path] = handler;
+                  return handler;
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { handlers, securedProcedure };
+}
+
+/**
+ * Creates a complete storage row with zero-like values for fields unrelated to claimable rewards.
+ */
+function createSnapshotRow() {
+  return {
+    active_count: 1n,
+    inactive_count: 0n,
+    beacon_status_breakdown: '{}',
+    total_balance: 32_000_000_000n,
+    total_effective_balance: 32_000_000_000n,
+    performance_h: null,
+    performance_d: null,
+    performance_w: null,
+    performance_m: null,
+    apy_h: null,
+    apy_d: null,
+    apy_w: null,
+    apy_m: null,
+    consensus_reward_h: null,
+    consensus_reward_d: null,
+    consensus_reward_w: null,
+    consensus_reward_m: null,
+    missed_reward_h: null,
+    missed_reward_d: null,
+    missed_reward_w: null,
+    missed_reward_m: null,
+    execution_reward_h: null,
+    execution_reward_d: null,
+    execution_reward_w: null,
+    execution_reward_m: null,
+    attestation_efficiency_d: null,
+    attestation_efficiency_w: null,
+    attestation_efficiency_m: null,
+    avg_attestation_delay_d: null,
+    avg_attestation_delay_w: null,
+    avg_attestation_delay_m: null,
+    claimable_rewards: null,
+  };
+}
+
+/**
+ * Creates the snapshot route with only the dependencies used by these tests.
+ */
+function createTestRoute(params: {
+  chain: 'ethereum' | 'gnosis';
+  getClusterSnapshot: ReturnType<typeof vi.fn>;
+}) {
+  const { handlers, securedProcedure } = createProcedureHarness();
+
+  createClusterSnapshotRoute({
+    chain: params.chain,
+    clusterStorage: {
+      existsForOwner: vi.fn().mockResolvedValue(true),
+      getClusterSnapshot: params.getClusterSnapshot,
+    },
+    logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } as never,
+    nativeTokenDecimals: 18,
+    procedures: { securedProcedure } as never,
+    tokenPriceApiUrl: 'https://price.example',
+    tokenPriceTokenName: 'gno',
+  });
+
+  return handlers['/clusters/{id}/snapshot'];
+}
+
+describe('createClusterSnapshotRoute', () => {
+  // These route tests verify the chain-specific claimable flag passed from API route to storage.
+  it('disables claimable reward storage work on Ethereum deployments', async () => {
+    // This scenario ensures Ethereum snapshots do not query the Gnosis-only claimable cache.
+    const getClusterSnapshot = vi.fn().mockResolvedValue(createSnapshotRow());
+    const handler = createTestRoute({ chain: 'ethereum', getClusterSnapshot });
+
+    // Fetches a cluster snapshot for an authenticated owner on an Ethereum deployment.
+    await handler({
+      context: { user: { id: 'user-a' } },
+      input: { id: 'cluster-a' },
+    });
+
+    // Confirms the route passes an explicit flag that lets storage omit claimable SQL.
+    expect(getClusterSnapshot).toHaveBeenCalledWith({
+      clusterId: 'cluster-a',
+      includeClaimable: false,
+    });
+  });
+
+  it('enables claimable reward storage work on Gnosis deployments', async () => {
+    // This scenario ensures Gnosis snapshots opt into the claimable cache join.
+    const getClusterSnapshot = vi.fn().mockResolvedValue(createSnapshotRow());
+    const handler = createTestRoute({ chain: 'gnosis', getClusterSnapshot });
+
+    // Fetches a cluster snapshot for an authenticated owner on a Gnosis deployment.
+    await handler({
+      context: { user: { id: 'user-a' } },
+      input: { id: 'cluster-a' },
+    });
+
+    // Confirms the route asks storage to include claimable rewards only on Gnosis.
+    expect(getClusterSnapshot).toHaveBeenCalledWith({
+      clusterId: 'cluster-a',
+      includeClaimable: true,
+    });
+  });
+});

--- a/packages/api/src/routers/cluster/snapshot.ts
+++ b/packages/api/src/routers/cluster/snapshot.ts
@@ -36,7 +36,10 @@ export function createClusterSnapshotRoute(params: {
           return ownershipError;
         }
 
-        const row = await params.clusterStorage.getClusterSnapshot(input.id);
+        const row = await params.clusterStorage.getClusterSnapshot({
+          clusterId: input.id,
+          includeClaimable: params.chain === 'gnosis',
+        });
         if (!row) {
           return {
             success: false,
@@ -65,6 +68,10 @@ export function createClusterSnapshotRoute(params: {
         const toExecReward = (value: string | null) =>
           value !== null
             ? { wei: value, token: formatWeiToToken(value, params.nativeTokenDecimals) }
+            : null;
+        const claimableRewards =
+          params.chain === 'gnosis' && row.claimable_rewards !== null
+            ? formatWeiToToken(row.claimable_rewards, params.nativeTokenDecimals)
             : null;
 
         return {
@@ -104,6 +111,7 @@ export function createClusterSnapshotRoute(params: {
             avgAttestationDelayD: toNum(row.avg_attestation_delay_d),
             avgAttestationDelayW: toNum(row.avg_attestation_delay_w),
             avgAttestationDelayM: toNum(row.avg_attestation_delay_m),
+            claimableRewards,
             tokenPrice,
           },
           meta: { timestamp: new Date().toISOString() },

--- a/packages/api/src/routers/user/claim.test.ts
+++ b/packages/api/src/routers/user/claim.test.ts
@@ -45,6 +45,7 @@ describe('executeUserClaim', () => {
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn(),
       clearClaimableWithdrawalAddresses: vi.fn(),
+      finalizeSuccessfulClaim: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -79,6 +80,7 @@ describe('executeUserClaim', () => {
       findClaimUserById: vi.fn(),
       listOwnedClusterWithdrawalAddresses: vi.fn(),
       clearClaimableWithdrawalAddresses: vi.fn(),
+      finalizeSuccessfulClaim: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -110,6 +112,7 @@ describe('executeUserClaim', () => {
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn(),
       clearClaimableWithdrawalAddresses: vi.fn(),
+      finalizeSuccessfulClaim: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -151,6 +154,7 @@ describe('executeUserClaim', () => {
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn().mockResolvedValue([]),
       clearClaimableWithdrawalAddresses: vi.fn(),
+      finalizeSuccessfulClaim: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -190,6 +194,7 @@ describe('executeUserClaim', () => {
         .fn()
         .mockResolvedValue([ADDRESS_ONE, ADDRESS_ONE, ADDRESS_TWO]),
       clearClaimableWithdrawalAddresses: vi.fn().mockResolvedValue(undefined),
+      finalizeSuccessfulClaim: vi.fn().mockResolvedValue(undefined),
       updateLastClaimed: vi.fn().mockResolvedValue(undefined),
     };
     const claimWithdrawalsService = {
@@ -213,16 +218,12 @@ describe('executeUserClaim', () => {
       ADDRESS_ONE,
       ADDRESS_TWO,
     ]);
-    // Confirms the claimable snapshot cache is cleared for the same deduplicated addresses.
-    expect(userStorage.clearClaimableWithdrawalAddresses).toHaveBeenCalledWith([
-      ADDRESS_ONE,
-      ADDRESS_TWO,
-    ]);
-    // Confirms cooldown is updated only after the transaction service succeeds and cache is cleared.
-    expect(userStorage.updateLastClaimed).toHaveBeenCalledWith('user-a', NOW);
-    expect(userStorage.clearClaimableWithdrawalAddresses.mock.invocationCallOrder[0]).toBeLessThan(
-      userStorage.updateLastClaimed.mock.invocationCallOrder[0],
-    );
+    // Confirms post-transaction database updates are finalized together for consistency.
+    expect(userStorage.finalizeSuccessfulClaim).toHaveBeenCalledWith({
+      claimedAt: NOW,
+      userId: 'user-a',
+      withdrawalAddresses: [ADDRESS_ONE, ADDRESS_TWO],
+    });
     expect(response).toEqual({
       success: true,
       data: {
@@ -235,6 +236,57 @@ describe('executeUserClaim', () => {
     });
   });
 
+  it('returns the successful transaction when post-claim database finalization fails', async () => {
+    // This scenario protects users from receiving a transaction error after the transaction was broadcast.
+    const logger = { error: vi.fn() };
+    const userStorage = {
+      findClaimUserById: vi.fn().mockResolvedValue({
+        id: 'user-a',
+        telegramId: 123n,
+        lastClaimed: OLD_CLAIM,
+      }),
+      listOwnedClusterWithdrawalAddresses: vi.fn().mockResolvedValue([ADDRESS_ONE]),
+      clearClaimableWithdrawalAddresses: vi.fn(),
+      finalizeSuccessfulClaim: vi.fn().mockRejectedValue(new Error('database write failed')),
+      updateLastClaimed: vi.fn(),
+    };
+    const claimWithdrawalsService = {
+      claimWithdrawals: vi.fn().mockResolvedValue({
+        transactionHash: TRANSACTION_HASH,
+        transactionUrl: TRANSACTION_URL,
+      }),
+    };
+
+    // Claims after cooldown while the database finalization step fails after broadcast.
+    const response = await executeUserClaim({
+      chain: 'gnosis',
+      claimWithdrawalsService,
+      logger,
+      now: NOW,
+      userId: 'user-a',
+      userStorage,
+    });
+
+    // Confirms the API does not misreport a successful on-chain broadcast as a transaction failure.
+    expect(response).toMatchObject({
+      success: true,
+      data: {
+        claimedAddresses: [ADDRESS_ONE],
+        transactionHash: TRANSACTION_HASH,
+        transactionUrl: TRANSACTION_URL,
+      },
+    });
+    // Confirms the database failure is still logged for operators to investigate.
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.any(Error),
+        transactionHash: TRANSACTION_HASH,
+        userId: 'user-a',
+      }),
+      'Failed to finalize successful claim',
+    );
+  });
+
   it('does not update cooldown when the on-chain claim fails', async () => {
     // This scenario preserves old bot behavior where failed transactions do not consume cooldown.
     const userStorage = {
@@ -245,6 +297,7 @@ describe('executeUserClaim', () => {
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn().mockResolvedValue([ADDRESS_ONE]),
       clearClaimableWithdrawalAddresses: vi.fn(),
+      finalizeSuccessfulClaim: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -269,6 +322,7 @@ describe('executeUserClaim', () => {
       },
     });
     expect(userStorage.clearClaimableWithdrawalAddresses).not.toHaveBeenCalled();
+    expect(userStorage.finalizeSuccessfulClaim).not.toHaveBeenCalled();
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
 });
@@ -287,6 +341,7 @@ describe('createUserClaimRoute', () => {
         findClaimUserById: vi.fn(),
         listOwnedClusterWithdrawalAddresses: vi.fn(),
         clearClaimableWithdrawalAddresses: vi.fn(),
+        finalizeSuccessfulClaim: vi.fn(),
         updateLastClaimed: vi.fn(),
       },
     });

--- a/packages/api/src/routers/user/claim.test.ts
+++ b/packages/api/src/routers/user/claim.test.ts
@@ -43,7 +43,7 @@ describe('executeUserClaim', () => {
         telegramId: null,
         lastClaimed: null,
       }),
-      listOwnedClusterFeeRecipientAddresses: vi.fn(),
+      listOwnedClusterWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -66,7 +66,7 @@ describe('executeUserClaim', () => {
         code: 'CLAIM_TELEGRAM_REQUIRED',
       },
     });
-    expect(userStorage.listOwnedClusterFeeRecipientAddresses).not.toHaveBeenCalled();
+    expect(userStorage.listOwnedClusterWithdrawalAddresses).not.toHaveBeenCalled();
     expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
@@ -75,7 +75,7 @@ describe('executeUserClaim', () => {
     // This scenario documents that claim support is Gnosis-only.
     const userStorage = {
       findClaimUserById: vi.fn(),
-      listOwnedClusterFeeRecipientAddresses: vi.fn(),
+      listOwnedClusterWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -105,7 +105,7 @@ describe('executeUserClaim', () => {
         telegramId: 123n,
         lastClaimed: RECENT_CLAIM,
       }),
-      listOwnedClusterFeeRecipientAddresses: vi.fn(),
+      listOwnedClusterWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -131,20 +131,20 @@ describe('executeUserClaim', () => {
         },
       },
     });
-    expect(userStorage.listOwnedClusterFeeRecipientAddresses).not.toHaveBeenCalled();
+    expect(userStorage.listOwnedClusterWithdrawalAddresses).not.toHaveBeenCalled();
     expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
 
-  it('rejects Telegram users without owned cluster fee recipients', async () => {
-    // This scenario covers users with clusters that have no claimable fee-recipient address.
+  it('rejects Telegram users without owned cluster withdrawal addresses', async () => {
+    // This scenario covers users with clusters that have no claimable withdrawal address.
     const userStorage = {
       findClaimUserById: vi.fn().mockResolvedValue({
         id: 'user-a',
         telegramId: 123n,
         lastClaimed: OLD_CLAIM,
       }),
-      listOwnedClusterFeeRecipientAddresses: vi.fn().mockResolvedValue([]),
+      listOwnedClusterWithdrawalAddresses: vi.fn().mockResolvedValue([]),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -171,15 +171,15 @@ describe('executeUserClaim', () => {
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
 
-  it('claims all distinct owned cluster fee recipients and updates cooldown after success', async () => {
-    // This scenario verifies one transaction claims every unique fee recipient across the user clusters.
+  it('claims all distinct owned cluster withdrawal addresses and updates cooldown after success', async () => {
+    // This scenario verifies one transaction claims every unique withdrawal address across the user clusters.
     const userStorage = {
       findClaimUserById: vi.fn().mockResolvedValue({
         id: 'user-a',
         telegramId: 123n,
         lastClaimed: OLD_CLAIM,
       }),
-      listOwnedClusterFeeRecipientAddresses: vi
+      listOwnedClusterWithdrawalAddresses: vi
         .fn()
         .mockResolvedValue([ADDRESS_ONE, ADDRESS_ONE, ADDRESS_TWO]),
       updateLastClaimed: vi.fn().mockResolvedValue(undefined),
@@ -191,7 +191,7 @@ describe('executeUserClaim', () => {
       }),
     };
 
-    // Claims after cooldown with two unique fee-recipient addresses.
+    // Claims after cooldown with two unique withdrawal addresses.
     const response = await executeUserClaim({
       chain: 'gnosis',
       claimWithdrawalsService,
@@ -227,7 +227,7 @@ describe('executeUserClaim', () => {
         telegramId: 123n,
         lastClaimed: OLD_CLAIM,
       }),
-      listOwnedClusterFeeRecipientAddresses: vi.fn().mockResolvedValue([ADDRESS_ONE]),
+      listOwnedClusterWithdrawalAddresses: vi.fn().mockResolvedValue([ADDRESS_ONE]),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -267,7 +267,7 @@ describe('createUserClaimRoute', () => {
       procedures: { securedProcedure } as never,
       userStorage: {
         findClaimUserById: vi.fn(),
-        listOwnedClusterFeeRecipientAddresses: vi.fn(),
+        listOwnedClusterWithdrawalAddresses: vi.fn(),
         updateLastClaimed: vi.fn(),
       },
     });

--- a/packages/api/src/routers/user/claim.test.ts
+++ b/packages/api/src/routers/user/claim.test.ts
@@ -44,6 +44,7 @@ describe('executeUserClaim', () => {
         lastClaimed: null,
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn(),
+      clearClaimableWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -67,6 +68,7 @@ describe('executeUserClaim', () => {
       },
     });
     expect(userStorage.listOwnedClusterWithdrawalAddresses).not.toHaveBeenCalled();
+    expect(userStorage.clearClaimableWithdrawalAddresses).not.toHaveBeenCalled();
     expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
@@ -76,6 +78,7 @@ describe('executeUserClaim', () => {
     const userStorage = {
       findClaimUserById: vi.fn(),
       listOwnedClusterWithdrawalAddresses: vi.fn(),
+      clearClaimableWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -106,6 +109,7 @@ describe('executeUserClaim', () => {
         lastClaimed: RECENT_CLAIM,
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn(),
+      clearClaimableWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -132,6 +136,7 @@ describe('executeUserClaim', () => {
       },
     });
     expect(userStorage.listOwnedClusterWithdrawalAddresses).not.toHaveBeenCalled();
+    expect(userStorage.clearClaimableWithdrawalAddresses).not.toHaveBeenCalled();
     expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
@@ -145,6 +150,7 @@ describe('executeUserClaim', () => {
         lastClaimed: OLD_CLAIM,
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn().mockResolvedValue([]),
+      clearClaimableWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -168,6 +174,7 @@ describe('executeUserClaim', () => {
       },
     });
     expect(claimWithdrawalsService.claimWithdrawals).not.toHaveBeenCalled();
+    expect(userStorage.clearClaimableWithdrawalAddresses).not.toHaveBeenCalled();
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
 
@@ -182,6 +189,7 @@ describe('executeUserClaim', () => {
       listOwnedClusterWithdrawalAddresses: vi
         .fn()
         .mockResolvedValue([ADDRESS_ONE, ADDRESS_ONE, ADDRESS_TWO]),
+      clearClaimableWithdrawalAddresses: vi.fn().mockResolvedValue(undefined),
       updateLastClaimed: vi.fn().mockResolvedValue(undefined),
     };
     const claimWithdrawalsService = {
@@ -205,8 +213,16 @@ describe('executeUserClaim', () => {
       ADDRESS_ONE,
       ADDRESS_TWO,
     ]);
-    // Confirms cooldown is updated only after the transaction service succeeds.
+    // Confirms the claimable snapshot cache is cleared for the same deduplicated addresses.
+    expect(userStorage.clearClaimableWithdrawalAddresses).toHaveBeenCalledWith([
+      ADDRESS_ONE,
+      ADDRESS_TWO,
+    ]);
+    // Confirms cooldown is updated only after the transaction service succeeds and cache is cleared.
     expect(userStorage.updateLastClaimed).toHaveBeenCalledWith('user-a', NOW);
+    expect(userStorage.clearClaimableWithdrawalAddresses.mock.invocationCallOrder[0]).toBeLessThan(
+      userStorage.updateLastClaimed.mock.invocationCallOrder[0],
+    );
     expect(response).toEqual({
       success: true,
       data: {
@@ -228,6 +244,7 @@ describe('executeUserClaim', () => {
         lastClaimed: OLD_CLAIM,
       }),
       listOwnedClusterWithdrawalAddresses: vi.fn().mockResolvedValue([ADDRESS_ONE]),
+      clearClaimableWithdrawalAddresses: vi.fn(),
       updateLastClaimed: vi.fn(),
     };
     const claimWithdrawalsService = {
@@ -251,6 +268,7 @@ describe('executeUserClaim', () => {
         message: 'RPC timeout',
       },
     });
+    expect(userStorage.clearClaimableWithdrawalAddresses).not.toHaveBeenCalled();
     expect(userStorage.updateLastClaimed).not.toHaveBeenCalled();
   });
 });
@@ -268,6 +286,7 @@ describe('createUserClaimRoute', () => {
       userStorage: {
         findClaimUserById: vi.fn(),
         listOwnedClusterWithdrawalAddresses: vi.fn(),
+        clearClaimableWithdrawalAddresses: vi.fn(),
         updateLastClaimed: vi.fn(),
       },
     });

--- a/packages/api/src/routers/user/claim.ts
+++ b/packages/api/src/routers/user/claim.ts
@@ -21,7 +21,7 @@ interface ClaimUser {
 
 interface UserClaimStorage {
   findClaimUserById: (userId: string) => Promise<ClaimUser | null>;
-  listOwnedClusterFeeRecipientAddresses: (userId: string) => Promise<string[]>;
+  listOwnedClusterWithdrawalAddresses: (userId: string) => Promise<string[]>;
   updateLastClaimed: (userId: string, claimedAt: Date) => Promise<unknown>;
 }
 
@@ -95,10 +95,10 @@ export async function executeUserClaim(
   }
 
   const claimedAddresses = uniqueAddresses(
-    await params.userStorage.listOwnedClusterFeeRecipientAddresses(params.userId),
+    await params.userStorage.listOwnedClusterWithdrawalAddresses(params.userId),
   );
   if (claimedAddresses.length === 0) {
-    return claimError('CLAIM_ADDRESSES_EMPTY', 'No cluster fee recipient addresses to claim');
+    return claimError('CLAIM_ADDRESSES_EMPTY', 'No cluster withdrawal addresses to claim');
   }
 
   try {

--- a/packages/api/src/routers/user/claim.ts
+++ b/packages/api/src/routers/user/claim.ts
@@ -22,6 +22,7 @@ interface ClaimUser {
 interface UserClaimStorage {
   findClaimUserById: (userId: string) => Promise<ClaimUser | null>;
   listOwnedClusterWithdrawalAddresses: (userId: string) => Promise<string[]>;
+  clearClaimableWithdrawalAddresses: (withdrawalAddresses: string[]) => Promise<unknown>;
   updateLastClaimed: (userId: string, claimedAt: Date) => Promise<unknown>;
 }
 
@@ -103,6 +104,7 @@ export async function executeUserClaim(
 
   try {
     const transaction = await params.claimWithdrawalsService.claimWithdrawals(claimedAddresses);
+    await params.userStorage.clearClaimableWithdrawalAddresses(claimedAddresses);
     await params.userStorage.updateLastClaimed(params.userId, params.now);
 
     return successResponse({

--- a/packages/api/src/routers/user/claim.ts
+++ b/packages/api/src/routers/user/claim.ts
@@ -7,6 +7,7 @@ import { ClaimUserResponseSchema } from './schemas.js';
 
 import type { ApiProcedures } from '@/auth/middleware.js';
 import { CLAIM_COOLDOWN_DAYS } from '@/constants/claim.js';
+import type { Logger } from '@/lib/logger.js';
 import type { ClaimWithdrawalsService } from '@/services/gnosis/claim-withdrawals.js';
 import type { ApiResponse } from '@/utils/response.js';
 import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
@@ -23,12 +24,18 @@ interface UserClaimStorage {
   findClaimUserById: (userId: string) => Promise<ClaimUser | null>;
   listOwnedClusterWithdrawalAddresses: (userId: string) => Promise<string[]>;
   clearClaimableWithdrawalAddresses: (withdrawalAddresses: string[]) => Promise<unknown>;
+  finalizeSuccessfulClaim: (params: {
+    claimedAt: Date;
+    userId: string;
+    withdrawalAddresses: string[];
+  }) => Promise<unknown>;
   updateLastClaimed: (userId: string, claimedAt: Date) => Promise<unknown>;
 }
 
 interface ExecuteUserClaimParams {
   chain: Chain;
   claimWithdrawalsService: ClaimWithdrawalsService | null;
+  logger?: Pick<Logger, 'error'>;
   now: Date;
   userId: string;
   userStorage: UserClaimStorage;
@@ -102,29 +109,47 @@ export async function executeUserClaim(
     return claimError('CLAIM_ADDRESSES_EMPTY', 'No cluster withdrawal addresses to claim');
   }
 
-  try {
-    const transaction = await params.claimWithdrawalsService.claimWithdrawals(claimedAddresses);
-    await params.userStorage.clearClaimableWithdrawalAddresses(claimedAddresses);
-    await params.userStorage.updateLastClaimed(params.userId, params.now);
+  let transaction: Awaited<ReturnType<ClaimWithdrawalsService['claimWithdrawals']>>;
 
-    return successResponse({
-      claimedAddresses,
-      nextClaimAt: getNextClaimAt(params.now).toISOString(),
-      transactionHash: transaction.transactionHash,
-      transactionUrl: transaction.transactionUrl,
-    });
+  try {
+    transaction = await params.claimWithdrawalsService.claimWithdrawals(claimedAddresses);
   } catch (error) {
     return claimError(
       'CLAIM_TX_ERROR',
       error instanceof Error ? error.message : 'Failed to send claim transaction',
     );
   }
+
+  try {
+    await params.userStorage.finalizeSuccessfulClaim({
+      claimedAt: params.now,
+      userId: params.userId,
+      withdrawalAddresses: claimedAddresses,
+    });
+  } catch (error) {
+    params.logger?.error(
+      {
+        err: error,
+        transactionHash: transaction.transactionHash,
+        userId: params.userId,
+      },
+      'Failed to finalize successful claim',
+    );
+  }
+
+  return successResponse({
+    claimedAddresses,
+    nextClaimAt: getNextClaimAt(params.now).toISOString(),
+    transactionHash: transaction.transactionHash,
+    transactionUrl: transaction.transactionUrl,
+  });
 }
 
 /** Creates the current-user claim route. */
 export function createUserClaimRoute(params: {
   chain: Chain;
   claimWithdrawalsService: ClaimWithdrawalsService | null;
+  logger?: Pick<Logger, 'error'>;
   procedures: ApiProcedures;
   userStorage: UserClaimStorage;
 }) {
@@ -144,6 +169,7 @@ export function createUserClaimRoute(params: {
       return executeUserClaim({
         chain: params.chain,
         claimWithdrawalsService: params.claimWithdrawalsService,
+        logger: params.logger,
         now: new Date(),
         userId: context.user.id,
         userStorage: params.userStorage,

--- a/packages/api/src/storage/cluster.test.ts
+++ b/packages/api/src/storage/cluster.test.ts
@@ -15,6 +15,20 @@ const migrationUrl = new URL(
   import.meta.url,
 );
 
+/**
+ * Extracts SQL text from either a Prisma tagged-template call or a Prisma.sql object.
+ */
+function getSqlText(queryArg: unknown): string {
+  if (Array.isArray(queryArg)) return Array.from(queryArg).join('?');
+  if (queryArg && typeof queryArg === 'object' && 'strings' in queryArg) {
+    return Array.from((queryArg as { strings: string[] }).strings).join('?');
+  }
+  if (queryArg && typeof queryArg === 'object' && 'sql' in queryArg) {
+    return (queryArg as { sql: string }).sql;
+  }
+  return '';
+}
+
 describe('ClusterStorage.getSummary', () => {
   // Verifies the API-key summary keeps inactive and blocked users out of active metrics.
   it('groups active, blocked, inactive, Telegram, anonymous, and Lido user metrics', async () => {
@@ -418,14 +432,46 @@ describe('ClusterStorage query performance safeguards', () => {
     const storage = new ClusterStorage({ $queryRaw: queryRaw } as never);
 
     // Executes the method so the Prisma tagged SQL is constructed through real code.
-    await storage.getClusterSnapshot('cluster-a');
+    await storage.getClusterSnapshot({ clusterId: 'cluster-a', includeClaimable: false });
 
     // Reads the raw SQL template sent to Prisma for structural assertions.
-    const sql = Array.from(queryRaw.mock.calls[0]?.[0] ?? []).join('?');
+    const sql = getSqlText(queryRaw.mock.calls[0]?.[0]);
 
     // Confirms the joined validator snapshot set is materialized once for reuse.
     expect(sql).toContain('WITH merged_snapshot AS MATERIALIZED');
     // Confirms status breakdown reuses the merged snapshot instead of a second membership join.
     expect(sql).not.toContain('FROM cluster_validator cv2');
+  });
+
+  it('omits claimable reward joins when claimable rewards are disabled', async () => {
+    // This case protects Ethereum deployments from spending DB work on Gnosis-only claimable rewards.
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const storage = new ClusterStorage({ $queryRaw: queryRaw } as never);
+
+    // Requests a cluster snapshot with claimable rewards explicitly disabled.
+    await storage.getClusterSnapshot({ clusterId: 'cluster-a', includeClaimable: false });
+
+    // Reads the generated SQL to verify no claimable table or withdrawal-address aggregation is used.
+    const sql = getSqlText(queryRaw.mock.calls[0]?.[0]);
+
+    // Confirms disabled claimable rewards do not join or aggregate the claimable cache table.
+    expect(sql).not.toContain('withdrawal_address_claimable_snapshot');
+  });
+
+  it('deduplicates claimable rewards by withdrawal address when enabled', async () => {
+    // This case protects clusters with many validators sharing one withdrawal address from double counting.
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const storage = new ClusterStorage({ $queryRaw: queryRaw } as never);
+
+    // Requests a Gnosis snapshot with claimable rewards enabled.
+    await storage.getClusterSnapshot({ clusterId: 'cluster-a', includeClaimable: true });
+
+    // Reads the generated SQL to verify claimable rewards are aggregated by distinct withdrawal address.
+    const sql = getSqlText(queryRaw.mock.calls[0]?.[0]);
+
+    // Confirms the claimable cache is joined only through distinct withdrawal addresses.
+    expect(sql).toContain('withdrawal_address_claimable_snapshot');
+    expect(sql).toContain('claimable_addresses AS');
+    expect(sql).toContain('SELECT DISTINCT');
   });
 });

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -29,6 +29,11 @@ interface ClusterSummaryMetric {
 
 type NumericQueryValue = bigint | number | string | { toString(): string };
 
+type GetClusterSnapshotParams = {
+  clusterId: string;
+  includeClaimable: boolean;
+};
+
 interface ClusterSummaryQueryRow {
   total_clusters: NumericQueryValue;
   active_total: NumericQueryValue;
@@ -683,7 +688,30 @@ export class ClusterStorage {
   /**
    * Get aggregated snapshot data for a cluster's validators
    */
-  async getClusterSnapshot(clusterId: string) {
+  async getClusterSnapshot(params: GetClusterSnapshotParams) {
+    const { clusterId, includeClaimable } = params;
+    const claimableCte = includeClaimable
+      ? Prisma.sql`,
+      claimable_addresses AS MATERIALIZED (
+        SELECT DISTINCT LOWER(v.withdrawal_address) AS withdrawal_address
+        FROM cluster_validator cv
+        JOIN validator v ON v.id = cv.validator_index
+        WHERE cv.cluster_id = ${clusterId}
+          AND v.withdrawal_address IS NOT NULL
+      ),
+      claimable_snapshot AS (
+        SELECT COALESCE(SUM(wacs.amount_wei), 0)::text AS claimable_rewards
+        FROM claimable_addresses ca
+        JOIN withdrawal_address_claimable_snapshot wacs
+          ON wacs.withdrawal_address = ca.withdrawal_address
+      )`
+      : Prisma.empty;
+    const claimableSelect = includeClaimable
+      ? Prisma.sql`,
+        (SELECT claimable_rewards FROM claimable_snapshot) AS claimable_rewards`
+      : Prisma.sql`,
+        NULL::text AS claimable_rewards`;
+
     const rows = await this.prisma.$queryRaw<
       Array<{
         active_count: bigint;
@@ -716,9 +744,10 @@ export class ClusterStorage {
         avg_attestation_delay_d: string | null;
         avg_attestation_delay_w: string | null;
         avg_attestation_delay_m: string | null;
+        claimable_rewards: string | null;
         beacon_status_breakdown: string;
       }>
-    >`
+    >(Prisma.sql`
       WITH merged_snapshot AS MATERIALIZED (
         SELECT
           cv.validator_index,
@@ -762,6 +791,7 @@ export class ClusterStorage {
         LEFT JOIN validators_snapshot_performance p ON p.validator_index = cv.validator_index
         WHERE cv.cluster_id = ${clusterId}
       )
+      ${claimableCte}
       SELECT
         COUNT(*) FILTER (WHERE merged_snapshot.is_inactive = false AND COALESCE(merged_snapshot.beacon_status, 0) IN (0, 1, 2, 3, 4))::bigint AS active_count,
         COUNT(*) FILTER (WHERE merged_snapshot.is_inactive = true AND COALESCE(merged_snapshot.beacon_status, 0) IN (0, 1, 2, 3, 4))::bigint AS inactive_count,
@@ -831,8 +861,9 @@ export class ClusterStorage {
            ) sub),
           '{}'
         ) AS beacon_status_breakdown
+        ${claimableSelect}
       FROM merged_snapshot
-    `;
+    `);
 
     return rows[0] ?? null;
   }

--- a/packages/api/src/storage/user.test.ts
+++ b/packages/api/src/storage/user.test.ts
@@ -42,29 +42,38 @@ describe('UserStorage claim data', () => {
     });
   });
 
-  it('lists distinct fee recipient addresses from clusters owned by the user', async () => {
-    // This scenario verifies claim addresses come from owned cluster fee recipients.
+  it('lists distinct withdrawal addresses from validators in clusters owned by the user', async () => {
+    // This scenario verifies claim addresses come from validators owned through clusters.
     const findMany = vi
       .fn()
       .mockResolvedValue([
-        { feeRecipientAddress: '0x0000000000000000000000000000000000000001' },
-        { feeRecipientAddress: '0x0000000000000000000000000000000000000002' },
+        { withdrawalAddress: '0x0000000000000000000000000000000000000001' },
+        { withdrawalAddress: '0x0000000000000000000000000000000000000002' },
       ]);
-    const storage = new UserStorage({ cluster: { findMany } } as never);
+    const storage = new UserStorage({ validator: { findMany } } as never);
 
-    // Loads all non-null fee recipient addresses for the authenticated user clusters.
-    const result = await storage.listOwnedClusterFeeRecipientAddresses('user-a');
+    // Loads all non-null withdrawal addresses for validators in authenticated user clusters.
+    const result = await storage.listOwnedClusterWithdrawalAddresses('user-a');
 
     // Confirms storage returns the address strings consumed by the claim service.
     expect(result).toEqual([
       '0x0000000000000000000000000000000000000001',
       '0x0000000000000000000000000000000000000002',
     ]);
-    // Confirms Prisma applies owner scoping, null filtering, and distinct address selection.
+    // Confirms Prisma applies owner scoping through cluster membership and distinct address selection.
     expect(findMany).toHaveBeenCalledWith({
-      where: { ownerId: 'user-a', feeRecipientAddress: { not: null } },
-      select: { feeRecipientAddress: true },
-      distinct: ['feeRecipientAddress'],
+      where: {
+        clusters: {
+          some: {
+            cluster: {
+              ownerId: 'user-a',
+            },
+          },
+        },
+        withdrawalAddress: { not: null },
+      },
+      select: { withdrawalAddress: true },
+      distinct: ['withdrawalAddress'],
     });
   });
 

--- a/packages/api/src/storage/user.test.ts
+++ b/packages/api/src/storage/user.test.ts
@@ -2,6 +2,17 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { UserStorage } from './user.js';
 
+/**
+ * Extracts SQL text from a Prisma.sql object used by raw storage operations.
+ */
+function getSqlText(queryArg: unknown): string {
+  if (queryArg && typeof queryArg === 'object' && 'sql' in queryArg) {
+    return (queryArg as { sql: string }).sql;
+  }
+
+  return '';
+}
+
 describe('UserStorage user context', () => {
   it('returns only user identity when resolving the current user', async () => {
     // This case verifies authenticated user context excludes cluster-level Lido CSM state.
@@ -91,5 +102,25 @@ describe('UserStorage claim data', () => {
       where: { id: 'user-a' },
       data: { lastClaimed: claimedAt },
     });
+  });
+
+  it('clears claimable snapshot rows for claimed withdrawal addresses', async () => {
+    // This scenario ensures the API claim path removes stale claimable amounts immediately after claim.
+    const executeRaw = vi.fn().mockResolvedValue(undefined);
+    const storage = new UserStorage({ $executeRaw: executeRaw } as never);
+    const withdrawalAddresses = [
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+    ];
+
+    // Clears the claimable snapshot cache for the exact addresses sent to the claim contract.
+    await storage.clearClaimableWithdrawalAddresses(withdrawalAddresses);
+
+    // Confirms storage deletes only from the withdrawal-address claimable snapshot table.
+    const sql = getSqlText(executeRaw.mock.calls[0]?.[0]);
+    expect(sql).toContain('DELETE FROM withdrawal_address_claimable_snapshot');
+    expect(sql).toContain('WHERE withdrawal_address IN');
+    // Confirms the delete is parameterized with the lowercased claimed withdrawal addresses.
+    expect(executeRaw.mock.calls[0]?.[0].values).toEqual(withdrawalAddresses);
   });
 });

--- a/packages/api/src/storage/user.test.ts
+++ b/packages/api/src/storage/user.test.ts
@@ -123,4 +123,38 @@ describe('UserStorage claim data', () => {
     // Confirms the delete is parameterized with the lowercased claimed withdrawal addresses.
     expect(executeRaw.mock.calls[0]?.[0].values).toEqual(withdrawalAddresses);
   });
+
+  it('finalizes a successful claim in one database transaction', async () => {
+    // This scenario keeps cache cleanup and cooldown updates atomic after an on-chain claim succeeds.
+    const transactionClient = {
+      $executeRaw: vi.fn().mockResolvedValue(undefined),
+      user: {
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+    const transaction = vi.fn(async (callback: (tx: typeof transactionClient) => Promise<void>) => {
+      await callback(transactionClient);
+    });
+    const storage = new UserStorage({ $transaction: transaction } as never);
+    const claimedAt = new Date('2026-01-10T12:00:00.000Z');
+    const withdrawalAddresses = [
+      '0x0000000000000000000000000000000000000001',
+      '0x0000000000000000000000000000000000000002',
+    ];
+
+    // Finalizes the database state associated with a successful claim transaction.
+    await storage.finalizeSuccessfulClaim({
+      claimedAt,
+      userId: 'user-a',
+      withdrawalAddresses,
+    });
+
+    // Confirms both database writes are executed inside the same Prisma transaction callback.
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transactionClient.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(transactionClient.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-a' },
+      data: { lastClaimed: claimedAt },
+    });
+  });
 });

--- a/packages/api/src/storage/user.ts
+++ b/packages/api/src/storage/user.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@beacon-indexer/db';
+import { Prisma, PrismaClient } from '@beacon-indexer/db';
 
 /**
  * UserStorage - Database persistence layer for user operations
@@ -92,6 +92,24 @@ export class UserStorage {
     });
 
     return rows.map((row) => row.withdrawalAddress as string);
+  }
+
+  /**
+   * Removes cached claimable amounts for withdrawal addresses submitted to the claim contract.
+   */
+  async clearClaimableWithdrawalAddresses(withdrawalAddresses: string[]): Promise<void> {
+    if (withdrawalAddresses.length === 0) {
+      return;
+    }
+
+    const normalizedAddresses = Array.from(
+      new Set(withdrawalAddresses.map((address) => address.toLowerCase())),
+    );
+
+    await this.prisma.$executeRaw(Prisma.sql`
+      DELETE FROM withdrawal_address_claimable_snapshot
+      WHERE withdrawal_address IN (${Prisma.join(normalizedAddresses)})
+    `);
   }
 
   /**

--- a/packages/api/src/storage/user.ts
+++ b/packages/api/src/storage/user.ts
@@ -73,16 +73,25 @@ export class UserStorage {
   }
 
   /**
-   * Lists unique fee recipient addresses configured on clusters owned by the user.
+   * Lists unique withdrawal addresses from validators in clusters owned by the user.
    */
-  async listOwnedClusterFeeRecipientAddresses(userId: string): Promise<string[]> {
-    const rows = await this.prisma.cluster.findMany({
-      where: { ownerId: userId, feeRecipientAddress: { not: null } },
-      select: { feeRecipientAddress: true },
-      distinct: ['feeRecipientAddress'],
+  async listOwnedClusterWithdrawalAddresses(userId: string): Promise<string[]> {
+    const rows = await this.prisma.validator.findMany({
+      where: {
+        clusters: {
+          some: {
+            cluster: {
+              ownerId: userId,
+            },
+          },
+        },
+        withdrawalAddress: { not: null },
+      },
+      select: { withdrawalAddress: true },
+      distinct: ['withdrawalAddress'],
     });
 
-    return rows.map((row) => row.feeRecipientAddress as string);
+    return rows.map((row) => row.withdrawalAddress as string);
   }
 
   /**

--- a/packages/api/src/storage/user.ts
+++ b/packages/api/src/storage/user.ts
@@ -1,5 +1,7 @@
 import { Prisma, PrismaClient } from '@beacon-indexer/db';
 
+type ClaimableSnapshotDeleteClient = Pick<PrismaClient, '$executeRaw'>;
+
 /**
  * UserStorage - Database persistence layer for user operations
  */
@@ -98,6 +100,33 @@ export class UserStorage {
    * Removes cached claimable amounts for withdrawal addresses submitted to the claim contract.
    */
   async clearClaimableWithdrawalAddresses(withdrawalAddresses: string[]): Promise<void> {
+    await this.deleteClaimableWithdrawalAddressRows(this.prisma, withdrawalAddresses);
+  }
+
+  /**
+   * Finalizes post-transaction claim state in one database transaction.
+   */
+  async finalizeSuccessfulClaim(params: {
+    claimedAt: Date;
+    userId: string;
+    withdrawalAddresses: string[];
+  }): Promise<void> {
+    await this.prisma.$transaction(async (tx) => {
+      await this.deleteClaimableWithdrawalAddressRows(tx, params.withdrawalAddresses);
+      await tx.user.update({
+        where: { id: params.userId },
+        data: { lastClaimed: params.claimedAt },
+      });
+    });
+  }
+
+  /**
+   * Deletes cached claimable rows using the provided Prisma client or active transaction.
+   */
+  private async deleteClaimableWithdrawalAddressRows(
+    prisma: ClaimableSnapshotDeleteClient,
+    withdrawalAddresses: string[],
+  ): Promise<void> {
     if (withdrawalAddresses.length === 0) {
       return;
     }
@@ -106,7 +135,7 @@ export class UserStorage {
       new Set(withdrawalAddresses.map((address) => address.toLowerCase())),
     );
 
-    await this.prisma.$executeRaw(Prisma.sql`
+    await prisma.$executeRaw(Prisma.sql`
       DELETE FROM withdrawal_address_claimable_snapshot
       WHERE withdrawal_address IN (${Prisma.join(normalizedAddresses)})
     `);

--- a/packages/db/prisma/migrations/20260605170000_add_withdrawal_address_claimable_snapshot/migration.sql
+++ b/packages/db/prisma/migrations/20260605170000_add_withdrawal_address_claimable_snapshot/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "public"."withdrawal_address_claimable_snapshot" (
+    "withdrawal_address" VARCHAR(42) NOT NULL,
+    "amount_wei" DECIMAL(78,0) NOT NULL,
+    "updated_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "withdrawal_address_claimable_snapshot_pkey" PRIMARY KEY ("withdrawal_address")
+);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -501,6 +501,14 @@ model ValidatorsSnapshotPerformance {
   @@map("validators_snapshot_performance")
 }
 
+model WithdrawalAddressClaimableSnapshot {
+  withdrawalAddress String   @id(map: "withdrawal_address_claimable_snapshot_pkey") @map("withdrawal_address") @db.VarChar(42)
+  amountWei         Decimal  @map("amount_wei") @db.Decimal(78, 0)
+  updatedAt         DateTime @default(now()) @map("updated_at") @db.Timestamp
+
+  @@map("withdrawal_address_claimable_snapshot")
+}
+
 model ValidatorActivityProcessorState {
   processor             String   @id @map("processor") @db.VarChar(64)
   lastEvaluatedDutySlot Int      @map("last_evaluated_duty_slot")

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -50,7 +50,7 @@
     "rate-limiter-flexible": "^5.0.3",
     "toad-scheduler": "^3.0.1",
     "tsx": "^4.7.1",
-    "viem": "^2.23.13",
+    "viem": "^2.52.2",
     "xstate": "^5.22.1",
     "zod": "^3.23.8"
   },

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -6,6 +6,7 @@ import createLogger from '@/src/lib/pino.js';
 import { getPrisma } from '@/src/lib/prisma.js';
 import { BeaconClient } from '@/src/services/consensus/beacon.js';
 import { ChainStatsController } from '@/src/services/consensus/controllers/chainStats.js';
+import { ClaimableWithdrawalsController } from '@/src/services/consensus/controllers/claimableWithdrawals.js';
 import { DailyArchiveController } from '@/src/services/consensus/controllers/dailyArchive.js';
 import { DailyArchiveDetailCleanupController } from '@/src/services/consensus/controllers/dailyArchiveDetailCleanup.js';
 import { EpochController } from '@/src/services/consensus/controllers/epoch.js';
@@ -19,6 +20,7 @@ import { SnapshotController } from '@/src/services/consensus/controllers/snapsho
 import { ValidatorActivityStatusController } from '@/src/services/consensus/controllers/validatorActivityStatus.js';
 import { ValidatorsController } from '@/src/services/consensus/controllers/validators.js';
 import { ChainStatsStorage } from '@/src/services/consensus/storage/chainStats.js';
+import { ClaimableWithdrawalsStorage } from '@/src/services/consensus/storage/claimableWithdrawals.js';
 import { DailyArchiveStorage } from '@/src/services/consensus/storage/dailyArchive.js';
 import { DailyArchiveDetailCleanupStorage } from '@/src/services/consensus/storage/dailyArchiveDetailCleanup.js';
 import { EpochStorage } from '@/src/services/consensus/storage/epoch.js';
@@ -32,6 +34,7 @@ import { SnapshotStorage } from '@/src/services/consensus/storage/snapshot.js';
 import { ValidatorActivityStatusStorage } from '@/src/services/consensus/storage/validatorActivityStatus.js';
 import { ValidatorsStorage } from '@/src/services/consensus/storage/validators.js';
 import { ExecutionClient } from '@/src/services/execution/execution.js';
+import { GnosisWithdrawableAmountsReader } from '@/src/services/gnosis/withdrawableAmounts.js';
 import initXstateMachines from '@/src/xstate/index.js';
 
 const logger = createLogger('index file');
@@ -186,6 +189,18 @@ async function main() {
   // Create snapshot storage and controller
   const snapshotStorage = new SnapshotStorage(prisma);
   const snapshotController = new SnapshotController(snapshotStorage, beaconTime);
+  const claimableWithdrawalsController =
+    env.CHAIN === 'gnosis' && chainConfig.blockchain.scDepositAddress
+      ? new ClaimableWithdrawalsController({
+          chain: env.CHAIN,
+          reader: new GnosisWithdrawableAmountsReader({
+            bkpRpcUrl: env.BKP_EXECUTION_RPC,
+            depositContractAddress: chainConfig.blockchain.scDepositAddress,
+            mainRpcUrl: env.MAIN_EXECUTION_RPC,
+          }),
+          storage: new ClaimableWithdrawalsStorage(prisma),
+        })
+      : undefined;
 
   // Create incident storage and tracker controller
   const incidentRewardsStorage = new IncidentRewardsStorage(prisma, {
@@ -234,6 +249,7 @@ async function main() {
     chainConfig.beacon.maxAttestationDelay,
     chainConfig.beacon.delaySlotsToHead,
     chainConfig.beacon.missedAttestationsForInactivity,
+    claimableWithdrawalsController,
   );
 }
 

--- a/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.test.ts
@@ -82,10 +82,6 @@ describe('ClaimableWithdrawalsController', () => {
       { amountWei: 200n, withdrawalAddress: ADDRESS_TWO },
       { amountWei: 300n, withdrawalAddress: ADDRESS_THREE },
     ]);
-    expect(storage.pruneUntrackedWithdrawalAddresses).toHaveBeenCalledWith([
-      ADDRESS_ONE,
-      ADDRESS_TWO,
-      ADDRESS_THREE,
-    ]);
+    expect(storage.pruneUntrackedWithdrawalAddresses).toHaveBeenCalledWith();
   });
 });

--- a/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ClaimableWithdrawalsController } from './claimableWithdrawals.js';
+
+const ADDRESS_ONE = '0x0000000000000000000000000000000000000001';
+const ADDRESS_TWO = '0x0000000000000000000000000000000000000002';
+const ADDRESS_THREE = '0x0000000000000000000000000000000000000003';
+
+/**
+ * Creates storage doubles that expose only the DB operations used by the controller.
+ */
+function createStorage() {
+  return {
+    listTrackedWithdrawalAddresses: vi.fn(),
+    pruneUntrackedWithdrawalAddresses: vi.fn(),
+    upsertClaimableAmounts: vi.fn(),
+  };
+}
+
+/**
+ * Creates an RPC reader double that exposes only the contract read operation.
+ */
+function createReader() {
+  return {
+    getWithdrawableAmounts: vi.fn(),
+  };
+}
+
+describe('ClaimableWithdrawalsController', () => {
+  // These controller tests verify chain gating and Gnosis RPC batching for claimable snapshots.
+  it('returns immediately on Ethereum without querying DB or RPC', async () => {
+    // This scenario protects Ethereum deployments from spending resources on Gnosis-only claimable work.
+    const storage = createStorage();
+    const reader = createReader();
+    const controller = new ClaimableWithdrawalsController({
+      chain: 'ethereum',
+      reader,
+      storage,
+    });
+
+    // Runs the hourly update on an Ethereum deployment.
+    await controller.updateClaimableSnapshots();
+
+    // Confirms the early return happens before any database or RPC dependency is touched.
+    expect(storage.listTrackedWithdrawalAddresses).not.toHaveBeenCalled();
+    expect(reader.getWithdrawableAmounts).not.toHaveBeenCalled();
+    expect(storage.upsertClaimableAmounts).not.toHaveBeenCalled();
+    expect(storage.pruneUntrackedWithdrawalAddresses).not.toHaveBeenCalled();
+  });
+
+  it('reads Gnosis withdrawable amounts in chunks and stores the raw amounts', async () => {
+    // This scenario verifies the Gnosis path batches RPC calls and persists every returned address amount.
+    const storage = createStorage();
+    storage.listTrackedWithdrawalAddresses.mockResolvedValue([
+      ADDRESS_ONE,
+      ADDRESS_TWO,
+      ADDRESS_THREE,
+    ]);
+    const reader = createReader();
+    reader.getWithdrawableAmounts
+      .mockResolvedValueOnce([
+        { amountWei: 100n, withdrawalAddress: ADDRESS_ONE },
+        { amountWei: 200n, withdrawalAddress: ADDRESS_TWO },
+      ])
+      .mockResolvedValueOnce([{ amountWei: 300n, withdrawalAddress: ADDRESS_THREE }]);
+    const controller = new ClaimableWithdrawalsController({
+      chain: 'gnosis',
+      chunkSize: 2,
+      reader,
+      storage,
+    });
+
+    // Runs the hourly update with three tracked withdrawal addresses and a chunk size of two.
+    await controller.updateClaimableSnapshots();
+
+    // Confirms RPC reads are split into predictable chunks.
+    expect(reader.getWithdrawableAmounts).toHaveBeenNthCalledWith(1, [ADDRESS_ONE, ADDRESS_TWO]);
+    expect(reader.getWithdrawableAmounts).toHaveBeenNthCalledWith(2, [ADDRESS_THREE]);
+    // Confirms all returned raw amounts are upserted before stale rows are pruned.
+    expect(storage.upsertClaimableAmounts).toHaveBeenCalledWith([
+      { amountWei: 100n, withdrawalAddress: ADDRESS_ONE },
+      { amountWei: 200n, withdrawalAddress: ADDRESS_TWO },
+      { amountWei: 300n, withdrawalAddress: ADDRESS_THREE },
+    ]);
+    expect(storage.pruneUntrackedWithdrawalAddresses).toHaveBeenCalledWith([
+      ADDRESS_ONE,
+      ADDRESS_TWO,
+      ADDRESS_THREE,
+    ]);
+  });
+});

--- a/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
+++ b/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
@@ -1,4 +1,5 @@
 import type { Chain } from '@beacon-indexer/beacon-utils';
+import chunk from 'lodash/chunk.js';
 
 import type { ClaimableWithdrawalAmount } from '../storage/claimableWithdrawals.js';
 
@@ -44,24 +45,11 @@ export class ClaimableWithdrawalsController {
     const withdrawalAddresses = await this.storage.listTrackedWithdrawalAddresses();
     const claimableAmounts: ClaimableWithdrawalAmount[] = [];
 
-    for (const addressChunk of this.chunkAddresses(withdrawalAddresses)) {
+    for (const addressChunk of chunk(withdrawalAddresses, this.chunkSize)) {
       claimableAmounts.push(...(await this.reader.getWithdrawableAmounts(addressChunk)));
     }
 
     await this.storage.upsertClaimableAmounts(claimableAmounts);
     await this.storage.pruneUntrackedWithdrawalAddresses();
-  }
-
-  /**
-   * Splits withdrawal addresses into deterministic RPC batches.
-   */
-  private chunkAddresses(withdrawalAddresses: string[]): string[][] {
-    const chunks: string[][] = [];
-
-    for (let index = 0; index < withdrawalAddresses.length; index += this.chunkSize) {
-      chunks.push(withdrawalAddresses.slice(index, index + this.chunkSize));
-    }
-
-    return chunks;
   }
 }

--- a/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
+++ b/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
@@ -8,7 +8,7 @@ type ClaimableWithdrawalsReader = {
 
 type ClaimableWithdrawalsStorageLike = {
   listTrackedWithdrawalAddresses: () => Promise<string[]>;
-  pruneUntrackedWithdrawalAddresses: (trackedWithdrawalAddresses: string[]) => Promise<void>;
+  pruneUntrackedWithdrawalAddresses: () => Promise<void>;
   upsertClaimableAmounts: (amounts: ClaimableWithdrawalAmount[]) => Promise<void>;
 };
 
@@ -49,7 +49,7 @@ export class ClaimableWithdrawalsController {
     }
 
     await this.storage.upsertClaimableAmounts(claimableAmounts);
-    await this.storage.pruneUntrackedWithdrawalAddresses(withdrawalAddresses);
+    await this.storage.pruneUntrackedWithdrawalAddresses();
   }
 
   /**

--- a/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
+++ b/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
@@ -1,0 +1,67 @@
+import type { Chain } from '@beacon-indexer/beacon-utils';
+
+import type { ClaimableWithdrawalAmount } from '../storage/claimableWithdrawals.js';
+
+type ClaimableWithdrawalsReader = {
+  getWithdrawableAmounts: (withdrawalAddresses: string[]) => Promise<ClaimableWithdrawalAmount[]>;
+};
+
+type ClaimableWithdrawalsStorageLike = {
+  listTrackedWithdrawalAddresses: () => Promise<string[]>;
+  pruneUntrackedWithdrawalAddresses: (trackedWithdrawalAddresses: string[]) => Promise<void>;
+  upsertClaimableAmounts: (amounts: ClaimableWithdrawalAmount[]) => Promise<void>;
+};
+
+type ClaimableWithdrawalsControllerParams = {
+  chain: Chain;
+  chunkSize?: number;
+  reader: ClaimableWithdrawalsReader;
+  storage: ClaimableWithdrawalsStorageLike;
+};
+
+/**
+ * ClaimableWithdrawalsController refreshes Gnosis claimable withdrawal snapshots from the deposit contract.
+ */
+export class ClaimableWithdrawalsController {
+  private readonly chunkSize: number;
+  private readonly chain: Chain;
+  private readonly reader: ClaimableWithdrawalsReader;
+  private readonly storage: ClaimableWithdrawalsStorageLike;
+
+  constructor(params: ClaimableWithdrawalsControllerParams) {
+    this.chain = params.chain;
+    this.chunkSize = params.chunkSize ?? 25;
+    this.reader = params.reader;
+    this.storage = params.storage;
+  }
+
+  /**
+   * Refreshes claimable snapshots for tracked withdrawal addresses, doing no work outside Gnosis.
+   */
+  async updateClaimableSnapshots(): Promise<void> {
+    if (this.chain !== 'gnosis') return;
+
+    const withdrawalAddresses = await this.storage.listTrackedWithdrawalAddresses();
+    const claimableAmounts: ClaimableWithdrawalAmount[] = [];
+
+    for (const addressChunk of this.chunkAddresses(withdrawalAddresses)) {
+      claimableAmounts.push(...(await this.reader.getWithdrawableAmounts(addressChunk)));
+    }
+
+    await this.storage.upsertClaimableAmounts(claimableAmounts);
+    await this.storage.pruneUntrackedWithdrawalAddresses(withdrawalAddresses);
+  }
+
+  /**
+   * Splits withdrawal addresses into deterministic RPC batches.
+   */
+  private chunkAddresses(withdrawalAddresses: string[]): string[][] {
+    const chunks: string[][] = [];
+
+    for (let index = 0; index < withdrawalAddresses.length; index += this.chunkSize) {
+      chunks.push(withdrawalAddresses.slice(index, index + this.chunkSize));
+    }
+
+    return chunks;
+  }
+}

--- a/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
+++ b/packages/indexer/src/services/consensus/controllers/claimableWithdrawals.ts
@@ -3,6 +3,8 @@ import chunk from 'lodash/chunk.js';
 
 import type { ClaimableWithdrawalAmount } from '../storage/claimableWithdrawals.js';
 
+const DEFAULT_CLAIMABLE_WITHDRAWAL_BATCH_SIZE = 50;
+
 type ClaimableWithdrawalsReader = {
   getWithdrawableAmounts: (withdrawalAddresses: string[]) => Promise<ClaimableWithdrawalAmount[]>;
 };
@@ -31,7 +33,7 @@ export class ClaimableWithdrawalsController {
 
   constructor(params: ClaimableWithdrawalsControllerParams) {
     this.chain = params.chain;
-    this.chunkSize = params.chunkSize ?? 25;
+    this.chunkSize = params.chunkSize ?? DEFAULT_CLAIMABLE_WITHDRAWAL_BATCH_SIZE;
     this.reader = params.reader;
     this.storage = params.storage;
   }

--- a/packages/indexer/src/services/consensus/storage/claimableWithdrawals.test.ts
+++ b/packages/indexer/src/services/consensus/storage/claimableWithdrawals.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ClaimableWithdrawalsStorage } from './claimableWithdrawals.js';
+
+/**
+ * Extracts SQL text from a Prisma.sql object used by raw storage operations.
+ */
+function getSqlText(queryArg: unknown): string {
+  if (queryArg && typeof queryArg === 'object' && 'sql' in queryArg) {
+    return (queryArg as { sql: string }).sql;
+  }
+
+  return '';
+}
+
+describe('ClaimableWithdrawalsStorage', () => {
+  // This suite verifies claimable snapshot pruning stays database-side and parameter-safe.
+  it('prunes stale claimable snapshots with a database-side tracked-address subquery', async () => {
+    // This scenario keeps pruning scalable when the tracked withdrawal address set grows large.
+    const executeRaw = vi.fn().mockResolvedValue(undefined);
+    const storage = new ClaimableWithdrawalsStorage({ $executeRaw: executeRaw } as never);
+
+    // Runs pruning without passing a potentially large tracked address array through query params.
+    await storage.pruneUntrackedWithdrawalAddresses();
+
+    // Confirms the delete computes tracked withdrawal addresses inside PostgreSQL.
+    const sql = getSqlText(executeRaw.mock.calls[0]?.[0]);
+    expect(sql).toContain('DELETE FROM withdrawal_address_claimable_snapshot');
+    expect(sql).toContain('SELECT DISTINCT LOWER(v.withdrawal_address)');
+    expect(sql).toContain('JOIN validator v ON v.id = cv.validator_index');
+    // Confirms pruning does not bind one parameter per tracked address.
+    expect(executeRaw.mock.calls[0]?.[0].values).toEqual([]);
+  });
+});

--- a/packages/indexer/src/services/consensus/storage/claimableWithdrawals.ts
+++ b/packages/indexer/src/services/consensus/storage/claimableWithdrawals.ts
@@ -56,19 +56,15 @@ export class ClaimableWithdrawalsStorage {
   /**
    * Removes claimable snapshot rows for withdrawal addresses no longer tracked by any cluster.
    */
-  async pruneUntrackedWithdrawalAddresses(trackedWithdrawalAddresses: string[]): Promise<void> {
-    if (trackedWithdrawalAddresses.length === 0) {
-      await this.prisma.$executeRaw(Prisma.sql`
-        DELETE FROM withdrawal_address_claimable_snapshot
-      `);
-      return;
-    }
-
-    const normalizedAddresses = trackedWithdrawalAddresses.map((address) => address.toLowerCase());
-
+  async pruneUntrackedWithdrawalAddresses(): Promise<void> {
     await this.prisma.$executeRaw(Prisma.sql`
       DELETE FROM withdrawal_address_claimable_snapshot
-      WHERE withdrawal_address NOT IN (${Prisma.join(normalizedAddresses)})
+      WHERE withdrawal_address NOT IN (
+        SELECT DISTINCT LOWER(v.withdrawal_address)
+        FROM cluster_validator cv
+        JOIN validator v ON v.id = cv.validator_index
+        WHERE v.withdrawal_address IS NOT NULL
+      )
     `);
   }
 }

--- a/packages/indexer/src/services/consensus/storage/claimableWithdrawals.ts
+++ b/packages/indexer/src/services/consensus/storage/claimableWithdrawals.ts
@@ -1,0 +1,74 @@
+import { Prisma, PrismaClient } from '@beacon-indexer/db';
+
+export type ClaimableWithdrawalAmount = {
+  withdrawalAddress: string;
+  amountWei: bigint;
+};
+
+/**
+ * ClaimableWithdrawalsStorage owns database reads and writes for withdrawal-address claimable snapshots.
+ */
+export class ClaimableWithdrawalsStorage {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Lists distinct withdrawal addresses currently tracked by at least one cluster validator.
+   */
+  async listTrackedWithdrawalAddresses(): Promise<string[]> {
+    const rows = await this.prisma.$queryRaw<Array<{ withdrawal_address: string }>>(Prisma.sql`
+      SELECT DISTINCT LOWER(v.withdrawal_address) AS withdrawal_address
+      FROM cluster_validator cv
+      JOIN validator v ON v.id = cv.validator_index
+      WHERE v.withdrawal_address IS NOT NULL
+    `);
+
+    return rows.map((row) => row.withdrawal_address);
+  }
+
+  /**
+   * Upserts raw contract amounts for withdrawal addresses read from the Gnosis deposit contract.
+   */
+  async upsertClaimableAmounts(amounts: ClaimableWithdrawalAmount[]): Promise<void> {
+    if (amounts.length === 0) return;
+
+    const values = amounts.map((amount) => {
+      return Prisma.sql`(
+        ${amount.withdrawalAddress.toLowerCase()},
+        ${amount.amountWei.toString()}::numeric,
+        NOW()
+      )`;
+    });
+
+    await this.prisma.$executeRaw(Prisma.sql`
+      INSERT INTO withdrawal_address_claimable_snapshot (
+        withdrawal_address,
+        amount_wei,
+        updated_at
+      )
+      VALUES ${Prisma.join(values)}
+      ON CONFLICT (withdrawal_address) DO UPDATE
+      SET
+        amount_wei = EXCLUDED.amount_wei,
+        updated_at = EXCLUDED.updated_at
+    `);
+  }
+
+  /**
+   * Removes claimable snapshot rows for withdrawal addresses no longer tracked by any cluster.
+   */
+  async pruneUntrackedWithdrawalAddresses(trackedWithdrawalAddresses: string[]): Promise<void> {
+    if (trackedWithdrawalAddresses.length === 0) {
+      await this.prisma.$executeRaw(Prisma.sql`
+        DELETE FROM withdrawal_address_claimable_snapshot
+      `);
+      return;
+    }
+
+    const normalizedAddresses = trackedWithdrawalAddresses.map((address) => address.toLowerCase());
+
+    await this.prisma.$executeRaw(Prisma.sql`
+      DELETE FROM withdrawal_address_claimable_snapshot
+      WHERE withdrawal_address NOT IN (${Prisma.join(normalizedAddresses)})
+    `);
+  }
+}

--- a/packages/indexer/src/services/gnosis/withdrawableAmounts.test.ts
+++ b/packages/indexer/src/services/gnosis/withdrawableAmounts.test.ts
@@ -9,35 +9,129 @@ const ADDRESS_TWO = '0x0000000000000000000000000000000000000002';
 // ADDRESS_THREE represents another tracked withdrawal address that must not be blocked by failures.
 const ADDRESS_THREE = '0x0000000000000000000000000000000000000003';
 
+type MulticallClientDouble = {
+  multicall: (params: {
+    allowFailure: true;
+    contracts: Array<{
+      abi: unknown;
+      address: string;
+      args: readonly [string];
+      functionName: string;
+    }>;
+  }) => Promise<unknown>;
+};
+
 /**
- * Reads the private axios client used by the Gnosis reader so tests can control RPC responses.
+ * Reads the private multicall clients used by the Gnosis reader so tests can control RPC behavior.
  */
-function getAxiosInstance(reader: GnosisWithdrawableAmountsReader): { post: unknown } {
-  return (reader as unknown as { axiosInstance: { post: unknown } }).axiosInstance;
+function getPublicClients(reader: GnosisWithdrawableAmountsReader): MulticallClientDouble[] {
+  return (reader as unknown as { publicClients: MulticallClientDouble[] }).publicClients;
+}
+
+/**
+ * Builds deterministic withdrawal addresses so batch-size tests can assert exact multicall sizes.
+ */
+function createWithdrawalAddresses(count: number): string[] {
+  return Array.from(
+    { length: count },
+    (_, index) => `0x${(index + 1).toString(16).padStart(40, '0')}`,
+  );
+}
+
+/**
+ * Creates successful multicall responses using the same raw amount for every contract call.
+ */
+function createSuccessfulMulticallResults(count: number) {
+  return Array.from({ length: count }, () => ({ result: 100n, status: 'success' as const }));
+}
+
+/**
+ * Creates a reader and exposes its viem clients so each test can stub RPC behavior precisely.
+ */
+function createReaderWithClients() {
+  const reader = new GnosisWithdrawableAmountsReader({
+    bkpRpcUrl: 'https://backup-rpc.example',
+    depositContractAddress: '0x0000000000000000000000000000000000000100',
+    mainRpcUrl: 'https://main-rpc.example',
+  });
+
+  return { publicClients: getPublicClients(reader), reader };
 }
 
 describe('GnosisWithdrawableAmountsReader', () => {
   // This suite verifies per-address RPC failures do not block the entire claimable snapshot batch.
+  it('reads through viem multicall contract calls against the deposit contract', async () => {
+    // This scenario verifies the reader delegates ABI encoding and Multicall3 transport to viem.
+    const { publicClients, reader } = createReaderWithClients();
+    const [mainClient] = publicClients;
+    const multicallSpy = vi.spyOn(mainClient, 'multicall').mockResolvedValueOnce([
+      { result: 100n, status: 'success' },
+      { result: 200n, status: 'success' },
+    ]);
+
+    // Reads two addresses so the test can inspect one viem multicall request with two contracts.
+    const amounts = await reader.getWithdrawableAmounts([ADDRESS_ONE, ADDRESS_TWO]);
+
+    // Confirms viem results are mapped back to the original withdrawal addresses.
+    expect(amounts).toEqual([
+      { amountWei: 100n, withdrawalAddress: ADDRESS_ONE },
+      { amountWei: 200n, withdrawalAddress: ADDRESS_TWO },
+    ]);
+    // Confirms the reader passes deposit-contract read calls to viem instead of building JSON-RPC.
+    expect(multicallSpy.mock.calls[0]?.[0]).toMatchObject({
+      allowFailure: true,
+      contracts: [
+        {
+          address: '0x0000000000000000000000000000000000000100',
+          args: [ADDRESS_ONE],
+          functionName: 'withdrawableAmount',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000100',
+          args: [ADDRESS_TWO],
+          functionName: 'withdrawableAmount',
+        },
+      ],
+    });
+    expect(multicallSpy.mock.calls[0]?.[0].contracts[0]?.abi).toBeDefined();
+  });
+
+  it('reads withdrawable amounts through sequential multicall batches of 50 addresses', async () => {
+    // This scenario keeps direct reader calls from creating oversized multicall payloads.
+    const { publicClients, reader } = createReaderWithClients();
+    const [mainClient, backupClient] = publicClients;
+    const mainMulticall = vi
+      .spyOn(mainClient, 'multicall')
+      .mockResolvedValueOnce(createSuccessfulMulticallResults(50))
+      .mockResolvedValueOnce(createSuccessfulMulticallResults(50))
+      .mockResolvedValueOnce(createSuccessfulMulticallResults(20));
+    const backupMulticall = vi.spyOn(backupClient, 'multicall');
+
+    // Reads more addresses than one safe multicall request should carry.
+    const amounts = await reader.getWithdrawableAmounts(createWithdrawalAddresses(120));
+
+    // Confirms all successful results are returned from three safe-sized multicall batches.
+    expect(amounts).toHaveLength(120);
+    expect(mainMulticall).toHaveBeenCalledTimes(3);
+    expect(mainMulticall.mock.calls[0]?.[0].contracts).toHaveLength(50);
+    expect(mainMulticall.mock.calls[1]?.[0].contracts).toHaveLength(50);
+    expect(mainMulticall.mock.calls[2]?.[0].contracts).toHaveLength(20);
+    // Confirms backup RPC is not used when the main RPC returns every amount successfully.
+    expect(backupMulticall).not.toHaveBeenCalled();
+  });
+
   it('skips addresses that fail on every RPC and returns successful reads', async () => {
     // This scenario prevents one permanently failing address from blocking the hourly snapshot update.
-    const reader = new GnosisWithdrawableAmountsReader({
-      bkpRpcUrl: 'https://backup-rpc.example',
-      depositContractAddress: '0x0000000000000000000000000000000000000100',
-      mainRpcUrl: 'https://main-rpc.example',
-    });
-    const axiosInstance = getAxiosInstance(reader);
-    const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockImplementation(((
-      _rpcUrl: string,
-      body: { params: [{ data: string }] },
-    ) => {
-      // This mocked RPC fails the second address on both main and backup endpoints.
-      if (body.params[0].data.endsWith(ADDRESS_TWO.slice(2).padStart(64, '0'))) {
-        return Promise.reject(new Error('rate limited'));
-      }
-
-      // This mocked RPC returns one raw uint256 amount for every address that is not failing.
-      return Promise.resolve({ data: { jsonrpc: '2.0', id: 1, result: '0x64' } });
-    }) as never);
+    const { publicClients, reader } = createReaderWithClients();
+    const [mainClient, backupClient] = publicClients;
+    const mainMulticall = vi.spyOn(mainClient, 'multicall').mockResolvedValueOnce([
+      { result: 100n, status: 'success' },
+      { error: new Error('rate limited'), status: 'failure' },
+      { result: 100n, status: 'success' },
+    ]);
+    const backupMulticall = vi
+      .spyOn(backupClient, 'multicall')
+      .mockResolvedValueOnce([{ error: new Error('backup rate limited'), status: 'failure' }]);
 
     // Reads three addresses while the middle address fails all RPC attempts.
     const amounts = await reader.getWithdrawableAmounts([ADDRESS_ONE, ADDRESS_TWO, ADDRESS_THREE]);
@@ -47,7 +141,8 @@ describe('GnosisWithdrawableAmountsReader', () => {
       { amountWei: 100n, withdrawalAddress: ADDRESS_ONE },
       { amountWei: 100n, withdrawalAddress: ADDRESS_THREE },
     ]);
-    // Confirms the failed address was attempted on the main RPC and then the backup RPC.
-    expect(postSpy).toHaveBeenCalledTimes(4);
+    // Confirms only the failed address is retried on the backup RPC.
+    expect(mainMulticall.mock.calls[0]?.[0].contracts).toHaveLength(3);
+    expect(backupMulticall.mock.calls[0]?.[0].contracts).toHaveLength(1);
   });
 });

--- a/packages/indexer/src/services/gnosis/withdrawableAmounts.test.ts
+++ b/packages/indexer/src/services/gnosis/withdrawableAmounts.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { GnosisWithdrawableAmountsReader } from './withdrawableAmounts.js';
+
+// ADDRESS_ONE represents a tracked withdrawal address whose contract read succeeds.
+const ADDRESS_ONE = '0x0000000000000000000000000000000000000001';
+// ADDRESS_TWO represents a tracked withdrawal address that fails on every configured RPC.
+const ADDRESS_TWO = '0x0000000000000000000000000000000000000002';
+// ADDRESS_THREE represents another tracked withdrawal address that must not be blocked by failures.
+const ADDRESS_THREE = '0x0000000000000000000000000000000000000003';
+
+/**
+ * Reads the private axios client used by the Gnosis reader so tests can control RPC responses.
+ */
+function getAxiosInstance(reader: GnosisWithdrawableAmountsReader): { post: unknown } {
+  return (reader as unknown as { axiosInstance: { post: unknown } }).axiosInstance;
+}
+
+describe('GnosisWithdrawableAmountsReader', () => {
+  // This suite verifies per-address RPC failures do not block the entire claimable snapshot batch.
+  it('skips addresses that fail on every RPC and returns successful reads', async () => {
+    // This scenario prevents one permanently failing address from blocking the hourly snapshot update.
+    const reader = new GnosisWithdrawableAmountsReader({
+      bkpRpcUrl: 'https://backup-rpc.example',
+      depositContractAddress: '0x0000000000000000000000000000000000000100',
+      mainRpcUrl: 'https://main-rpc.example',
+    });
+    const axiosInstance = getAxiosInstance(reader);
+    const postSpy = vi.spyOn(axiosInstance, 'post' as never).mockImplementation(((
+      _rpcUrl: string,
+      body: { params: [{ data: string }] },
+    ) => {
+      // This mocked RPC fails the second address on both main and backup endpoints.
+      if (body.params[0].data.endsWith(ADDRESS_TWO.slice(2).padStart(64, '0'))) {
+        return Promise.reject(new Error('rate limited'));
+      }
+
+      // This mocked RPC returns one raw uint256 amount for every address that is not failing.
+      return Promise.resolve({ data: { jsonrpc: '2.0', id: 1, result: '0x64' } });
+    }) as never);
+
+    // Reads three addresses while the middle address fails all RPC attempts.
+    const amounts = await reader.getWithdrawableAmounts([ADDRESS_ONE, ADDRESS_TWO, ADDRESS_THREE]);
+
+    // Confirms successful addresses are preserved and the failed address keeps its last snapshot value.
+    expect(amounts).toEqual([
+      { amountWei: 100n, withdrawalAddress: ADDRESS_ONE },
+      { amountWei: 100n, withdrawalAddress: ADDRESS_THREE },
+    ]);
+    // Confirms the failed address was attempted on the main RPC and then the backup RPC.
+    expect(postSpy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/indexer/src/services/gnosis/withdrawableAmounts.ts
+++ b/packages/indexer/src/services/gnosis/withdrawableAmounts.ts
@@ -1,0 +1,115 @@
+import axios, { AxiosInstance } from 'axios';
+import ms from 'ms';
+
+import type { ClaimableWithdrawalAmount } from '@/src/services/consensus/storage/claimableWithdrawals.js';
+import type { JsonRpcResponse } from '@/src/services/execution/types.js';
+
+const WITHDRAWABLE_AMOUNT_SELECTOR = '0xbe7ab51b';
+
+type GnosisWithdrawableAmountsReaderParams = {
+  bkpRpcUrl: string;
+  depositContractAddress: string;
+  mainRpcUrl: string;
+};
+
+/**
+ * GnosisWithdrawableAmountsReader reads claimable withdrawal amounts from the Gnosis deposit contract.
+ */
+export class GnosisWithdrawableAmountsReader {
+  private readonly axiosInstance: AxiosInstance;
+  private readonly depositContractAddress: string;
+  private readonly rpcUrls: string[];
+
+  constructor(params: GnosisWithdrawableAmountsReaderParams) {
+    this.axiosInstance = axios.create();
+    this.depositContractAddress = this.normalizeAddress(params.depositContractAddress);
+    this.rpcUrls = [params.mainRpcUrl, params.bkpRpcUrl];
+  }
+
+  /**
+   * Reads raw uint256 amounts for each withdrawal address and returns values keyed by original address.
+   */
+  async getWithdrawableAmounts(
+    withdrawalAddresses: string[],
+  ): Promise<ClaimableWithdrawalAmount[]> {
+    return Promise.all(
+      withdrawalAddresses.map(async (withdrawalAddress) => ({
+        amountWei: await this.readWithdrawableAmount(withdrawalAddress),
+        withdrawalAddress,
+      })),
+    );
+  }
+
+  /**
+   * Reads one withdrawal address from the main RPC and then the backup RPC if needed.
+   */
+  private async readWithdrawableAmount(withdrawalAddress: string): Promise<bigint> {
+    let lastError: unknown;
+
+    for (const rpcUrl of this.rpcUrls) {
+      try {
+        return await this.readWithdrawableAmountFromRpc(rpcUrl, withdrawalAddress);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`Failed to read withdrawableAmount for ${withdrawalAddress}`);
+  }
+
+  /**
+   * Sends one eth_call for withdrawableAmount(address) and parses the uint256 result.
+   */
+  private async readWithdrawableAmountFromRpc(
+    rpcUrl: string,
+    withdrawalAddress: string,
+  ): Promise<bigint> {
+    const response = await this.axiosInstance.post<JsonRpcResponse<string>>(
+      rpcUrl,
+      {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_call',
+        params: [
+          {
+            data: this.encodeWithdrawableAmountCall(withdrawalAddress),
+            to: this.depositContractAddress,
+          },
+          'latest',
+        ],
+      },
+      { timeout: ms('15s') },
+    );
+
+    if (response.data.error) {
+      throw new Error(`eth_call withdrawableAmount error: ${response.data.error.message}`);
+    }
+
+    if (!response.data.result) {
+      throw new Error(`eth_call withdrawableAmount returned empty result for ${withdrawalAddress}`);
+    }
+
+    return BigInt(response.data.result);
+  }
+
+  /**
+   * Encodes withdrawableAmount(address) calldata for a normalized Ethereum address.
+   */
+  private encodeWithdrawableAmountCall(withdrawalAddress: string): string {
+    const normalizedAddress = this.normalizeAddress(withdrawalAddress).slice(2);
+    return `${WITHDRAWABLE_AMOUNT_SELECTOR}${normalizedAddress.padStart(64, '0')}`;
+  }
+
+  /**
+   * Validates and lowercases an EVM address before using it in contract calls.
+   */
+  private normalizeAddress(address: string): string {
+    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) {
+      throw new Error(`Invalid EVM address: ${address}`);
+    }
+
+    return address.toLowerCase();
+  }
+}

--- a/packages/indexer/src/services/gnosis/withdrawableAmounts.ts
+++ b/packages/indexer/src/services/gnosis/withdrawableAmounts.ts
@@ -32,12 +32,20 @@ export class GnosisWithdrawableAmountsReader {
   async getWithdrawableAmounts(
     withdrawalAddresses: string[],
   ): Promise<ClaimableWithdrawalAmount[]> {
-    return Promise.all(
-      withdrawalAddresses.map(async (withdrawalAddress) => ({
-        amountWei: await this.readWithdrawableAmount(withdrawalAddress),
-        withdrawalAddress,
-      })),
+    const amounts = await Promise.all(
+      withdrawalAddresses.map(async (withdrawalAddress) => {
+        try {
+          return {
+            amountWei: await this.readWithdrawableAmount(withdrawalAddress),
+            withdrawalAddress,
+          };
+        } catch {
+          return null;
+        }
+      }),
     );
+
+    return amounts.filter((amount): amount is ClaimableWithdrawalAmount => amount !== null);
   }
 
   /**

--- a/packages/indexer/src/services/gnosis/withdrawableAmounts.ts
+++ b/packages/indexer/src/services/gnosis/withdrawableAmounts.ts
@@ -1,10 +1,44 @@
-import axios, { AxiosInstance } from 'axios';
-import ms from 'ms';
+import chunk from 'lodash/chunk.js';
+import { type Address, createPublicClient as createViemPublicClient, getAddress, http } from 'viem';
+import { gnosis } from 'viem/chains';
 
 import type { ClaimableWithdrawalAmount } from '@/src/services/consensus/storage/claimableWithdrawals.js';
-import type { JsonRpcResponse } from '@/src/services/execution/types.js';
 
-const WITHDRAWABLE_AMOUNT_SELECTOR = '0xbe7ab51b';
+const WITHDRAWABLE_AMOUNT_MULTICALL_BATCH_SIZE = 50;
+
+const GNOSIS_DEPOSIT_ABI = [
+  {
+    inputs: [{ internalType: 'address', name: '_address', type: 'address' }],
+    name: 'withdrawableAmount',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+type GnosisDepositContractCall = {
+  abi: typeof GNOSIS_DEPOSIT_ABI;
+  address: Address;
+  args: readonly [Address];
+  functionName: 'withdrawableAmount';
+};
+
+type GnosisMulticallResult =
+  | {
+      result: bigint;
+      status: 'success';
+    }
+  | {
+      error: unknown;
+      status: 'failure';
+    };
+
+type GnosisMulticallClient = {
+  multicall: (params: {
+    allowFailure: true;
+    contracts: GnosisDepositContractCall[];
+  }) => Promise<GnosisMulticallResult[]>;
+};
 
 type GnosisWithdrawableAmountsReaderParams = {
   bkpRpcUrl: string;
@@ -16,108 +50,118 @@ type GnosisWithdrawableAmountsReaderParams = {
  * GnosisWithdrawableAmountsReader reads claimable withdrawal amounts from the Gnosis deposit contract.
  */
 export class GnosisWithdrawableAmountsReader {
-  private readonly axiosInstance: AxiosInstance;
-  private readonly depositContractAddress: string;
-  private readonly rpcUrls: string[];
+  private readonly depositContractAddress: Address;
+  private readonly publicClients: GnosisMulticallClient[];
 
   constructor(params: GnosisWithdrawableAmountsReaderParams) {
-    this.axiosInstance = axios.create();
     this.depositContractAddress = this.normalizeAddress(params.depositContractAddress);
-    this.rpcUrls = [params.mainRpcUrl, params.bkpRpcUrl];
+    this.publicClients = [
+      this.createPublicClient(params.mainRpcUrl),
+      this.createPublicClient(params.bkpRpcUrl),
+    ];
   }
 
   /**
-   * Reads raw uint256 amounts for each withdrawal address and returns values keyed by original address.
+   * Reads raw uint256 amounts using multicall batches capped to a conservative RPC-safe size.
    */
   async getWithdrawableAmounts(
     withdrawalAddresses: string[],
   ): Promise<ClaimableWithdrawalAmount[]> {
-    const amounts = await Promise.all(
-      withdrawalAddresses.map(async (withdrawalAddress) => {
-        try {
-          return {
-            amountWei: await this.readWithdrawableAmount(withdrawalAddress),
-            withdrawalAddress,
-          };
-        } catch {
-          return null;
-        }
-      }),
-    );
+    const amounts: ClaimableWithdrawalAmount[] = [];
 
-    return amounts.filter((amount): amount is ClaimableWithdrawalAmount => amount !== null);
+    for (const addressBatch of chunk(
+      withdrawalAddresses,
+      WITHDRAWABLE_AMOUNT_MULTICALL_BATCH_SIZE,
+    )) {
+      amounts.push(...(await this.readWithdrawableAmountBatch(addressBatch)));
+    }
+
+    return amounts;
   }
 
   /**
-   * Reads one withdrawal address from the main RPC and then the backup RPC if needed.
+   * Creates a viem public client for the configured Gnosis RPC endpoint.
    */
-  private async readWithdrawableAmount(withdrawalAddress: string): Promise<bigint> {
-    let lastError: unknown;
+  private createPublicClient(rpcUrl: string): GnosisMulticallClient {
+    return createViemPublicClient({
+      chain: gnosis,
+      transport: http(rpcUrl, { timeout: 15_000 }),
+    }) as unknown as GnosisMulticallClient;
+  }
 
-    for (const rpcUrl of this.rpcUrls) {
+  /**
+   * Reads one safe-sized address batch from main RPC and retries failed entries on the backup RPC.
+   */
+  private async readWithdrawableAmountBatch(
+    withdrawalAddresses: string[],
+  ): Promise<ClaimableWithdrawalAmount[]> {
+    const amounts: ClaimableWithdrawalAmount[] = [];
+    let pendingWithdrawalAddresses = withdrawalAddresses;
+
+    for (const publicClient of this.publicClients) {
+      if (pendingWithdrawalAddresses.length === 0) break;
+
       try {
-        return await this.readWithdrawableAmountFromRpc(rpcUrl, withdrawalAddress);
-      } catch (error) {
-        lastError = error;
+        const result = await this.readWithdrawableAmountsFromClient(
+          publicClient,
+          pendingWithdrawalAddresses,
+        );
+        amounts.push(...result.amounts);
+        pendingWithdrawalAddresses = result.failedWithdrawalAddresses;
+      } catch {
+        // A full RPC failure keeps the pending addresses available for the next configured RPC.
       }
     }
 
-    throw lastError instanceof Error
-      ? lastError
-      : new Error(`Failed to read withdrawableAmount for ${withdrawalAddress}`);
+    return amounts;
   }
 
   /**
-   * Sends one eth_call for withdrawableAmount(address) and parses the uint256 result.
+   * Executes one viem multicall and separates successful amounts from addresses that need retrying.
    */
-  private async readWithdrawableAmountFromRpc(
-    rpcUrl: string,
-    withdrawalAddress: string,
-  ): Promise<bigint> {
-    const response = await this.axiosInstance.post<JsonRpcResponse<string>>(
-      rpcUrl,
-      {
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'eth_call',
-        params: [
-          {
-            data: this.encodeWithdrawableAmountCall(withdrawalAddress),
-            to: this.depositContractAddress,
-          },
-          'latest',
-        ],
-      },
-      { timeout: ms('15s') },
-    );
+  private async readWithdrawableAmountsFromClient(
+    publicClient: GnosisMulticallClient,
+    withdrawalAddresses: string[],
+  ): Promise<{
+    amounts: ClaimableWithdrawalAmount[];
+    failedWithdrawalAddresses: string[];
+  }> {
+    const results = await publicClient.multicall({
+      allowFailure: true,
+      contracts: withdrawalAddresses.map((withdrawalAddress) => ({
+        abi: GNOSIS_DEPOSIT_ABI,
+        address: this.depositContractAddress,
+        args: [this.normalizeAddress(withdrawalAddress)] as const,
+        functionName: 'withdrawableAmount',
+      })),
+    });
 
-    if (response.data.error) {
-      throw new Error(`eth_call withdrawableAmount error: ${response.data.error.message}`);
-    }
+    const amounts: ClaimableWithdrawalAmount[] = [];
+    const failedWithdrawalAddresses: string[] = [];
 
-    if (!response.data.result) {
-      throw new Error(`eth_call withdrawableAmount returned empty result for ${withdrawalAddress}`);
-    }
+    results.forEach((result, index) => {
+      const withdrawalAddress = withdrawalAddresses[index];
+      if (!withdrawalAddress) return;
 
-    return BigInt(response.data.result);
+      if (result.status === 'success') {
+        amounts.push({ amountWei: result.result, withdrawalAddress });
+        return;
+      }
+
+      failedWithdrawalAddresses.push(withdrawalAddress);
+    });
+
+    return { amounts, failedWithdrawalAddresses };
   }
 
   /**
-   * Encodes withdrawableAmount(address) calldata for a normalized Ethereum address.
+   * Validates and normalizes an EVM address before using it in contract calls.
    */
-  private encodeWithdrawableAmountCall(withdrawalAddress: string): string {
-    const normalizedAddress = this.normalizeAddress(withdrawalAddress).slice(2);
-    return `${WITHDRAWABLE_AMOUNT_SELECTOR}${normalizedAddress.padStart(64, '0')}`;
-  }
-
-  /**
-   * Validates and lowercases an EVM address before using it in contract calls.
-   */
-  private normalizeAddress(address: string): string {
-    if (!/^0x[0-9a-fA-F]{40}$/.test(address)) {
+  private normalizeAddress(address: string): Address {
+    try {
+      return getAddress(address);
+    } catch {
       throw new Error(`Invalid EVM address: ${address}`);
     }
-
-    return address.toLowerCase();
   }
 }

--- a/packages/indexer/src/xstate/index.ts
+++ b/packages/indexer/src/xstate/index.ts
@@ -15,6 +15,7 @@ import { getSnapshotActor } from './snapshot/index.js';
 import { getValidatorActivityStatusActor } from './validatorActivityStatus/index.js';
 
 import { ChainStatsController } from '@/src/services/consensus/controllers/chainStats.js';
+import type { ClaimableWithdrawalsController } from '@/src/services/consensus/controllers/claimableWithdrawals.js';
 import { DailyArchiveController } from '@/src/services/consensus/controllers/dailyArchive.js';
 import { DailyArchiveDetailCleanupController } from '@/src/services/consensus/controllers/dailyArchiveDetailCleanup.js';
 import { EpochController } from '@/src/services/consensus/controllers/epoch.js';
@@ -46,6 +47,7 @@ export default function initXstateMachines(
   maxAttestationDelay: number,
   delaySlotsToHead: number,
   missedAttestationsForInactivity: number,
+  claimableWithdrawalsController?: ClaimableWithdrawalsController,
 ) {
   // Create and start hourly archive actor
   const hourlyArchiveActor = getHourlyArchiveActor(hourlyArchiveController);
@@ -104,6 +106,7 @@ export default function initXstateMachines(
     maxAttestationDelay,
     delaySlotsToHead,
     missedAttestationsForInactivity,
+    claimableWithdrawalsController,
   );
   snapshotActor.start();
 

--- a/packages/indexer/src/xstate/snapshot/index.ts
+++ b/packages/indexer/src/xstate/snapshot/index.ts
@@ -3,6 +3,7 @@ import { createActor } from 'xstate';
 
 import { snapshotMachine } from './snapshot.machine.js';
 
+import type { ClaimableWithdrawalsController } from '@/src/services/consensus/controllers/claimableWithdrawals.js';
 import { SnapshotController } from '@/src/services/consensus/controllers/snapshot.js';
 
 export { snapshotMachine } from './snapshot.machine.js';
@@ -15,6 +16,7 @@ export const getSnapshotActor = (
   maxAttestationDelay: number,
   delaySlotsToHead: number,
   missedAttestationsForInactivity: number,
+  claimableWithdrawalsController?: ClaimableWithdrawalsController,
 ) => {
   const actor = createActor(snapshotMachine, {
     input: {
@@ -22,6 +24,7 @@ export const getSnapshotActor = (
       slotDuration,
       slotsPerEpoch,
       chain,
+      claimableWithdrawalsController,
       maxAttestationDelay,
       delaySlotsToHead,
       missedAttestationsForInactivity,

--- a/packages/indexer/src/xstate/snapshot/snapshot.machine.ts
+++ b/packages/indexer/src/xstate/snapshot/snapshot.machine.ts
@@ -1,6 +1,7 @@
 import type { Chain } from '@beacon-indexer/beacon-utils';
 import { assign, fromPromise, setup } from 'xstate';
 
+import type { ClaimableWithdrawalsController } from '@/src/services/consensus/controllers/claimableWithdrawals.js';
 import { SnapshotController } from '@/src/services/consensus/controllers/snapshot.js';
 import { pinoLog } from '@/src/xstate/pinoLog.js';
 
@@ -9,6 +10,7 @@ type SnapshotContext = {
   slotDuration: number;
   slotsPerEpoch: number;
   chain: Chain;
+  claimableWithdrawalsController?: ClaimableWithdrawalsController;
   maxAttestationDelay: number;
   delaySlotsToHead: number;
   missedAttestationsForInactivity: number;
@@ -19,6 +21,7 @@ type SnapshotContext = {
   lastWUpdate: number | null;
   lastMUpdate: number | null;
   lastNewValidatorCheck: number | null;
+  lastClaimableUpdate: number | null;
 };
 
 type TickResult = {
@@ -29,9 +32,11 @@ type TickResult = {
   lastWUpdate: number | null;
   lastMUpdate: number | null;
   lastNewValidatorCheck: number | null;
+  lastClaimableUpdate: number | null;
 };
 
 const INTERVAL_NEW_VALIDATOR_CHECK = 30 * 1000; // 30 seconds
+const INTERVAL_CLAIMABLE = 60 * 60 * 1000; // 1 hour
 const INTERVAL_D = 30 * 60 * 1000; // 30 minutes
 const INTERVAL_W = 3 * 60 * 60 * 1000; // 3 hours
 const INTERVAL_M = 6 * 60 * 60 * 1000; // 6 hours
@@ -48,6 +53,7 @@ const runTick = fromPromise(async ({ input }: { input: { context: SnapshotContex
   let lastWUpdate = ctx.lastWUpdate;
   let lastMUpdate = ctx.lastMUpdate;
   let lastNewValidatorCheck = ctx.lastNewValidatorCheck;
+  let lastClaimableUpdate = ctx.lastClaimableUpdate;
 
   // Level 0: Detect and backfill new validators (every 30s)
   if (
@@ -70,6 +76,17 @@ const runTick = fromPromise(async ({ input }: { input: { context: SnapshotContex
     updatedLevels.push('h');
 
     lastEpochUpdate = currentEpoch;
+  }
+
+  // Level 1b: Gnosis claimable withdrawal snapshots (hourly)
+  if (
+    ctx.chain === 'gnosis' &&
+    ctx.claimableWithdrawalsController &&
+    (lastClaimableUpdate === null || now - lastClaimableUpdate >= INTERVAL_CLAIMABLE)
+  ) {
+    await ctx.claimableWithdrawalsController.updateClaimableSnapshots();
+    lastClaimableUpdate = now;
+    updatedLevels.push('claimable');
   }
 
   // Level 4: d performance (every 30 min)
@@ -101,6 +118,7 @@ const runTick = fromPromise(async ({ input }: { input: { context: SnapshotContex
     lastWUpdate,
     lastMUpdate,
     lastNewValidatorCheck,
+    lastClaimableUpdate,
   } satisfies TickResult;
 });
 
@@ -109,6 +127,7 @@ export const snapshotMachine = setup({
     context: SnapshotContext;
     input: {
       snapshotController: SnapshotController;
+      claimableWithdrawalsController?: ClaimableWithdrawalsController;
       slotDuration: number;
       slotsPerEpoch: number;
       chain: Chain;
@@ -128,6 +147,7 @@ export const snapshotMachine = setup({
   initial: 'waiting',
   context: ({ input }) => ({
     snapshotController: input.snapshotController,
+    claimableWithdrawalsController: input.claimableWithdrawalsController,
     slotDuration: input.slotDuration,
     slotsPerEpoch: input.slotsPerEpoch,
     chain: input.chain,
@@ -140,6 +160,7 @@ export const snapshotMachine = setup({
     lastWUpdate: null,
     lastMUpdate: null,
     lastNewValidatorCheck: null,
+    lastClaimableUpdate: null,
   }),
   states: {
     waiting: {
@@ -163,6 +184,7 @@ export const snapshotMachine = setup({
               lastWUpdate: ({ event }) => event.output.lastWUpdate,
               lastMUpdate: ({ event }) => event.output.lastMUpdate,
               lastNewValidatorCheck: ({ event }) => event.output.lastNewValidatorCheck,
+              lastClaimableUpdate: ({ event }) => event.output.lastClaimableUpdate,
             }),
             pinoLog(({ event }) => {
               const levels = event.output.updatedLevels;

--- a/packages/indexer/tsconfig.json
+++ b/packages/indexer/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2023",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "outDir": "./dist",
     "rootDir": ".",
     "baseUrl": ".",

--- a/packages/telegram-bot/src/scheduler/notify-user-stats.ts
+++ b/packages/telegram-bot/src/scheduler/notify-user-stats.ts
@@ -133,6 +133,7 @@ interface SnapshotData {
   executionRewardD: { wei: string; token: string } | null;
   executionRewardW: { wei: string; token: string } | null;
   executionRewardM: { wei: string; token: string } | null;
+  claimableRewards: string | null;
   tokenPrice: number;
 }
 
@@ -171,6 +172,8 @@ function aggregateSnapshots(snapshots: SnapshotData[]): SnapshotData {
   let elRewardD = 0,
     elRewardW = 0,
     elRewardM = 0;
+  let claimableRewards = 0;
+  let hasClaimableRewards = false;
 
   for (const s of snapshots) {
     const validatorCount = s.activeCount + s.inactiveCount;
@@ -217,6 +220,10 @@ function aggregateSnapshots(snapshots: SnapshotData[]): SnapshotData {
     if (s.executionRewardD) elRewardD += parseFloat(s.executionRewardD.token);
     if (s.executionRewardW) elRewardW += parseFloat(s.executionRewardW.token);
     if (s.executionRewardM) elRewardM += parseFloat(s.executionRewardM.token);
+    if (s.claimableRewards !== null) {
+      claimableRewards += parseFloat(s.claimableRewards);
+      hasClaimableRewards = true;
+    }
   }
 
   return {
@@ -237,6 +244,7 @@ function aggregateSnapshots(snapshots: SnapshotData[]): SnapshotData {
     executionRewardD: elRewardD ? { wei: '0', token: elRewardD.toString() } : null,
     executionRewardW: elRewardW ? { wei: '0', token: elRewardW.toString() } : null,
     executionRewardM: elRewardM ? { wei: '0', token: elRewardM.toString() } : null,
+    claimableRewards: hasClaimableRewards ? claimableRewards.toString() : null,
     tokenPrice,
   };
 }

--- a/packages/telegram-bot/src/telegram/format-stats.ts
+++ b/packages/telegram-bot/src/telegram/format-stats.ts
@@ -25,6 +25,7 @@ interface ClusterSnapshotData {
   executionRewardD: { wei: string; token: string } | null;
   executionRewardW: { wei: string; token: string } | null;
   executionRewardM: { wei: string; token: string } | null;
+  claimableRewards: string | null;
   tokenPrice: number;
 }
 
@@ -127,9 +128,15 @@ export function formatStatsMessage(snapshot: ClusterSnapshotData): string {
     snapshot.performanceH != null ? `${(snapshot.performanceH * 100).toFixed(2)}%` : '-';
 
   // Main stats
+  const claimable = snapshot.claimableRewards ? parseFloat(snapshot.claimableRewards) : 0;
   const mainStats = [
     `*Last 1h performance:* ${perfStr}`,
     `*Bal:* ${formatNumber(balance)} ${chainDisplay.tokenSymbol} $${formatNumber(balance * tokenPrice)}`,
+    ...(env.CHAIN === 'gnosis'
+      ? [
+          `*Claimable:* ${formatNumber(claimable)} ${chainDisplay.tokenSymbol} $${formatNumber(claimable * tokenPrice)}`,
+        ]
+      : []),
   ].join('\n');
 
   // Rewards table

--- a/packages/webapp/components/cluster/cluster-card.tsx
+++ b/packages/webapp/components/cluster/cluster-card.tsx
@@ -5,6 +5,8 @@ import { Settings } from 'lucide-react';
 import DashboardCard from '@/components/dashboard/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { env } from '@/env';
+import { getTokenConfig } from '@/lib/utils';
 import type { Cluster } from '@/types/cluster';
 
 interface ClusterCardProps {
@@ -60,6 +62,8 @@ export default function ClusterCard({ cluster, gnoPrice, onManage }: ClusterCard
   };
 
   const totalValidators = cluster.validatorCount ?? cluster.validators.length;
+  const { balanceDecimals, tokenSymbol } = getTokenConfig(env.NEXT_PUBLIC_CHAIN);
+  const showClaimable = env.NEXT_PUBLIC_CHAIN === 'gnosis';
 
   const balanceUsd = (cluster.totalBalance * gnoPrice).toFixed(2);
   const effectiveBalanceUsd = (cluster.totalEffectiveBalance * gnoPrice).toFixed(0);
@@ -81,24 +85,32 @@ export default function ClusterCard({ cluster, gnoPrice, onManage }: ClusterCard
       intent={cluster.performance >= 98 ? 'success' : 'default'}
     >
       <div className="section-spacing">
-        <div className="grid grid-cols-1 sm:grid-cols-3 grid-spacing pb-3 md:pb-4 border-b border-border">
+        <div
+          className={`grid grid-cols-1 ${showClaimable ? 'sm:grid-cols-3' : 'sm:grid-cols-2'} grid-spacing pb-3 md:pb-4 border-b border-border`}
+        >
           <div>
             <p className="label-primary mb-1">BALANCE</p>
-            <span className="value-secondary">{cluster.totalBalance.toFixed(2)} GNO</span>
+            <span className="value-secondary">
+              {cluster.totalBalance.toFixed(balanceDecimals)} {tokenSymbol}
+            </span>
             <p className="text-helper">${balanceUsd}</p>
           </div>
           <div>
             <p className="label-primary mb-1">EFFECTIVE BALANCE</p>
-            <span className="value-secondary">{cluster.totalEffectiveBalance.toFixed(0)} GNO</span>
+            <span className="value-secondary">
+              {cluster.totalEffectiveBalance.toFixed(0)} {tokenSymbol}
+            </span>
             <p className="text-helper">${effectiveBalanceUsd}</p>
           </div>
-          <div>
-            <p className="label-primary mb-1">CLAIMABLE</p>
-            <span className="value-secondary text-success">
-              {cluster.claimableRewards.toFixed(2)} GNO
-            </span>
-            <p className="text-helper">${claimableUsd}</p>
-          </div>
+          {showClaimable && (
+            <div>
+              <p className="label-primary mb-1">CLAIMABLE</p>
+              <span className="value-secondary text-success">
+                {cluster.claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
+              </span>
+              <p className="text-helper">${claimableUsd}</p>
+            </div>
+          )}
         </div>
 
         <div>

--- a/packages/webapp/components/cluster/cluster-card.tsx
+++ b/packages/webapp/components/cluster/cluster-card.tsx
@@ -64,10 +64,11 @@ export default function ClusterCard({ cluster, gnoPrice, onManage }: ClusterCard
   const totalValidators = cluster.validatorCount ?? cluster.validators.length;
   const { balanceDecimals, tokenSymbol } = getTokenConfig(env.NEXT_PUBLIC_CHAIN);
   const showClaimable = env.NEXT_PUBLIC_CHAIN === 'gnosis';
+  const claimableRewards = cluster.claimableRewards ?? 0;
 
   const balanceUsd = (cluster.totalBalance * gnoPrice).toFixed(2);
   const effectiveBalanceUsd = (cluster.totalEffectiveBalance * gnoPrice).toFixed(0);
-  const claimableUsd = (cluster.claimableRewards * gnoPrice).toFixed(2);
+  const claimableUsd = (claimableRewards * gnoPrice).toFixed(2);
 
   return (
     <DashboardCard
@@ -106,7 +107,7 @@ export default function ClusterCard({ cluster, gnoPrice, onManage }: ClusterCard
             <div>
               <p className="label-primary mb-1">CLAIMABLE</p>
               <span className="value-secondary text-success">
-                {cluster.claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
+                {claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
               </span>
               <p className="text-helper">${claimableUsd}</p>
             </div>

--- a/packages/webapp/components/cluster/cluster-claimable-nullish.test.ts
+++ b/packages/webapp/components/cluster/cluster-claimable-nullish.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+describe('cluster claimable reward fallback', () => {
+  // This suite verifies legacy cluster components normalize nullable claimable reward values.
+  it('normalizes nullable claimable rewards before rendering legacy cluster components', () => {
+    // This scenario protects Gnosis legacy components from nullable API claimable rewards.
+    const cardSource = readFileSync(new URL('./cluster-card.tsx', import.meta.url), 'utf8');
+    const overviewSource = readFileSync(new URL('./cluster-overview.tsx', import.meta.url), 'utf8');
+
+    // Confirm each component creates a numeric fallback before USD and token formatting.
+    assert.match(cardSource, /const claimableRewards = cluster\.claimableRewards \?\? 0/);
+    assert.match(overviewSource, /const claimableRewards = cluster\.claimableRewards \?\? 0/);
+    // Confirm each component avoids direct toFixed calls on nullable cluster.claimableRewards.
+    assert.doesNotMatch(cardSource, /cluster\.claimableRewards\.toFixed/);
+    assert.doesNotMatch(overviewSource, /cluster\.claimableRewards\.toFixed/);
+  });
+});

--- a/packages/webapp/components/cluster/cluster-overview-content.tsx
+++ b/packages/webapp/components/cluster/cluster-overview-content.tsx
@@ -76,10 +76,12 @@ export default function ClusterOverviewContent({
   );
 
   const totalValidators = cluster.validatorCount ?? cluster.validators.length;
+  const showClaimable = env.NEXT_PUBLIC_CHAIN === 'gnosis';
+  const claimableRewards = snapshot?.claimableRewards ? Number(snapshot.claimableRewards) : null;
 
   const balanceUsd = formatNumber(cluster.totalBalance * gnoPrice);
   const effectiveBalanceUsd = formatNumber(cluster.totalEffectiveBalance * gnoPrice, 0);
-  const claimableUsd = formatNumber(cluster.claimableRewards * gnoPrice);
+  const claimableUsd = claimableRewards !== null ? formatNumber(claimableRewards * gnoPrice) : null;
 
   const getPerformance = (key: PeriodKey): number | null => {
     if (!snapshot) return null;
@@ -199,7 +201,9 @@ export default function ClusterOverviewContent({
             </span>
             <div className="flex-1 h-px bg-primary/20" />
           </div>
-          <div className="grid grid-cols-3 gap-3 md:gap-4 md:text-center">
+          <div
+            className={`grid ${showClaimable ? 'grid-cols-3' : 'grid-cols-2'} gap-3 md:gap-4 md:text-center`}
+          >
             <div>
               <p className="text-[10px] md:text-xs text-muted-foreground mb-0.5">Balance</p>
               <p className="text-sm md:text-lg font-normal font-semibold">
@@ -214,13 +218,19 @@ export default function ClusterOverviewContent({
               </p>
               <p className="text-[10px] text-muted-foreground">${effectiveBalanceUsd}</p>
             </div>
-            <div>
-              <p className="text-[10px] md:text-xs text-muted-foreground mb-0.5">Claimable</p>
-              <p className="text-sm md:text-lg font-normal font-semibold">
-                {cluster.claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
-              </p>
-              <p className="text-[10px] text-muted-foreground">${claimableUsd}</p>
-            </div>
+            {showClaimable && (
+              <div>
+                <p className="text-[10px] md:text-xs text-muted-foreground mb-0.5">Claimable</p>
+                <p className="text-sm md:text-lg font-normal font-semibold">
+                  {snapshotLoading || claimableRewards === null
+                    ? '-'
+                    : `${claimableRewards.toFixed(balanceDecimals)} ${tokenSymbol}`}
+                </p>
+                <p className="text-[10px] text-muted-foreground">
+                  {claimableUsd !== null ? `$${claimableUsd}` : '-'}
+                </p>
+              </div>
+            )}
           </div>
         </div>
 

--- a/packages/webapp/components/cluster/cluster-overview.test.tsx
+++ b/packages/webapp/components/cluster/cluster-overview.test.tsx
@@ -73,7 +73,7 @@ describe('ClusterOverview', () => {
     });
   });
 
-  it('uses Ethereum token labels and four decimals for balance and claimable only', () => {
+  it('uses Ethereum token labels and hides Gnosis-only claimable rewards', () => {
     // Render the overview with the default Ethereum chain environment.
     const markup = renderToStaticMarkup(
       <ClusterOverview
@@ -85,12 +85,14 @@ describe('ClusterOverview', () => {
       />,
     );
 
-    // Confirm total balance and claimable rewards use ETH with four decimals.
+    // Confirm total balance uses ETH with four decimals.
     assert.match(markup, /96\.1235 ETH/);
-    assert.match(markup, /0\.1235 ETH/);
 
     // Confirm effective balance keeps integer formatting with the ETH token.
     assert.match(markup, /96 ETH/);
+    // Confirm claimable rewards are omitted because they are only available on Gnosis.
+    assert.doesNotMatch(markup, /CLAIMABLE/);
+    assert.doesNotMatch(markup, /0\.1235 ETH/);
 
     // Confirm old Gnosis labels are not rendered on Ethereum.
     assert.doesNotMatch(markup, /GNO/);

--- a/packages/webapp/components/cluster/cluster-overview.tsx
+++ b/packages/webapp/components/cluster/cluster-overview.tsx
@@ -31,10 +31,11 @@ export default function ClusterOverview({
     env.NEXT_PUBLIC_CHAIN,
   );
   const showClaimable = env.NEXT_PUBLIC_CHAIN === 'gnosis';
+  const claimableRewards = cluster.claimableRewards ?? 0;
 
   const balanceUsd = (cluster.totalBalance * gnoPrice).toFixed(2);
   const effectiveBalanceUsd = (cluster.totalEffectiveBalance * gnoPrice).toFixed(0);
-  const claimableUsd = (cluster.claimableRewards * gnoPrice).toFixed(2);
+  const claimableUsd = (claimableRewards * gnoPrice).toFixed(2);
 
   const performance24h = 82.0;
   const performance7d = 91.0;
@@ -93,7 +94,7 @@ export default function ClusterOverview({
             <div className="col-span-2 md:col-span-1">
               <p className="text-xs text-muted-foreground mb-0.5 md:mb-1">CLAIMABLE</p>
               <span className="text-base md:text-xl font-display text-white">
-                {cluster.claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
+                {claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
               </span>
               <p className="text-xs text-muted-foreground">${claimableUsd}</p>
             </div>

--- a/packages/webapp/components/cluster/cluster-overview.tsx
+++ b/packages/webapp/components/cluster/cluster-overview.tsx
@@ -30,6 +30,7 @@ export default function ClusterOverview({
   const { balanceDecimals, executionTokenSymbol, tokenSymbol } = getTokenConfig(
     env.NEXT_PUBLIC_CHAIN,
   );
+  const showClaimable = env.NEXT_PUBLIC_CHAIN === 'gnosis';
 
   const balanceUsd = (cluster.totalBalance * gnoPrice).toFixed(2);
   const effectiveBalanceUsd = (cluster.totalEffectiveBalance * gnoPrice).toFixed(0);
@@ -71,7 +72,9 @@ export default function ClusterOverview({
           ))}
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-2.5 md:gap-4 pb-3.5 md:pb-4 border-b border-border">
+        <div
+          className={`grid grid-cols-2 ${showClaimable ? 'md:grid-cols-3' : 'md:grid-cols-2'} gap-2.5 md:gap-4 pb-3.5 md:pb-4 border-b border-border`}
+        >
           <div>
             <p className="text-xs text-muted-foreground mb-0.5 md:mb-1">BALANCE</p>
             <span className="text-base md:text-xl font-display">
@@ -86,13 +89,15 @@ export default function ClusterOverview({
             </span>
             <p className="text-xs text-muted-foreground">${effectiveBalanceUsd}</p>
           </div>
-          <div className="col-span-2 md:col-span-1">
-            <p className="text-xs text-muted-foreground mb-0.5 md:mb-1">CLAIMABLE</p>
-            <span className="text-base md:text-xl font-display text-white">
-              {cluster.claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
-            </span>
-            <p className="text-xs text-muted-foreground">${claimableUsd}</p>
-          </div>
+          {showClaimable && (
+            <div className="col-span-2 md:col-span-1">
+              <p className="text-xs text-muted-foreground mb-0.5 md:mb-1">CLAIMABLE</p>
+              <span className="text-base md:text-xl font-display text-white">
+                {cluster.claimableRewards.toFixed(balanceDecimals)} {tokenSymbol}
+              </span>
+              <p className="text-xs text-muted-foreground">${claimableUsd}</p>
+            </div>
+          )}
         </div>
 
         <div className="pb-3.5 md:pb-4 border-b border-border">

--- a/packages/webapp/components/cluster/user-dashboard.tsx
+++ b/packages/webapp/components/cluster/user-dashboard.tsx
@@ -35,7 +35,10 @@ function getAggregatedCluster(clusters: Cluster[]): Cluster {
     (sum, cluster) => sum + cluster.totalEffectiveBalance,
     0,
   );
-  const totalClaimable = clusters.reduce((sum, cluster) => sum + cluster.claimableRewards, 0);
+  const totalClaimable = clusters.reduce(
+    (sum, cluster) => sum + (cluster.claimableRewards ?? 0),
+    0,
+  );
   const avgPerformance =
     clusters.length > 0
       ? clusters.reduce((sum, cluster) => sum + cluster.performance, 0) / clusters.length

--- a/packages/webapp/hooks/use-cluster-snapshot.ts
+++ b/packages/webapp/hooks/use-cluster-snapshot.ts
@@ -36,6 +36,7 @@ export interface ClusterSnapshot {
   avgAttestationDelay1d: number | null;
   avgAttestationDelay1w: number | null;
   avgAttestationDelay1m: number | null;
+  claimableRewards: string | null;
   tokenPrice: number;
 }
 
@@ -81,6 +82,7 @@ export function useClusterSnapshot(clusterId: string | null) {
         avgAttestationDelay1d: d.avgAttestationDelayD,
         avgAttestationDelay1w: d.avgAttestationDelayW,
         avgAttestationDelay1m: d.avgAttestationDelayM,
+        claimableRewards: d.claimableRewards,
         tokenPrice: d.tokenPrice,
       } satisfies ClusterSnapshot;
     },

--- a/packages/webapp/types/cluster.ts
+++ b/packages/webapp/types/cluster.ts
@@ -20,7 +20,7 @@ export interface Cluster {
   validators: ClusterValidator[];
   totalBalance: number;
   totalEffectiveBalance: number;
-  claimableRewards: number;
+  claimableRewards: number | null;
   performance: number;
   // From API response
   validatorCount?: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,8 +269,8 @@ importers:
         specifier: ^4.7.1
         version: 4.20.6
       viem:
-        specifier: ^2.23.13
-        version: 2.37.8(typescript@5.9.2)(zod@3.25.76)
+        specifier: ^2.52.2
+        version: 2.52.2(typescript@5.9.2)(zod@3.25.76)
       xstate:
         specifier: ^5.22.1
         version: 5.22.1
@@ -346,7 +346,7 @@ importers:
         version: 1.13.4
       '@orpc/server':
         specifier: 1.13.4
-        version: 1.13.4(ws@8.18.3)
+        version: 1.13.4(ws@8.20.1)
       '@t3-oss/env-core':
         specifier: ^0.10.1
         version: 0.10.1(typescript@5.9.2)(zod@3.25.76)
@@ -428,7 +428,7 @@ importers:
         version: 1.13.4
       '@orpc/server':
         specifier: 1.13.4
-        version: 1.13.4(ws@8.18.3)
+        version: 1.13.4(ws@8.20.1)
       '@orpc/tanstack-query':
         specifier: 1.13.4
         version: 1.13.4(@orpc/client@1.13.4)(@tanstack/query-core@5.100.9)
@@ -2657,7 +2657,7 @@ packages:
   '@vercel/analytics@1.3.1':
     resolution: {integrity: sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==}
     peerDependencies:
-      next: '>=14.2.32'
+      next: '>=14.2.26'
       react: ^18 || ^19
     peerDependenciesMeta:
       next:
@@ -2669,7 +2669,7 @@ packages:
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
     peerDependencies:
       '@sveltejs/kit': ^1 || ^2
-      next: '>=14.2.32'
+      next: '>=14.2.26'
       nuxt: '>= 3'
       react: ^18 || ^19 || ^19.0.0-rc
       svelte: '>= 4'
@@ -2731,6 +2731,17 @@ packages:
 
   abitype@1.1.0:
     resolution: {integrity: sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3.22.0 || ^4.0.0
@@ -4542,6 +4553,14 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.9.6:
     resolution: {integrity: sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg==}
     peerDependencies:
@@ -5492,6 +5511,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.52.2:
+    resolution: {integrity: sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -5615,6 +5642,18 @@ packages:
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6280,6 +6319,25 @@ snapshots:
       cookie: 1.1.1
     optionalDependencies:
       ws: 8.18.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - fastify
+
+  '@orpc/server@1.13.4(ws@8.20.1)':
+    dependencies:
+      '@orpc/client': 1.13.4
+      '@orpc/contract': 1.13.4
+      '@orpc/interop': 1.13.4
+      '@orpc/shared': 1.13.4
+      '@orpc/standard-server': 1.13.4
+      '@orpc/standard-server-aws-lambda': 1.13.4
+      '@orpc/standard-server-fastify': 1.13.4
+      '@orpc/standard-server-fetch': 1.13.4
+      '@orpc/standard-server-node': 1.13.4
+      '@orpc/standard-server-peer': 1.13.4
+      cookie: 1.1.1
+    optionalDependencies:
+      ws: 8.20.1
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - fastify
@@ -7212,7 +7270,7 @@ snapshots:
 
   '@scure/bip32@1.7.0':
     dependencies:
-      '@noble/curves': 1.9.1
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
@@ -7749,6 +7807,11 @@ snapshots:
       tinyrainbow: 2.0.0
 
   abitype@1.1.0(typescript@5.9.2)(zod@3.25.76):
+    optionalDependencies:
+      typescript: 5.9.2
+      zod: 3.25.76
+
+  abitype@1.2.3(typescript@5.9.2)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.2
       zod: 3.25.76
@@ -9332,6 +9395,10 @@ snapshots:
     dependencies:
       ws: 8.18.3
 
+  isows@1.0.7(ws@8.20.1):
+    dependencies:
+      ws: 8.20.1
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -9783,6 +9850,21 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  ox@0.14.29(typescript@5.9.2)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.2)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - zod
 
   ox@0.9.6(typescript@5.9.2)(zod@3.25.76):
     dependencies:
@@ -10901,6 +10983,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.52.2(typescript@5.9.2)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.2)(zod@3.25.76)
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.29(typescript@5.9.2)(zod@3.25.76)
+      ws: 8.20.1
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-node@3.2.4(@types/node@22.18.6)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.4)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
@@ -11131,6 +11230,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.3: {}
+
+  ws@8.20.1: {}
 
   xstate@5.22.1: {}
 


### PR DESCRIPTION
## Summary
- add hourly Gnosis claimable withdrawal snapshot storage and worker
- expose claimable rewards in API cluster snapshots and clients
- clear claimable snapshot rows after user claim

## Verification
- pnpm --filter @beacon-indexer/api test -- --run
- pnpm --filter @beacon-indexer/api lint
- pnpm type-check
- pnpm --filter indexer exec vitest run
- pnpm --filter telegram-bot test -- --run
- pnpm build:app
- push hook: pnpm -r run lint