### PR TITLE
Retry processor persistence steps

### DIFF
--- a/packages/indexer/src/xstate/epoch/epochProcessor.machine.test.ts
+++ b/packages/indexer/src/xstate/epoch/epochProcessor.machine.test.ts
@@ -693,6 +693,52 @@ describe('epochProcessorMachine', () => {
         actor.stop();
         subscription.unsubscribe();
       });
+
+      test('retries updating slots fetched after waiting five seconds', async () => {
+        // Scenario: slots completed successfully, but persisting the epoch slots-fetched flag
+        // fails once. The epoch processor must retry so the epoch can still finish.
+        vi.setSystemTime(new Date(EPOCH_100_START_TIME + 50));
+
+        // This storage update fails once and succeeds after the XState retry delay.
+        (mockEpochController.updateSlotsFetched as ReturnType<typeof vi.fn>)
+          .mockRejectedValueOnce(new Error('slots fetched update timeout'))
+          .mockResolvedValueOnce(undefined);
+
+        // Keep rewards pending so this test focuses only on the slotsProcessing branch.
+        const rewardsPromise = createControllablePromise<void>();
+        (mockEpochController.fetchEpochRewards as ReturnType<typeof vi.fn>).mockReturnValue(
+          rewardsPromise.promise,
+        );
+
+        // Start the epoch processor and let it spawn the slot orchestrator.
+        const { actor, subscription } = createAndStartActor(
+          epochProcessorMachine,
+          createProcessorMachineDefaultInput(100),
+        );
+        await vi.runAllTimersAsync();
+
+        // Simulate the slot orchestrator reporting that every slot in the epoch completed.
+        actor.send({ type: 'SLOTS_COMPLETED', epoch: 100 });
+        await vi.advanceTimersByTimeAsync(0);
+        await waitForXStateTransitions();
+
+        // The failed update must not retry before the five-second recovery delay elapses.
+        expect(mockEpochController.updateSlotsFetched).toHaveBeenCalledTimes(1);
+        await vi.advanceTimersByTimeAsync(4_999);
+        await waitForXStateTransitions();
+        expect(mockEpochController.updateSlotsFetched).toHaveBeenCalledTimes(1);
+
+        // Advancing the final millisecond triggers the retry and marks slots as processed.
+        await vi.advanceTimersByTimeAsync(1);
+        await waitForXStateTransitions();
+
+        // This assertion verifies the epoch did not remain stuck after the transient failure.
+        expect(mockEpochController.updateSlotsFetched).toHaveBeenCalledTimes(2);
+
+        // Stop the actor so no pending retry or reward work leaks into other tests.
+        actor.stop();
+        subscription.unsubscribe();
+      });
     });
 
     describe('trackingValidatorsActivation', () => {
@@ -1177,6 +1223,86 @@ describe('epochProcessorMachine', () => {
       // Verify parent reached completed state (proves the full lifecycle worked)
       expect(parentActor.getSnapshot().value).toBe('completed');
 
+      parentActor.stop();
+    });
+
+    test('retries marking epoch processed after waiting five seconds', async () => {
+      // Scenario: all epoch branches complete, but the final processed marker fails once.
+      // The parent must receive EPOCH_COMPLETED only after the retry succeeds.
+      const epochEndTime = EPOCH_101_START_TIME + SLOTS_PER_EPOCH * SLOT_DURATION + 100;
+      vi.setSystemTime(new Date(epochEndTime));
+
+      // This final epoch update fails once and succeeds after the XState retry delay.
+      (mockEpochController.markEpochAsProcessed as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('mark processed transaction timeout'))
+        .mockResolvedValueOnce(undefined);
+
+      // Create a parent machine so the test can verify the retried child emits EPOCH_COMPLETED.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { createActor, setup } = require('xstate');
+
+      // This flag records whether the final parent event was emitted after retry.
+      let receivedEpochCompleted = false;
+
+      // This parent invokes the real epoch processor and completes when the child reports success.
+      const parentMachine = setup({
+        actors: {
+          epochProcessor: epochProcessorMachine,
+        },
+      }).createMachine({
+        id: 'testMarkProcessedRetryParent',
+        initial: 'running',
+        states: {
+          running: {
+            invoke: {
+              id: 'epochProcessor',
+              src: 'epochProcessor',
+              input: createProcessorMachineDefaultInput(100),
+            },
+            on: {
+              EPOCH_COMPLETED: {
+                target: 'completed',
+                actions: () => {
+                  receivedEpochCompleted = true;
+                },
+              },
+            },
+          },
+          completed: {
+            type: 'final',
+          },
+        },
+      });
+
+      // Start the full epoch processor and let every branch except slots finish.
+      const parentActor = createActor(parentMachine);
+      parentActor.start();
+      await vi.runAllTimersAsync();
+
+      // Complete the mocked slot orchestrator so the processor reaches markingEpochProcessed.
+      const epochProcessorActor = parentActor.getSnapshot().children.epochProcessor;
+      const slotOrchestratorActor =
+        epochProcessorActor?.getSnapshot().context.actors.slotOrchestratorActor;
+      slotOrchestratorActor?.send({ type: 'COMPLETE_SLOTS' });
+      await vi.advanceTimersByTimeAsync(0);
+      await waitForXStateTransitions();
+
+      // The failed mark must not retry before the five-second recovery delay elapses.
+      expect(mockEpochController.markEpochAsProcessed).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(4_999);
+      await waitForXStateTransitions();
+      expect(mockEpochController.markEpochAsProcessed).toHaveBeenCalledTimes(1);
+
+      // Advancing the final millisecond triggers the retry and lets the parent complete.
+      await vi.advanceTimersByTimeAsync(1);
+      await waitForXStateTransitions();
+
+      // These assertions verify the retry restored epoch progress and emitted completion.
+      expect(mockEpochController.markEpochAsProcessed).toHaveBeenCalledTimes(2);
+      expect(receivedEpochCompleted).toBe(true);
+      expect(parentActor.getSnapshot().value).toBe('completed');
+
+      // Stop the parent actor so no state machine work leaks into other tests.
       parentActor.stop();
     });
   });

