### PR TITLE
Add user clusters API endpoint

### DIFF
--- a/packages/api/src/routers/user/clusters.test.ts
+++ b/packages/api/src/routers/user/clusters.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createUserRouter } from './index.js';
+
+/**
+ * Builds the minimum oRPC procedure chain needed to unit-test user route handlers.
+ */
+function createProcedureHarness() {
+  const handlers: Record<string, (params: unknown) => Promise<unknown>> = {};
+  const procedure = {
+    route({ path }: { path: string }) {
+      return {
+        input() {
+          return {
+            output() {
+              return {
+                handler(handler: (params: unknown) => Promise<unknown>) {
+                  handlers[path] = handler;
+                  return handler;
+                },
+              };
+            },
+          };
+        },
+        output() {
+          return {
+            handler(handler: (params: unknown) => Promise<unknown>) {
+              handlers[path] = handler;
+              return handler;
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return { handlers, procedure };
+}
+
+describe('createUserRouter clusters route', () => {
+  it('registers an API-key route that lists one user clusters with nested validators', async () => {
+    // This scenario verifies token-authenticated callers can inspect clusters for any provided user id.
+    const { handlers, procedure } = createProcedureHarness();
+    const listWithValidatorsByOwner = vi.fn().mockResolvedValue([
+      {
+        id: 'cluster-a',
+        name: 'Mainnet validators',
+        visibility: 'private',
+        feeRecipientAddress: '0x0000000000000000000000000000000000000001',
+        lidoOperatorId: null,
+        ownerId: 'user-a',
+        createdAt: new Date('2026-01-10T12:00:00.000Z'),
+        validators: [
+          {
+            validatorIndex: 42,
+            validator: {
+              withdrawalAddress: '0x0000000000000000000000000000000000000002',
+              status: 1,
+              balance: 32_500_000_000n,
+              effectiveBalance: 32_000_000_000n,
+              pubkey: '0xvalidator',
+            },
+          },
+        ],
+      },
+    ]);
+
+    // Registers the user router with both secured and API-key procedures because other user routes share it.
+    createUserRouter({
+      chain: 'ethereum',
+      claimWithdrawalsService: null,
+      clusterStorage: { listWithValidatorsByOwner },
+      procedures: { apiKeyProcedure: procedure, securedProcedure: procedure },
+      userStorage: {
+        findClaimUserById: vi.fn(),
+        getOrCreateAnonymous: vi.fn(),
+        listOwnedClusterWithdrawalAddresses: vi.fn(),
+        clearClaimableWithdrawalAddresses: vi.fn(),
+        finalizeSuccessfulClaim: vi.fn(),
+        updateLastClaimed: vi.fn(),
+      },
+    } as never);
+
+    // Confirms the REST/RPC router exposes the approved user-scoped API-key endpoint.
+    expect(handlers['/users/{userId}/clusters']).toBeDefined();
+
+    // Calls the registered handler with the user id that should constrain the cluster query.
+    const response = await handlers['/users/{userId}/clusters']({
+      input: { userId: 'user-a' },
+    });
+
+    // Confirms only the requested owner id is passed to storage and balances are API-formatted.
+    expect(listWithValidatorsByOwner).toHaveBeenCalledWith('user-a');
+    expect(response).toEqual({
+      success: true,
+      data: [
+        {
+          id: 'cluster-a',
+          name: 'Mainnet validators',
+          visibility: 'private',
+          feeRecipientAddress: '0x0000000000000000000000000000000000000001',
+          lidoOperatorId: null,
+          ownerId: 'user-a',
+          createdAt: '2026-01-10T12:00:00.000Z',
+          validators: [
+            {
+              validatorIndex: 42,
+              withdrawalAddress: '0x0000000000000000000000000000000000000002',
+              status: 1,
+              balance: '32.5',
+              effectiveBalance: '32',
+              pubkey: '0xvalidator',
+            },
+          ],
+        },
+      ],
+      meta: { timestamp: expect.any(String) },
+    });
+  });
+});

--- a/packages/api/src/routers/user/clusters.ts
+++ b/packages/api/src/routers/user/clusters.ts
@@ -1,0 +1,101 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Chain } from '@beacon-indexer/beacon-utils';
+import { z } from 'zod';
+
+import { UserClusterWithValidatorsSchema, UserIdParamSchema } from './schemas.js';
+
+import type { ApiProcedures } from '@/auth/middleware.js';
+import { ApiResponseSchema, errorResponse, successResponse } from '@/utils/response.js';
+import { formatBalance } from '@/utils/tokenFormat.js';
+
+interface UserClusterValidatorRow {
+  validatorIndex: number;
+  validator: {
+    withdrawalAddress: string | null;
+    status: number | null;
+    balance: bigint;
+    effectiveBalance: bigint | null;
+    pubkey: string | null;
+  };
+}
+
+interface UserClusterRow {
+  id: string;
+  name: string;
+  visibility: string;
+  feeRecipientAddress: string | null;
+  lidoOperatorId: string | null;
+  ownerId: string;
+  createdAt: Date;
+  validators: UserClusterValidatorRow[];
+}
+
+interface UserClustersStorage {
+  listWithValidatorsByOwner: (ownerId: string) => Promise<UserClusterRow[]>;
+}
+
+const UserClustersResponseSchema = ApiResponseSchema(z.array(UserClusterWithValidatorsSchema));
+type UserClustersResponse = z.infer<typeof UserClustersResponseSchema>;
+
+/**
+ * Formats one cluster-validator membership for the token-authenticated user cluster listing.
+ */
+function formatUserClusterValidator(row: UserClusterValidatorRow, chain: Chain) {
+  return {
+    validatorIndex: row.validatorIndex,
+    withdrawalAddress: row.validator.withdrawalAddress,
+    status: row.validator.status,
+    balance: formatBalance(row.validator.balance, chain),
+    effectiveBalance:
+      row.validator.effectiveBalance !== null
+        ? formatBalance(row.validator.effectiveBalance, chain)
+        : null,
+    pubkey: row.validator.pubkey,
+  };
+}
+
+/**
+ * Formats one owned cluster with nested validators for API consumers.
+ */
+function formatUserCluster(cluster: UserClusterRow, chain: Chain) {
+  return {
+    id: cluster.id,
+    name: cluster.name,
+    visibility: cluster.visibility as 'private' | 'shared',
+    feeRecipientAddress: cluster.feeRecipientAddress,
+    lidoOperatorId: cluster.lidoOperatorId,
+    ownerId: cluster.ownerId,
+    createdAt: cluster.createdAt.toISOString(),
+    validators: cluster.validators.map((validator) => formatUserClusterValidator(validator, chain)),
+  };
+}
+
+/**
+ * Creates the API-key route that lists clusters and validators for a provided user id.
+ */
+export function createUserClustersRoute(params: {
+  chain: Chain;
+  clusterStorage: UserClustersStorage;
+  procedures: ApiProcedures;
+}) {
+  const { apiKeyProcedure } = params.procedures;
+
+  return apiKeyProcedure
+    .route({ method: 'GET', path: '/users/{userId}/clusters' })
+    .input(UserIdParamSchema)
+    .output(UserClustersResponseSchema)
+    .handler(async ({ input }: any) => {
+      try {
+        const clusters = await params.clusterStorage.listWithValidatorsByOwner(input.userId);
+
+        return successResponse(
+          clusters.map((cluster) => formatUserCluster(cluster, params.chain)),
+        ) as UserClustersResponse;
+      } catch (error) {
+        return errorResponse(
+          'USER_CLUSTERS_LIST_ERROR',
+          error instanceof Error ? error.message : 'Failed to list user clusters',
+        ) as UserClustersResponse;
+      }
+    });
+}

--- a/packages/api/src/routers/user/clusters.ts
+++ b/packages/api/src/routers/user/clusters.ts
@@ -84,7 +84,7 @@ export function createUserClustersRoute(params: {
     .route({ method: 'GET', path: '/users/{userId}/clusters' })
     .input(UserIdParamSchema)
     .output(UserClustersResponseSchema)
-    .handler(async ({ input }: any) => {
+    .handler(async ({ input }) => {
       try {
         const clusters = await params.clusterStorage.listWithValidatorsByOwner(input.userId);
 

--- a/packages/api/src/routers/user/index.ts
+++ b/packages/api/src/routers/user/index.ts
@@ -1,5 +1,6 @@
 import { createAnonymousUserRoute } from './anonymous.js';
 import { createUserClaimRoute } from './claim.js';
+import { createUserClustersRoute } from './clusters.js';
 import { createMeRoute } from './me.js';
 
 /**
@@ -8,6 +9,7 @@ import { createMeRoute } from './me.js';
 export function createUserRouter(params: {
   chain: Parameters<typeof createUserClaimRoute>[0]['chain'];
   claimWithdrawalsService: Parameters<typeof createUserClaimRoute>[0]['claimWithdrawalsService'];
+  clusterStorage: Parameters<typeof createUserClustersRoute>[0]['clusterStorage'];
   procedures: Parameters<typeof createAnonymousUserRoute>[0]['procedures'];
   userStorage: Parameters<typeof createAnonymousUserRoute>[0]['userStorage'] &
     Parameters<typeof createUserClaimRoute>[0]['userStorage'];
@@ -15,6 +17,7 @@ export function createUserRouter(params: {
   return {
     anonymous: createAnonymousUserRoute(params),
     claim: createUserClaimRoute(params),
+    clusters: createUserClustersRoute(params),
     me: createMeRoute(params),
   };
 }

--- a/packages/api/src/routers/user/schemas.ts
+++ b/packages/api/src/routers/user/schemas.ts
@@ -30,3 +30,42 @@ export const ClaimUserResponseSchema = z.object({
 });
 
 export type ClaimUserResponse = z.infer<typeof ClaimUserResponseSchema>;
+
+/**
+ * User ID path parameter schema for API-key user inspection routes.
+ */
+export const UserIdParamSchema = z.object({
+  userId: z.string().min(1),
+});
+
+export type UserIdParam = z.infer<typeof UserIdParamSchema>;
+
+/**
+ * Validator fields exposed when listing a user's clusters through an API token.
+ */
+export const UserClusterValidatorSchema = z.object({
+  validatorIndex: z.number(),
+  withdrawalAddress: z.string().nullable(),
+  status: z.number().nullable(),
+  balance: z.string(),
+  effectiveBalance: z.string().nullable(),
+  pubkey: z.string().nullable(),
+});
+
+export type UserClusterValidator = z.infer<typeof UserClusterValidatorSchema>;
+
+/**
+ * Cluster plus nested validators for API-token user inspection.
+ */
+export const UserClusterWithValidatorsSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  visibility: z.enum(['private', 'shared']),
+  feeRecipientAddress: z.string().nullable(),
+  lidoOperatorId: z.string().nullable(),
+  ownerId: z.string(),
+  createdAt: z.string(),
+  validators: z.array(UserClusterValidatorSchema),
+});
+
+export type UserClusterWithValidators = z.infer<typeof UserClusterWithValidatorsSchema>;

--- a/packages/api/src/storage/cluster.ts
+++ b/packages/api/src/storage/cluster.ts
@@ -283,6 +283,33 @@ export class ClusterStorage {
   }
 
   /**
+   * Lists one owner's clusters with validator details for API-key inspection.
+   */
+  async listWithValidatorsByOwner(ownerId: string) {
+    return this.prisma.cluster.findMany({
+      where: { ownerId },
+      include: {
+        validators: {
+          orderBy: { validatorIndex: 'asc' },
+          select: {
+            validatorIndex: true,
+            validator: {
+              select: {
+                withdrawalAddress: true,
+                status: true,
+                balance: true,
+                effectiveBalance: true,
+                pubkey: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  /**
    * Get a cross-user summary of clusters and validator membership counts.
    */
   async getSummary() {


### PR DESCRIPTION
## Summary
- Add API-key protected GET /users/{userId}/clusters.
- Return each owned cluster with nested validator details.
- Add route coverage for registration, owner filtering, and balance formatting.

## Validation
- pnpm --filter @beacon-indexer/api test -- src/routers/user
- pnpm --filter @beacon-indexer/api build
- git push hook: pnpm -r run lint