--- a/packages/indexer/src/xstate/epoch/epochProcessor.machine.ts
+++ b/packages/indexer/src/xstate/epoch/epochProcessor.machine.ts
@@ -678,6 +678,7 @@ export const epochProcessorMachine = setup({
                       target: 'slotsProcessed',
                     },
                     onError: {
+                      target: 'waitingSlotsFetchedRetry',
                       actions: pinoLog(
                         ({ context, event }) =>
                           `error updating slots fetched for epoch ${context.epoch}: ${event.error}`,
@@ -687,6 +688,11 @@ export const epochProcessorMachine = setup({
                     },
                   },
                 }),
+                waitingSlotsFetchedRetry: {
+                  after: {
+                    retryWait: 'updatingSlotsFetched',
+                  },
+                },
                 slotsProcessed: {
                   type: 'final',
                   entry: [
@@ -978,6 +984,7 @@ export const epochProcessorMachine = setup({
           ],
         },
         onError: {
+          target: 'waitingMarkEpochProcessedRetry',
           actions: pinoLog(
             ({ context, event }) =>
               `error marking epoch ${context.epoch} as processed: ${event.error}`,
@@ -987,6 +994,11 @@ export const epochProcessorMachine = setup({
         },
       },
     }),
+    waitingMarkEpochProcessedRetry: {
+      after: {
+        retryWait: 'markingEpochProcessed',
+      },
+    },
     epochCompleted: {
       type: 'final',
     },

--- a/packages/indexer/src/xstate/slot/slotProcessor.machine.test.ts
+++ b/packages/indexer/src/xstate/slot/slotProcessor.machine.test.ts
@@ -59,6 +59,16 @@ function createSlotController() {
   };
 }
 
+/**
+ * Let XState settle promise completions and immediate transitions in tests.
+ */
+async function waitForXStateTransitions() {
+  // Multiple microtasks are needed because invoked promises can resolve and then trigger nested transitions.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 // This suite verifies retry behavior for the slot processor state machine.
 describe('slotProcessorMachine', () => {
   beforeEach(() => {
@@ -270,6 +280,155 @@ describe('slotProcessorMachine', () => {
     expect(slotController.fetchBeaconBlock).toHaveBeenCalledTimes(2);
 
     // This assertion verifies the retry allowed the slot processor to complete normally.
+    expect(receivedSlotCompleted).toBe(true);
+    expect(actor.getSnapshot().value).toBe('completed');
+
+    // Stop the actor so no state machine work leaks into other tests.
+    actor.stop();
+  });
+
+  // This test verifies attestation processing retries after a transient storage or committee lookup failure.
+  test('retries attestation processing after waiting five seconds', async () => {
+    // This controller simulates a failed attestation update followed by a successful retry.
+    const slotController = createSlotController();
+    slotController.processAttestations
+      .mockRejectedValueOnce(new Error('committee rows locked'))
+      .mockResolvedValueOnce(undefined);
+
+    // This flag verifies the parent receives completion once the retry succeeds.
+    let receivedSlotCompleted = false;
+
+    // This parent receives the slot completion event from the real slot processor.
+    const parentMachine = setup({
+      actors: {
+        slotProcessor: slotProcessorMachine,
+      },
+    }).createMachine({
+      id: 'testAttestationsRetryParent',
+      initial: 'running',
+      states: {
+        running: {
+          invoke: {
+            id: 'slotProcessor',
+            src: 'slotProcessor',
+            input: {
+              epoch: 1,
+              lookbackSlot: 0,
+              slot: 32,
+              slotController: slotController as never,
+              slotDuration: 12_000,
+            },
+            onDone: {
+              target: 'completed',
+            },
+          },
+          on: {
+            SLOT_COMPLETED: {
+              actions: () => {
+                receivedSlotCompleted = true;
+              },
+            },
+          },
+        },
+        completed: {
+          type: 'final',
+        },
+      },
+    });
+
+    // Start processing and allow the first attestation processing attempt to fail.
+    const actor = createActor(parentMachine);
+    actor.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForXStateTransitions();
+
+    // The failed branch must stay parked until the full retry delay elapses.
+    expect(slotController.processAttestations).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(4_999);
+    await waitForXStateTransitions();
+    expect(slotController.processAttestations).toHaveBeenCalledTimes(1);
+
+    // Advancing the last millisecond triggers the retry and lets the slot finish.
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.runAllTimersAsync();
+
+    // These assertions verify the retry happened and restored slot progress.
+    expect(slotController.processAttestations).toHaveBeenCalledTimes(2);
+    expect(receivedSlotCompleted).toBe(true);
+    expect(actor.getSnapshot().value).toBe('completed');
+
+    // Stop the actor so no state machine work leaks into other tests.
+    actor.stop();
+  });
+
+  // This test verifies the lookback-slot attestation marker retries when its storage update fails.
+  test('retries lookback-slot attestation marker after waiting five seconds', async () => {
+    // This controller simulates a failed processed-flag update followed by a successful retry.
+    const slotController = createSlotController();
+    slotController.updateAttestationsProcessed
+      .mockRejectedValueOnce(new Error('slot update timeout'))
+      .mockResolvedValueOnce(undefined);
+
+    // This flag verifies the parent receives completion after the retry succeeds.
+    let receivedSlotCompleted = false;
+
+    // This parent uses slot 32 as both the current slot and lookback slot so the
+    // attestation branch takes the updateAttestationsProcessed path.
+    const parentMachine = setup({
+      actors: {
+        slotProcessor: slotProcessorMachine,
+      },
+    }).createMachine({
+      id: 'testUpdateAttestationsRetryParent',
+      initial: 'running',
+      states: {
+        running: {
+          invoke: {
+            id: 'slotProcessor',
+            src: 'slotProcessor',
+            input: {
+              epoch: 1,
+              lookbackSlot: 32,
+              slot: 32,
+              slotController: slotController as never,
+              slotDuration: 12_000,
+            },
+            onDone: {
+              target: 'completed',
+            },
+          },
+          on: {
+            SLOT_COMPLETED: {
+              actions: () => {
+                receivedSlotCompleted = true;
+              },
+            },
+          },
+        },
+        completed: {
+          type: 'final',
+        },
+      },
+    });
+
+    // Start processing and allow the first processed-flag update to fail.
+    const actor = createActor(parentMachine);
+    actor.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await waitForXStateTransitions();
+
+    // The failed update must not retry before five seconds pass.
+    expect(slotController.updateAttestationsProcessed).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(4_999);
+    await waitForXStateTransitions();
+    expect(slotController.updateAttestationsProcessed).toHaveBeenCalledTimes(1);
+
+    // Advancing the last millisecond triggers the retry and lets the slot finish.
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.runAllTimersAsync();
+
+    // These assertions verify the retry happened and restored slot progress.
+    expect(slotController.updateAttestationsProcessed).toHaveBeenCalledTimes(2);
     expect(receivedSlotCompleted).toBe(true);
     expect(actor.getSnapshot().value).toBe('completed');
 

--- a/packages/indexer/src/xstate/slot/slotProcessor.machine.ts
+++ b/packages/indexer/src/xstate/slot/slotProcessor.machine.ts
@@ -360,6 +360,7 @@ export const slotProcessorMachine = setup({
                           target: 'complete',
                         },
                         onError: {
+                          target: 'waitingAttestationsRetry',
                           actions: pinoLog(
                             ({ context, event }) =>
                               `error processing attestations for slot ${context.slot}: ${event.error}`,
@@ -369,6 +370,11 @@ export const slotProcessorMachine = setup({
                         },
                       },
                     }),
+                    waitingAttestationsRetry: {
+                      after: {
+                        retryWait: 'processingAttestations',
+                      },
+                    },
                     updateAttestationsProcessed: monitoredState('update attestations', {
                       entry: [
                         pinoLog(
@@ -387,6 +393,7 @@ export const slotProcessorMachine = setup({
                           target: 'complete',
                         },
                         onError: {
+                          target: 'waitingAttestationsProcessedUpdateRetry',
                           actions: pinoLog(
                             ({ context, event }) =>
                               `error updating attestations processed flag for slot ${context.slot}: ${event.error}`,
@@ -396,6 +403,11 @@ export const slotProcessorMachine = setup({
                         },
                       },
                     }),
+                    waitingAttestationsProcessedUpdateRetry: {
+                      after: {
+                        retryWait: 'updateAttestationsProcessed',
+                      },
+                    },
                     complete: {
                       entry: pinoLog(
                         ({ context }) => `attestations complete for slot ${context.slot}`,


### PR DESCRIPTION
## Summary

- Add retry waits for epoch slots-fetched and final processed marker updates.
- Add retry waits for slot attestation processing and lookback attestation marker updates.
- Cover the new retry paths with focused XState tests.

## Validation

- pnpm --filter indexer test -- src/xstate/epoch/epochProcessor.machine.test.ts src/xstate/slot/slotProcessor.machine.test.ts --run
- pre-commit hook: eslint --fix, prettier --write, indexer type-check
- pre-push hook: pnpm -r run lint