### PR TITLE
Implement withdrawals events tab

### DIFF
--- a/packages/api/e2e/server.ts
+++ b/packages/api/e2e/server.ts
@@ -24,6 +24,7 @@ import { IncidentStorage } from '@/storage/incident.js';
 import { SystemConfigStorage } from '@/storage/systemConfig.js';
 import { UserStorage } from '@/storage/user.js';
 import { ValidatorStorage } from '@/storage/validator.js';
+import { WithdrawalStorage } from '@/storage/withdrawal.js';
 import { createBeaconHelpers } from '@/utils/beaconTime.js';
 
 interface E2EServerOverrides {
@@ -211,6 +212,7 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     userStorage,
     validatorController,
     validatorStorage,
+    withdrawalStorage: new WithdrawalStorage(prisma),
   };
   const router = createRouter(deps);
   const server = createHttpServer({

--- a/packages/api/e2e/server.ts
+++ b/packages/api/e2e/server.ts
@@ -23,6 +23,7 @@ import { ClusterStorage } from '@/storage/cluster.js';
 import { ConsolidationStorage } from '@/storage/consolidation.js';
 import { DepositStorage } from '@/storage/deposit.js';
 import { IncidentStorage } from '@/storage/incident.js';
+import { PayoutStorage } from '@/storage/payout.js';
 import { SystemConfigStorage } from '@/storage/systemConfig.js';
 import { UserStorage } from '@/storage/user.js';
 import { ValidatorStorage } from '@/storage/validator.js';
@@ -208,6 +209,7 @@ export async function startE2EServer(overrides: E2EServerOverrides = {}): Promis
     incidentStorage: new IncidentStorage(prisma),
     logger,
     nativeTokenDecimals: env.NATIVE_TOKEN_DECIMALS,
+    payoutStorage: new PayoutStorage(prisma),
     prisma,
     procedures,
     systemConfigController,

--- a/packages/api/src/dependencies.ts
+++ b/packages/api/src/dependencies.ts
@@ -15,6 +15,7 @@ import type { ClusterStorage } from '@/storage/cluster.js';
 import type { IncidentStorage } from '@/storage/incident.js';
 import type { UserStorage } from '@/storage/user.js';
 import type { ValidatorStorage } from '@/storage/validator.js';
+import type { WithdrawalStorage } from '@/storage/withdrawal.js';
 import type { BeaconHelpers } from '@/utils/beaconTime.js';
 
 /**
@@ -42,6 +43,7 @@ export interface ApiDependencies {
   userStorage: UserStorage;
   validatorController: ValidatorController;
   validatorStorage: ValidatorStorage;
+  withdrawalStorage: WithdrawalStorage;
   chain: 'ethereum' | 'gnosis';
   claimWithdrawalsService: ClaimWithdrawalsService | null;
 }

--- a/packages/api/src/dependencies.ts
+++ b/packages/api/src/dependencies.ts
@@ -15,6 +15,7 @@ import type { ClusterStorage } from '@/storage/cluster.js';
 import type { ConsolidationStorage } from '@/storage/consolidation.js';
 import type { DepositStorage } from '@/storage/deposit.js';
 import type { IncidentStorage } from '@/storage/incident.js';
+import type { PayoutStorage } from '@/storage/payout.js';
 import type { UserStorage } from '@/storage/user.js';
 import type { ValidatorStorage } from '@/storage/validator.js';
 import type { WithdrawalStorage } from '@/storage/withdrawal.js';
@@ -39,6 +40,7 @@ export interface ApiDependencies {
   incidentStorage: IncidentStorage;
   logger: Logger;
   nativeTokenDecimals: number;
+  payoutStorage: PayoutStorage;
   prisma: PrismaClient;
   procedures: ApiProcedures;
   systemConfigController: SystemConfigController;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -22,6 +22,7 @@ import { ClusterStorage } from './storage/cluster.js';
 import { ConsolidationStorage } from './storage/consolidation.js';
 import { DepositStorage } from './storage/deposit.js';
 import { IncidentStorage } from './storage/incident.js';
+import { PayoutStorage } from './storage/payout.js';
 import { SystemConfigStorage } from './storage/systemConfig.js';
 import { UserStorage } from './storage/user.js';
 import { ValidatorStorage } from './storage/validator.js';
@@ -91,6 +92,7 @@ async function main() {
     incidentStorage: new IncidentStorage(prisma),
     logger,
     nativeTokenDecimals: env.NATIVE_TOKEN_DECIMALS,
+    payoutStorage: new PayoutStorage(prisma),
     prisma,
     procedures,
     systemConfigController,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -23,6 +23,7 @@ import { IncidentStorage } from './storage/incident.js';
 import { SystemConfigStorage } from './storage/systemConfig.js';
 import { UserStorage } from './storage/user.js';
 import { ValidatorStorage } from './storage/validator.js';
+import { WithdrawalStorage } from './storage/withdrawal.js';
 import { createBeaconHelpers } from './utils/beaconTime.js';
 
 /**
@@ -94,6 +95,7 @@ async function main() {
     userStorage,
     validatorController,
     validatorStorage,
+    withdrawalStorage: new WithdrawalStorage(prisma),
   });
 
   const server = createHttpServer({

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -7,6 +7,7 @@ import { createIndexerRouter } from './indexer/index.js';
 import { createUserRouter } from './user/index.js';
 import { createUtilsRouter } from './utils.js';
 import { createValidatorRouter } from './validator/index.js';
+import { createWithdrawalsRouter } from './withdrawals/index.js';
 import type { ApiDependencies } from '@/dependencies.js';
 
 export type Router = ReturnType<typeof createRouter>;
@@ -26,5 +27,6 @@ export function createRouter(deps: ApiDependencies) {
     user: createUserRouter(deps),
     utils: createUtilsRouter(deps),
     validator: createValidatorRouter(deps),
+    withdrawals: createWithdrawalsRouter(deps),
   };
 }

--- a/packages/api/src/routers/index.ts
+++ b/packages/api/src/routers/index.ts
@@ -6,6 +6,7 @@ import { createConsolidationsRouter } from './consolidations/index.js';
 import { createDepositsRouter } from './deposits/index.js';
 import { createHealthRouter } from './health.js';
 import { createIndexerRouter } from './indexer/index.js';
+import { createPayoutsRouter } from './payouts/index.js';
 import { createUserRouter } from './user/index.js';
 import { createUtilsRouter } from './utils.js';
 import { createValidatorRouter } from './validator/index.js';
@@ -28,6 +29,7 @@ export function createRouter(deps: ApiDependencies) {
     deposits: createDepositsRouter(deps),
     health: createHealthRouter(deps),
     indexer: createIndexerRouter(deps),
+    payouts: createPayoutsRouter(deps),
     user: createUserRouter(deps),
     utils: createUtilsRouter(deps),
     validator: createValidatorRouter(deps),

--- a/packages/api/src/routers/payouts/index.ts
+++ b/packages/api/src/routers/payouts/index.ts
@@ -1,0 +1,10 @@
+import { createListPayoutsRoute } from './list.js';
+
+/**
+ * Creates the payouts router.
+ */
+export function createPayoutsRouter(params: Parameters<typeof createListPayoutsRoute>[0]) {
+  return {
+    list: createListPayoutsRoute(params),
+  };
+}

--- a/packages/api/src/routers/payouts/list.test.ts
+++ b/packages/api/src/routers/payouts/list.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createListPayoutsRoute } from './list.js';
+
+/**
+ * Builds the minimum secured procedure chain needed to invoke the payouts handler.
+ */
+function createProcedureHarness() {
+  let routeHandler: ((params: never) => Promise<unknown>) | undefined;
+  const securedProcedure = {
+    route() {
+      return {
+        input() {
+          return {
+            output() {
+              return {
+                handler(handler: (params: never) => Promise<unknown>) {
+                  routeHandler = handler;
+                  return handler;
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return {
+    getHandler: () => {
+      if (!routeHandler) throw new Error('Payout route handler was not registered');
+      return routeHandler;
+    },
+    securedProcedure,
+  };
+}
+
+// This suite verifies completed payouts cannot be listed through another user's cluster identifier.
+describe('createListPayoutsRoute', () => {
+  // This scenario expects ownership rejection before any completed payout rows are queried.
+  it('rejects a cluster that is not owned by the authenticated user', async () => {
+    // The ownership lookup returns false for the concrete user and cluster pair under test.
+    const existsForOwner = vi.fn().mockResolvedValue(false);
+    const getPayouts = vi.fn();
+    const { getHandler, securedProcedure } = createProcedureHarness();
+
+    // The route receives storage mocks that reveal whether authorization occurs before payout access.
+    createListPayoutsRoute({
+      beaconHelpers: {} as never,
+      chain: 'ethereum',
+      clusterStorage: { existsForOwner } as never,
+      payoutStorage: { getPayouts } as never,
+      procedures: { securedProcedure } as never,
+    });
+
+    // An authenticated user requests a cluster that the ownership storage does not associate with them.
+    const result = (await getHandler()({
+      context: { user: { id: 'user-a', username: 'requester' } },
+      input: { clusterId: 'cluster-b', page: 1 },
+    } as never)) as {
+      success: boolean;
+      error: { code: string };
+    };
+
+    // The route hides cluster existence and never queries completed payout data.
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ code: 'CLUSTER_NOT_FOUND' }),
+      }),
+    );
+    expect(existsForOwner).toHaveBeenCalledWith('cluster-b', 'user-a');
+    expect(getPayouts).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routers/payouts/list.ts
+++ b/packages/api/src/routers/payouts/list.ts
@@ -1,28 +1,28 @@
-import { WithdrawalsInputSchema, WithdrawalsOutputSchema } from './schemas.js';
+import { PayoutsInputSchema, PayoutsOutputSchema } from './schemas.js';
 
 import type { ApiDependencies } from '@/dependencies.js';
 import { requireOwnedCluster } from '@/routers/cluster/ownership.js';
-import type { WithdrawalEventRow } from '@/storage/withdrawal.js';
+import type { PayoutEventRow } from '@/storage/payout.js';
 import { ApiResponseSchema } from '@/utils/response.js';
 import { formatBalance } from '@/utils/tokenFormat.js';
 
 const PAGE_SIZE = 10;
 
 /**
- * Creates the paginated operator withdrawal requests route.
+ * Creates the paginated completed payouts route.
  */
-export function createListWithdrawalsRoute(
+export function createListPayoutsRoute(
   params: Pick<
     ApiDependencies,
-    'beaconHelpers' | 'chain' | 'clusterStorage' | 'procedures' | 'withdrawalStorage'
+    'beaconHelpers' | 'chain' | 'clusterStorage' | 'payoutStorage' | 'procedures'
   >,
 ) {
   const { securedProcedure } = params.procedures;
 
   return securedProcedure
-    .route({ method: 'GET', path: '/withdrawals' })
-    .input(WithdrawalsInputSchema)
-    .output(ApiResponseSchema(WithdrawalsOutputSchema))
+    .route({ method: 'GET', path: '/payouts' })
+    .input(PayoutsInputSchema)
+    .output(ApiResponseSchema(PayoutsOutputSchema))
     .handler(async ({ context, input }) => {
       const ownershipError = await requireOwnedCluster(
         params.clusterStorage,
@@ -34,7 +34,7 @@ export function createListWithdrawalsRoute(
       }
 
       try {
-        const { hasNextPage, rows } = await params.withdrawalStorage.getWithdrawals({
+        const { hasNextPage, rows } = await params.payoutStorage.getPayouts({
           clusterId: input.clusterId,
           page: input.page,
           pageSize: PAGE_SIZE,
@@ -43,13 +43,10 @@ export function createListWithdrawalsRoute(
         return {
           success: true,
           data: {
-            withdrawals: rows.map((row: WithdrawalEventRow) => ({
+            payouts: rows.map((row: PayoutEventRow) => ({
               slot: row.slot,
-              requestIndex: row.request_index,
-              type: row.amount === BigInt(0) ? ('full_exit' as const) : ('partial' as const),
+              index: row.payout_index,
               validatorIndex: row.validator_index,
-              pubkey: row.pubkey,
-              sourceAddress: row.source_address,
               amount: formatBalance(row.amount, params.chain),
               timestamp: params.beaconHelpers.beaconTime.getTimestampFromSlotNumber(row.slot),
             })),
@@ -62,8 +59,8 @@ export function createListWithdrawalsRoute(
         return {
           success: false,
           error: {
-            code: 'WITHDRAWALS_ERROR',
-            message: error instanceof Error ? error.message : 'Failed to fetch withdrawals',
+            code: 'PAYOUTS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to fetch payouts',
           },
           meta: { timestamp: new Date().toISOString() },
         };

--- a/packages/api/src/routers/payouts/schemas.ts
+++ b/packages/api/src/routers/payouts/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const PayoutsInputSchema = z.object({
+  clusterId: z.string(),
+  page: z.number().int().positive().default(1),
+});
+
+export const PayoutEventSchema = z.object({
+  slot: z.number(),
+  index: z.string(),
+  validatorIndex: z.number(),
+  amount: z.string(),
+  timestamp: z.number(),
+});
+
+export const PayoutsOutputSchema = z.object({
+  payouts: z.array(PayoutEventSchema),
+  hasNextPage: z.boolean(),
+  page: z.number(),
+});

--- a/packages/api/src/routers/withdrawals/index.ts
+++ b/packages/api/src/routers/withdrawals/index.ts
@@ -1,0 +1,10 @@
+import { createListWithdrawalsRoute } from './list.js';
+
+/**
+ * Creates the withdrawals router.
+ */
+export function createWithdrawalsRouter(params: Parameters<typeof createListWithdrawalsRoute>[0]) {
+  return {
+    list: createListWithdrawalsRoute(params),
+  };
+}

--- a/packages/api/src/routers/withdrawals/list.test.ts
+++ b/packages/api/src/routers/withdrawals/list.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createListWithdrawalsRoute } from './list.js';
+
+/**
+ * Builds the minimum secured procedure chain needed to invoke the withdrawals handler.
+ */
+function createProcedureHarness() {
+  let routeHandler: ((params: never) => Promise<unknown>) | undefined;
+  const securedProcedure = {
+    route() {
+      return {
+        input() {
+          return {
+            output() {
+              return {
+                handler(handler: (params: never) => Promise<unknown>) {
+                  routeHandler = handler;
+                  return handler;
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return {
+    getHandler: () => {
+      if (!routeHandler) throw new Error('Withdrawal route handler was not registered');
+      return routeHandler;
+    },
+    securedProcedure,
+  };
+}
+
+// This suite verifies EIP-7002 requests remain distinct from completed payouts in the API contract.
+describe('createListWithdrawalsRoute', () => {
+  // This scenario expects amount zero to represent a full exit and a positive amount to represent a partial request.
+  it('classifies full exits and partial withdrawal requests', async () => {
+    // These rows model the two EIP-7002 meanings of the amount field for one owned cluster.
+    const getWithdrawals = vi.fn().mockResolvedValue({
+      hasNextPage: false,
+      rows: [
+        {
+          slot: 100,
+          request_index: 0,
+          validator_index: 12,
+          pubkey: '0xfull-exit-validator',
+          source_address: '0xfull-exit-owner',
+          amount: 0n,
+        },
+        {
+          slot: 99,
+          request_index: 1,
+          validator_index: 13,
+          pubkey: '0xpartial-validator',
+          source_address: '0xpartial-owner',
+          amount: 1_000_000_000n,
+        },
+      ],
+    });
+    const { getHandler, securedProcedure } = createProcedureHarness();
+
+    // The route uses deterministic timestamps and confirms ownership before reading request rows.
+    createListWithdrawalsRoute({
+      beaconHelpers: {
+        beaconTime: { getTimestampFromSlotNumber: (slot: number) => slot * 12_000 },
+      } as never,
+      chain: 'ethereum',
+      clusterStorage: { existsForOwner: vi.fn().mockResolvedValue(true) } as never,
+      procedures: { securedProcedure } as never,
+      withdrawalStorage: { getWithdrawals } as never,
+    });
+
+    // An authenticated owner requests the first page for the concrete test cluster.
+    const result = (await getHandler()({
+      context: { user: { id: 'user-a', username: 'owner' } },
+      input: { clusterId: 'cluster-a', page: 1 },
+    } as never)) as {
+      success: boolean;
+      data: { withdrawals: Array<{ type: string; amount: string }> };
+    };
+
+    // The API exposes request intent without treating either row as a completed payout.
+    expect(result.success).toBe(true);
+    expect(result.data.withdrawals).toEqual([
+      expect.objectContaining({ type: 'full_exit', amount: '0' }),
+      expect.objectContaining({ type: 'partial', amount: '1' }),
+    ]);
+    expect(getWithdrawals).toHaveBeenCalledWith({
+      clusterId: 'cluster-a',
+      page: 1,
+      pageSize: 10,
+    });
+  });
+});

--- a/packages/api/src/routers/withdrawals/list.ts
+++ b/packages/api/src/routers/withdrawals/list.ts
@@ -30,7 +30,7 @@ export function createListWithdrawalsRoute(
     .output(ApiResponseSchema(WithdrawalsOutputSchema))
     .handler(async ({ input }) => {
       try {
-        const { rows, totalCount } = await params.withdrawalStorage.getWithdrawals({
+        const { hasNextPage, rows } = await params.withdrawalStorage.getWithdrawals({
           clusterId: input.clusterId,
           page: input.page,
           pageSize: PAGE_SIZE,
@@ -49,9 +49,8 @@ export function createListWithdrawalsRoute(
               amount: formatBalance(row.amount, params.chain),
               timestamp: params.beaconHelpers.beaconTime.getTimestampFromSlotNumber(row.slot),
             })),
-            totalCount,
+            hasNextPage,
             page: input.page,
-            pageSize: PAGE_SIZE,
           },
           meta: { timestamp: new Date().toISOString() },
         };

--- a/packages/api/src/routers/withdrawals/list.ts
+++ b/packages/api/src/routers/withdrawals/list.ts
@@ -1,0 +1,69 @@
+import { WithdrawalsInputSchema, WithdrawalsOutputSchema } from './schemas.js';
+
+import type { ApiDependencies } from '@/dependencies.js';
+import type { WithdrawalEventRow } from '@/storage/withdrawal.js';
+import { ApiResponseSchema } from '@/utils/response.js';
+import { formatBalance } from '@/utils/tokenFormat.js';
+
+const PAGE_SIZE = 10;
+
+type WithdrawalSource = 'payload' | 'execution_request';
+
+/**
+ * Converts compact database source labels into API source labels.
+ */
+function formatWithdrawalSource(source: string): WithdrawalSource {
+  return source === 'request' ? 'execution_request' : 'payload';
+}
+
+/**
+ * Creates the paginated withdrawals route.
+ */
+export function createListWithdrawalsRoute(
+  params: Pick<ApiDependencies, 'beaconHelpers' | 'chain' | 'procedures' | 'withdrawalStorage'>,
+) {
+  const { securedProcedure } = params.procedures;
+
+  return securedProcedure
+    .route({ method: 'GET', path: '/withdrawals' })
+    .input(WithdrawalsInputSchema)
+    .output(ApiResponseSchema(WithdrawalsOutputSchema))
+    .handler(async ({ input }) => {
+      try {
+        const { rows, totalCount } = await params.withdrawalStorage.getWithdrawals({
+          clusterId: input.clusterId,
+          page: input.page,
+          pageSize: PAGE_SIZE,
+        });
+
+        return {
+          success: true,
+          data: {
+            withdrawals: rows.map((row: WithdrawalEventRow) => ({
+              slot: row.slot,
+              source: formatWithdrawalSource(row.source),
+              index: row.event_index,
+              validatorIndex: row.validator_index,
+              pubkey: row.pubkey,
+              sourceAddress: row.source_address,
+              amount: formatBalance(row.amount, params.chain),
+              timestamp: params.beaconHelpers.beaconTime.getTimestampFromSlotNumber(row.slot),
+            })),
+            totalCount,
+            page: input.page,
+            pageSize: PAGE_SIZE,
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: {
+            code: 'WITHDRAWALS_ERROR',
+            message: error instanceof Error ? error.message : 'Failed to fetch withdrawals',
+          },
+          meta: { timestamp: new Date().toISOString() },
+        };
+      }
+    });
+}

--- a/packages/api/src/routers/withdrawals/schemas.ts
+++ b/packages/api/src/routers/withdrawals/schemas.ts
@@ -7,10 +7,10 @@ export const WithdrawalsInputSchema = z.object({
 
 export const WithdrawalEventSchema = z.object({
   slot: z.number(),
-  source: z.enum(['payload', 'execution_request']),
-  index: z.string(),
+  requestIndex: z.number(),
+  type: z.enum(['partial', 'full_exit']),
   validatorIndex: z.number(),
-  pubkey: z.string().nullable(),
+  pubkey: z.string(),
   sourceAddress: z.string().nullable(),
   amount: z.string(),
   timestamp: z.number(),

--- a/packages/api/src/routers/withdrawals/schemas.ts
+++ b/packages/api/src/routers/withdrawals/schemas.ts
@@ -18,7 +18,6 @@ export const WithdrawalEventSchema = z.object({
 
 export const WithdrawalsOutputSchema = z.object({
   withdrawals: z.array(WithdrawalEventSchema),
-  totalCount: z.number(),
+  hasNextPage: z.boolean(),
   page: z.number(),
-  pageSize: z.number(),
 });

--- a/packages/api/src/routers/withdrawals/schemas.ts
+++ b/packages/api/src/routers/withdrawals/schemas.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const WithdrawalsInputSchema = z.object({
+  clusterId: z.string(),
+  page: z.number().int().positive().default(1),
+});
+
+export const WithdrawalEventSchema = z.object({
+  slot: z.number(),
+  source: z.enum(['payload', 'execution_request']),
+  index: z.string(),
+  validatorIndex: z.number(),
+  pubkey: z.string().nullable(),
+  sourceAddress: z.string().nullable(),
+  amount: z.string(),
+  timestamp: z.number(),
+});
+
+export const WithdrawalsOutputSchema = z.object({
+  withdrawals: z.array(WithdrawalEventSchema),
+  totalCount: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+});

--- a/packages/api/src/storage/payout.ts
+++ b/packages/api/src/storage/payout.ts
@@ -1,0 +1,48 @@
+import { PrismaClient } from '@beacon-indexer/db';
+
+export interface PayoutEventRow {
+  slot: number;
+  payout_index: string;
+  validator_index: number;
+  amount: bigint;
+}
+
+export interface PayoutEventsResult {
+  hasNextPage: boolean;
+  rows: PayoutEventRow[];
+}
+
+export class PayoutStorage {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Lists completed beacon-chain payouts for validators in the selected cluster.
+   */
+  async getPayouts(params: {
+    clusterId: string;
+    page: number;
+    pageSize: number;
+  }): Promise<PayoutEventsResult> {
+    const { clusterId, page, pageSize } = params;
+    const offset = (page - 1) * pageSize;
+    const limit = pageSize + 1;
+
+    const rows = await this.prisma.$queryRaw<PayoutEventRow[]>`
+      SELECT
+        w.slot,
+        w.withdrawal_index::text AS payout_index,
+        w.validator_index::integer AS validator_index,
+        w.amount
+      FROM validator_withdrawals w
+      JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
+      WHERE cv.cluster_id = ${clusterId}
+      ORDER BY w.slot DESC, w.withdrawal_index DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `;
+
+    return {
+      hasNextPage: rows.length > pageSize,
+      rows: rows.slice(0, pageSize),
+    };
+  }
+}

--- a/packages/api/src/storage/withdrawal.test.ts
+++ b/packages/api/src/storage/withdrawal.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PayoutStorage } from './payout.js';
+import { WithdrawalStorage } from './withdrawal.js';
+
+/**
+ * Extracts SQL text from Prisma tagged-template calls for storage query assertions.
+ */
+function getSqlText(queryArg: unknown): string {
+  if (Array.isArray(queryArg)) return Array.from(queryArg).join('?');
+  if (queryArg && typeof queryArg === 'object' && 'strings' in queryArg) {
+    return Array.from((queryArg as { strings: string[] }).strings).join('?');
+  }
+  if (queryArg && typeof queryArg === 'object' && 'sql' in queryArg) {
+    return (queryArg as { sql: string }).sql;
+  }
+  return '';
+}
+
+// This suite protects the domain boundary between completed payouts and operator withdrawal requests.
+describe('payout and withdrawal storage', () => {
+  // This scenario expects the payouts listing to read completed execution-payload withdrawals only.
+  it('queries validator withdrawals without including withdrawal requests for payouts', async () => {
+    // The empty result keeps the assertion focused on the SQL source selected for cluster payouts.
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const storage = new PayoutStorage({ $queryRaw: queryRaw } as never);
+
+    // A first-page cluster query builds the real Prisma tagged template with a ten-row page.
+    await storage.getPayouts({ clusterId: 'cluster-a', page: 1, pageSize: 10 });
+
+    // The emitted SQL must use completed withdrawals and must not join the EIP-7002 request table.
+    const sql = getSqlText(queryRaw.mock.calls[0]?.[0]);
+    expect(sql).toContain('FROM validator_withdrawals w');
+    expect(sql).not.toContain('validator_request_withdrawals');
+  });
+
+  // This scenario expects the withdrawals listing to read EIP-7002 operator requests only.
+  it('queries withdrawal requests without including completed payouts', async () => {
+    // The empty result keeps the assertion focused on the SQL source selected for operator requests.
+    const queryRaw = vi.fn().mockResolvedValue([]);
+    const storage = new WithdrawalStorage({ $queryRaw: queryRaw } as never);
+
+    // A first-page cluster query builds the real Prisma tagged template with a ten-row page.
+    await storage.getWithdrawals({ clusterId: 'cluster-a', page: 1, pageSize: 10 });
+
+    // The emitted SQL must use the request table and must not union completed payout rows.
+    const sql = getSqlText(queryRaw.mock.calls[0]?.[0]);
+    expect(sql).toContain('FROM validator_request_withdrawals wr');
+    expect(sql).not.toContain('FROM validator_withdrawals w');
+    expect(sql).not.toContain('UNION ALL');
+  });
+});

--- a/packages/api/src/storage/withdrawal.ts
+++ b/packages/api/src/storage/withdrawal.ts
@@ -1,11 +1,10 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
 export interface WithdrawalEventRow {
-  source: 'payload' | 'request';
   slot: number;
-  event_index: string;
+  request_index: number;
   validator_index: number;
-  pubkey: string | null;
+  pubkey: string;
   source_address: string | null;
   amount: bigint;
 }
@@ -19,7 +18,7 @@ export class WithdrawalStorage {
   constructor(private readonly prisma: PrismaClient) {}
 
   /**
-   * Lists execution payload and request withdrawals for validators in the selected cluster.
+   * Lists operator-initiated withdrawal requests for validators in the selected cluster.
    */
   async getWithdrawals(params: {
     clusterId: string;
@@ -31,39 +30,18 @@ export class WithdrawalStorage {
     const limit = pageSize + 1;
 
     const rows = await this.prisma.$queryRaw<WithdrawalEventRow[]>`
-      WITH withdrawal_events AS (
-        SELECT
-          'payload'::text AS source,
-          w.slot,
-          w.withdrawal_index::text AS event_index,
-          w.withdrawal_index::numeric AS sort_index,
-          w.validator_index::integer AS validator_index,
-          NULL::text AS pubkey,
-          NULL::text AS source_address,
-          w.amount
-        FROM validator_withdrawals w
-        JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
-        WHERE cv.cluster_id = ${clusterId}
-
-        UNION ALL
-
-        SELECT
-          'request'::text AS source,
-          wr.slot,
-          wr.request_index::text AS event_index,
-          wr.request_index::numeric AS sort_index,
-          v.id AS validator_index,
-          wr.pub_key AS pubkey,
-          wr.source_address,
-          wr.amount
-        FROM validator_request_withdrawals wr
-        JOIN validator v ON v.pubkey = wr.pub_key
-        JOIN cluster_validator cv ON cv.validator_index = v.id
-        WHERE cv.cluster_id = ${clusterId}
-      )
-      SELECT source, slot, event_index, validator_index, pubkey, source_address, amount
-      FROM withdrawal_events
-      ORDER BY slot DESC, source ASC, sort_index DESC
+      SELECT
+        wr.slot,
+        wr.request_index,
+        v.id AS validator_index,
+        wr.pub_key AS pubkey,
+        wr.source_address,
+        wr.amount
+      FROM validator_request_withdrawals wr
+      JOIN validator v ON v.pubkey = wr.pub_key
+      JOIN cluster_validator cv ON cv.validator_index = v.id
+      WHERE cv.cluster_id = ${clusterId}
+      ORDER BY wr.slot DESC, wr.request_index DESC
       LIMIT ${limit} OFFSET ${offset}
     `;
 

--- a/packages/api/src/storage/withdrawal.ts
+++ b/packages/api/src/storage/withdrawal.ts
@@ -10,32 +10,9 @@ export interface WithdrawalEventRow {
   amount: bigint;
 }
 
-interface SortableWithdrawalEventRow extends WithdrawalEventRow {
-  sort_index: bigint;
-}
-
-/**
- * Sorts mixed withdrawal sources the same way the previous SQL union did.
- */
-function compareWithdrawalEvents(
-  left: SortableWithdrawalEventRow,
-  right: SortableWithdrawalEventRow,
-) {
-  if (left.slot !== right.slot) {
-    return right.slot - left.slot;
-  }
-
-  const sourceRank = { payload: 0, request: 1 };
-  const sourceOrder = sourceRank[left.source] - sourceRank[right.source];
-  if (sourceOrder !== 0) {
-    return sourceOrder;
-  }
-
-  if (left.sort_index === right.sort_index) {
-    return 0;
-  }
-
-  return left.sort_index > right.sort_index ? -1 : 1;
+export interface WithdrawalEventsResult {
+  hasNextPage: boolean;
+  rows: WithdrawalEventRow[];
 }
 
 export class WithdrawalStorage {
@@ -44,86 +21,55 @@ export class WithdrawalStorage {
   /**
    * Lists execution payload and request withdrawals for validators in the selected cluster.
    */
-  async getWithdrawals(params: { clusterId: string; page: number; pageSize: number }) {
+  async getWithdrawals(params: {
+    clusterId: string;
+    page: number;
+    pageSize: number;
+  }): Promise<WithdrawalEventsResult> {
     const { clusterId, page, pageSize } = params;
     const offset = (page - 1) * pageSize;
-    const pageWindowSize = offset + pageSize;
+    const limit = pageSize + 1;
 
-    const clusterValidators = await this.prisma.clusterValidator.findMany({
-      where: { clusterId },
-      select: {
-        validatorIndex: true,
-        validator: { select: { pubkey: true } },
-      },
-    });
-    const validatorIndexes = clusterValidators.map(
-      (clusterValidator) => clusterValidator.validatorIndex,
-    );
-    const validatorIndexStrings = validatorIndexes.map(String);
-    const validatorIndexByPubkey = new Map(
-      clusterValidators
-        .filter(
-          (
-            clusterValidator,
-          ): clusterValidator is { validatorIndex: number; validator: { pubkey: string } } =>
-            clusterValidator.validator.pubkey !== null,
-        )
-        .map((clusterValidator) => [
-          clusterValidator.validator.pubkey,
-          clusterValidator.validatorIndex,
-        ]),
-    );
-    const pubkeys = Array.from(validatorIndexByPubkey.keys());
+    const rows = await this.prisma.$queryRaw<WithdrawalEventRow[]>`
+      WITH withdrawal_events AS (
+        SELECT
+          'payload'::text AS source,
+          w.slot,
+          w.withdrawal_index::text AS event_index,
+          w.withdrawal_index::numeric AS sort_index,
+          w.validator_index::integer AS validator_index,
+          NULL::text AS pubkey,
+          NULL::text AS source_address,
+          w.amount
+        FROM validator_withdrawals w
+        JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
+        WHERE cv.cluster_id = ${clusterId}
 
-    if (validatorIndexes.length === 0) {
-      return { rows: [], totalCount: 0 };
-    }
+        UNION ALL
 
-    const [payloadWithdrawals, requestWithdrawals, payloadCount, requestCount] = await Promise.all([
-      this.prisma.validatorWithdrawals.findMany({
-        where: { validatorIndex: { in: validatorIndexStrings } },
-        orderBy: [{ slot: 'desc' }, { withdrawalIndex: 'desc' }],
-        take: pageWindowSize,
-      }),
-      this.prisma.validatorWithdrawalsRequests.findMany({
-        where: { pubKey: { in: pubkeys } },
-        orderBy: [{ slot: 'desc' }, { requestIndex: 'desc' }],
-        take: pageWindowSize,
-      }),
-      this.prisma.validatorWithdrawals.count({
-        where: { validatorIndex: { in: validatorIndexStrings } },
-      }),
-      this.prisma.validatorWithdrawalsRequests.count({
-        where: { pubKey: { in: pubkeys } },
-      }),
-    ]);
-    const events: SortableWithdrawalEventRow[] = [
-      ...payloadWithdrawals.map((withdrawal) => ({
-        source: 'payload' as const,
-        slot: withdrawal.slot,
-        event_index: withdrawal.withdrawalIndex.toString(),
-        sort_index: withdrawal.withdrawalIndex,
-        validator_index: Number(withdrawal.validatorIndex),
-        pubkey: null,
-        source_address: null,
-        amount: withdrawal.amount,
-      })),
-      ...requestWithdrawals.map((withdrawal) => ({
-        source: 'request' as const,
-        slot: withdrawal.slot,
-        event_index: withdrawal.requestIndex.toString(),
-        sort_index: BigInt(withdrawal.requestIndex),
-        validator_index: validatorIndexByPubkey.get(withdrawal.pubKey)!,
-        pubkey: withdrawal.pubKey,
-        source_address: withdrawal.sourceAddress,
-        amount: withdrawal.amount,
-      })),
-    ];
-    const rows = events
-      .sort(compareWithdrawalEvents)
-      .slice(offset, offset + pageSize)
-      .map(({ sort_index: _sortIndex, ...event }) => event);
+        SELECT
+          'request'::text AS source,
+          wr.slot,
+          wr.request_index::text AS event_index,
+          wr.request_index::numeric AS sort_index,
+          v.id AS validator_index,
+          wr.pub_key AS pubkey,
+          wr.source_address,
+          wr.amount
+        FROM validator_request_withdrawals wr
+        JOIN validator v ON v.pubkey = wr.pub_key
+        JOIN cluster_validator cv ON cv.validator_index = v.id
+        WHERE cv.cluster_id = ${clusterId}
+      )
+      SELECT source, slot, event_index, validator_index, pubkey, source_address, amount
+      FROM withdrawal_events
+      ORDER BY slot DESC, source ASC, sort_index DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `;
 
-    return { rows, totalCount: payloadCount + requestCount };
+    return {
+      hasNextPage: rows.length > pageSize,
+      rows: rows.slice(0, pageSize),
+    };
   }
 }

--- a/packages/api/src/storage/withdrawal.ts
+++ b/packages/api/src/storage/withdrawal.ts
@@ -1,13 +1,41 @@
 import { PrismaClient } from '@beacon-indexer/db';
 
 export interface WithdrawalEventRow {
-  source: string;
+  source: 'payload' | 'request';
   slot: number;
   event_index: string;
   validator_index: number;
   pubkey: string | null;
   source_address: string | null;
   amount: bigint;
+}
+
+interface SortableWithdrawalEventRow extends WithdrawalEventRow {
+  sort_index: bigint;
+}
+
+/**
+ * Sorts mixed withdrawal sources the same way the previous SQL union did.
+ */
+function compareWithdrawalEvents(
+  left: SortableWithdrawalEventRow,
+  right: SortableWithdrawalEventRow,
+) {
+  if (left.slot !== right.slot) {
+    return right.slot - left.slot;
+  }
+
+  const sourceRank = { payload: 0, request: 1 };
+  const sourceOrder = sourceRank[left.source] - sourceRank[right.source];
+  if (sourceOrder !== 0) {
+    return sourceOrder;
+  }
+
+  if (left.sort_index === right.sort_index) {
+    return 0;
+  }
+
+  return left.sort_index > right.sort_index ? -1 : 1;
 }
 
 export class WithdrawalStorage {
@@ -19,63 +47,83 @@ export class WithdrawalStorage {
   async getWithdrawals(params: { clusterId: string; page: number; pageSize: number }) {
     const { clusterId, page, pageSize } = params;
     const offset = (page - 1) * pageSize;
+    const pageWindowSize = offset + pageSize;
 
-    const [rows, countResult] = await Promise.all([
-      this.prisma.$queryRaw<WithdrawalEventRow[]>`
-        WITH withdrawal_events AS (
-          SELECT
-            'payload'::text AS source,
-            w.slot,
-            w.withdrawal_index::text AS event_index,
-            w.withdrawal_index::numeric AS sort_index,
-            w.validator_index::integer AS validator_index,
-            NULL::text AS pubkey,
-            NULL::text AS source_address,
-            w.amount
-          FROM validator_withdrawals w
-          JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
-          WHERE cv.cluster_id = ${clusterId}
-
-          UNION ALL
-
-          SELECT
-            'request'::text AS source,
-            wr.slot,
-            wr.request_index::text AS event_index,
-            wr.request_index::numeric AS sort_index,
-            v.id AS validator_index,
-            wr.pub_key AS pubkey,
-            wr.source_address,
-            wr.amount
-          FROM validator_request_withdrawals wr
-          JOIN validator v ON v.pubkey = wr.pub_key
-          JOIN cluster_validator cv ON cv.validator_index = v.id
-          WHERE cv.cluster_id = ${clusterId}
+    const clusterValidators = await this.prisma.clusterValidator.findMany({
+      where: { clusterId },
+      select: {
+        validatorIndex: true,
+        validator: { select: { pubkey: true } },
+      },
+    });
+    const validatorIndexes = clusterValidators.map(
+      (clusterValidator) => clusterValidator.validatorIndex,
+    );
+    const validatorIndexStrings = validatorIndexes.map(String);
+    const validatorIndexByPubkey = new Map(
+      clusterValidators
+        .filter(
+          (
+            clusterValidator,
+          ): clusterValidator is { validatorIndex: number; validator: { pubkey: string } } =>
+            clusterValidator.validator.pubkey !== null,
         )
-        SELECT source, slot, event_index, validator_index, pubkey, source_address, amount
-        FROM withdrawal_events
-        ORDER BY slot DESC, source ASC, sort_index DESC
-        LIMIT ${pageSize} OFFSET ${offset}
-      `,
-      this.prisma.$queryRaw<[{ count: bigint }]>`
-        SELECT COUNT(*)::bigint AS count
-        FROM (
-          SELECT 1
-          FROM validator_withdrawals w
-          JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
-          WHERE cv.cluster_id = ${clusterId}
+        .map((clusterValidator) => [
+          clusterValidator.validator.pubkey,
+          clusterValidator.validatorIndex,
+        ]),
+    );
+    const pubkeys = Array.from(validatorIndexByPubkey.keys());
 
-          UNION ALL
+    if (validatorIndexes.length === 0) {
+      return { rows: [], totalCount: 0 };
+    }
 
-          SELECT 1
-          FROM validator_request_withdrawals wr
-          JOIN validator v ON v.pubkey = wr.pub_key
-          JOIN cluster_validator cv ON cv.validator_index = v.id
-          WHERE cv.cluster_id = ${clusterId}
-        ) withdrawal_events
-      `,
+    const [payloadWithdrawals, requestWithdrawals, payloadCount, requestCount] = await Promise.all([
+      this.prisma.validatorWithdrawals.findMany({
+        where: { validatorIndex: { in: validatorIndexStrings } },
+        orderBy: [{ slot: 'desc' }, { withdrawalIndex: 'desc' }],
+        take: pageWindowSize,
+      }),
+      this.prisma.validatorWithdrawalsRequests.findMany({
+        where: { pubKey: { in: pubkeys } },
+        orderBy: [{ slot: 'desc' }, { requestIndex: 'desc' }],
+        take: pageWindowSize,
+      }),
+      this.prisma.validatorWithdrawals.count({
+        where: { validatorIndex: { in: validatorIndexStrings } },
+      }),
+      this.prisma.validatorWithdrawalsRequests.count({
+        where: { pubKey: { in: pubkeys } },
+      }),
     ]);
+    const events: SortableWithdrawalEventRow[] = [
+      ...payloadWithdrawals.map((withdrawal) => ({
+        source: 'payload' as const,
+        slot: withdrawal.slot,
+        event_index: withdrawal.withdrawalIndex.toString(),
+        sort_index: withdrawal.withdrawalIndex,
+        validator_index: Number(withdrawal.validatorIndex),
+        pubkey: null,
+        source_address: null,
+        amount: withdrawal.amount,
+      })),
+      ...requestWithdrawals.map((withdrawal) => ({
+        source: 'request' as const,
+        slot: withdrawal.slot,
+        event_index: withdrawal.requestIndex.toString(),
+        sort_index: BigInt(withdrawal.requestIndex),
+        validator_index: validatorIndexByPubkey.get(withdrawal.pubKey)!,
+        pubkey: withdrawal.pubKey,
+        source_address: withdrawal.sourceAddress,
+        amount: withdrawal.amount,
+      })),
+    ];
+    const rows = events
+      .sort(compareWithdrawalEvents)
+      .slice(offset, offset + pageSize)
+      .map(({ sort_index: _sortIndex, ...event }) => event);
 
-    return { rows, totalCount: Number(countResult[0].count) };
+    return { rows, totalCount: payloadCount + requestCount };
   }
 }

--- a/packages/api/src/storage/withdrawal.ts
+++ b/packages/api/src/storage/withdrawal.ts
@@ -1,0 +1,81 @@
+import { PrismaClient } from '@beacon-indexer/db';
+
+export interface WithdrawalEventRow {
+  source: string;
+  slot: number;
+  event_index: string;
+  validator_index: number;
+  pubkey: string | null;
+  source_address: string | null;
+  amount: bigint;
+}
+
+export class WithdrawalStorage {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  /**
+   * Lists execution payload and request withdrawals for validators in the selected cluster.
+   */
+  async getWithdrawals(params: { clusterId: string; page: number; pageSize: number }) {
+    const { clusterId, page, pageSize } = params;
+    const offset = (page - 1) * pageSize;
+
+    const [rows, countResult] = await Promise.all([
+      this.prisma.$queryRaw<WithdrawalEventRow[]>`
+        WITH withdrawal_events AS (
+          SELECT
+            'payload'::text AS source,
+            w.slot,
+            w.withdrawal_index::text AS event_index,
+            w.withdrawal_index::numeric AS sort_index,
+            w.validator_index::integer AS validator_index,
+            NULL::text AS pubkey,
+            NULL::text AS source_address,
+            w.amount
+          FROM validator_withdrawals w
+          JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
+          WHERE cv.cluster_id = ${clusterId}
+
+          UNION ALL
+
+          SELECT
+            'request'::text AS source,
+            wr.slot,
+            wr.request_index::text AS event_index,
+            wr.request_index::numeric AS sort_index,
+            v.id AS validator_index,
+            wr.pub_key AS pubkey,
+            wr.source_address,
+            wr.amount
+          FROM validator_request_withdrawals wr
+          JOIN validator v ON v.pubkey = wr.pub_key
+          JOIN cluster_validator cv ON cv.validator_index = v.id
+          WHERE cv.cluster_id = ${clusterId}
+        )
+        SELECT source, slot, event_index, validator_index, pubkey, source_address, amount
+        FROM withdrawal_events
+        ORDER BY slot DESC, source ASC, sort_index DESC
+        LIMIT ${pageSize} OFFSET ${offset}
+      `,
+      this.prisma.$queryRaw<[{ count: bigint }]>`
+        SELECT COUNT(*)::bigint AS count
+        FROM (
+          SELECT 1
+          FROM validator_withdrawals w
+          JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
+          WHERE cv.cluster_id = ${clusterId}
+
+          UNION ALL
+
+          SELECT 1
+          FROM validator_request_withdrawals wr
+          JOIN validator v ON v.pubkey = wr.pub_key
+          JOIN cluster_validator cv ON cv.validator_index = v.id
+          WHERE cv.cluster_id = ${clusterId}
+        ) withdrawal_events
+      `,
+    ]);
+
+    return { rows, totalCount: Number(countResult[0].count) };
+  }
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -137,6 +137,8 @@ model epochRewards {
   @@map("epoch_rewards")
 }
 
+// Stores transfers executed by the beacon chain and included in execution payloads.
+// Rows are completed payouts, including automatic rewards and processed partial or full withdrawals.
 model validatorWithdrawals {
   withdrawalIndex BigInt @id @map("withdrawal_index")
   slot            Int    @map("slot")
@@ -186,6 +188,8 @@ model validatorExits {
   @@map("validator_voluntary_exits")
 }
 
+// Stores EIP-7002 withdrawal requests initiated by the withdrawal-address controller.
+// An amount of zero requests a full validator exit; a positive amount requests a partial withdrawal.
 model validatorWithdrawalsRequests {
   slot          Int     @map("slot")
   requestIndex  Int     @map("request_index")

--- a/packages/webapp/components/cluster/events/events-tab-pagination.tsx
+++ b/packages/webapp/components/cluster/events/events-tab-pagination.tsx
@@ -4,7 +4,8 @@ import { Button } from '@/components/ui/button';
 
 interface EventsTabPaginationProps {
   currentPage: number;
-  totalPages: number;
+  hasNextPage?: boolean;
+  totalPages?: number;
   onPreviousPage: () => void;
   onNextPage: () => void;
 }
@@ -12,19 +13,22 @@ interface EventsTabPaginationProps {
 /** Renders the shared pager used by event tabs. */
 export function EventsTabPagination({
   currentPage,
+  hasNextPage,
   onNextPage,
   onPreviousPage,
   totalPages,
 }: EventsTabPaginationProps) {
+  const canGoNext = totalPages !== undefined ? currentPage < totalPages : Boolean(hasNextPage);
+
   return (
     <div className="flex items-center justify-between pt-3 border-t border-border/50">
       <Button variant="ghost" size="sm" onClick={onPreviousPage} disabled={currentPage <= 1}>
         Prev
       </Button>
       <span className="text-xs text-muted-foreground">
-        Page {currentPage} of {totalPages}
+        {totalPages !== undefined ? `Page ${currentPage} of ${totalPages}` : `Page ${currentPage}`}
       </span>
-      <Button variant="ghost" size="sm" onClick={onNextPage} disabled={currentPage >= totalPages}>
+      <Button variant="ghost" size="sm" onClick={onNextPage} disabled={!canGoNext}>
         Next
       </Button>
     </div>

--- a/packages/webapp/components/cluster/events/index.tsx
+++ b/packages/webapp/components/cluster/events/index.tsx
@@ -6,7 +6,7 @@ import { BlocksTab } from './blocks-tab';
 import { ConsolidationsTab } from './consolidations-tab';
 import { DepositsTab } from './deposits-tab';
 import { IncidentsTab } from './incidents-tab';
-import { WithdrawalsTab } from './withdrawals-tab';
+import { WithdrawalEvents } from './withdrawal-events';
 
 import {
   UnderlineTabs,
@@ -57,7 +57,7 @@ export default function EventsFeedContent({ clusterId }: EventsFeedContentProps)
         </UnderlineTabsContent>
 
         <UnderlineTabsContent value="withdrawals" className="space-y-2 mt-4 min-h-[400px]">
-          <WithdrawalsTab clusterId={clusterId} />
+          <WithdrawalEvents clusterId={clusterId} />
         </UnderlineTabsContent>
       </UnderlineTabs>
     </div>

--- a/packages/webapp/components/cluster/events/index.tsx
+++ b/packages/webapp/components/cluster/events/index.tsx
@@ -57,7 +57,7 @@ export default function EventsFeedContent({ clusterId }: EventsFeedContentProps)
         </UnderlineTabsContent>
 
         <UnderlineTabsContent value="withdrawals" className="space-y-2 mt-4 min-h-[400px]">
-          <WithdrawalsTab />
+          <WithdrawalsTab clusterId={clusterId} />
         </UnderlineTabsContent>
       </UnderlineTabs>
     </div>

--- a/packages/webapp/components/cluster/events/payouts-tab.tsx
+++ b/packages/webapp/components/cluster/events/payouts-tab.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { format } from 'date-fns';
+import { useState } from 'react';
+
+import { EmptyStateTab } from './empty-state-tab';
+import { EventsTabPagination } from './events-tab-pagination';
+
+import ArrowRight from '@/components/icons/arrow-right';
+import { Badge } from '@/components/ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { env } from '@/env';
+import type { PayoutEvent } from '@/hooks/use-payouts';
+import { usePayouts } from '@/hooks/use-payouts';
+import { cn, getTokenSymbol } from '@/lib/utils';
+
+interface PayoutsTabProps {
+  clusterId: string | null;
+}
+
+interface PayoutItemProps {
+  payout: PayoutEvent;
+  tokenSymbol: string;
+}
+
+/**
+ * Renders paginated completed beacon-chain payouts for the selected cluster.
+ */
+export function PayoutsTab({ clusterId }: PayoutsTabProps) {
+  const [payoutsPage, setPayoutsPage] = useState(1);
+  const { data: payoutsData, error, isLoading } = usePayouts(clusterId, payoutsPage);
+  const tokenSymbol = getTokenSymbol(env.NEXT_PUBLIC_CHAIN);
+
+  if (!clusterId) {
+    return <EmptyStateTab message="Select a cluster" />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="h-16 bg-foreground/5 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-destructive text-center py-8">{error.message}</p>;
+  }
+
+  if (!payoutsData || payoutsData.payouts.length === 0) {
+    return <EmptyStateTab message="No payouts" />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {payoutsData.payouts.map((payout) => (
+        <PayoutItem key={payout.index} payout={payout} tokenSymbol={tokenSymbol} />
+      ))}
+      {(payoutsPage > 1 || payoutsData.hasNextPage) && (
+        <EventsTabPagination
+          currentPage={payoutsPage}
+          hasNextPage={payoutsData.hasNextPage}
+          onPreviousPage={() => setPayoutsPage((page) => Math.max(1, page - 1))}
+          onNextPage={() => setPayoutsPage((page) => page + 1)}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Renders one completed payout and its beacon-chain details.
+ */
+function PayoutItem({ payout, tokenSymbol }: PayoutItemProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger className="w-full">
+        <div className="flex items-center gap-2 md:gap-3 p-2 md:p-3 rounded-lg bg-accent hover:bg-accent/80 transition-colors group cursor-pointer border border-border/50 hover:border-border">
+          <div className="flex-1 flex items-center gap-2 text-left min-w-0">
+            <Badge variant="default" className="uppercase shrink-0">
+              Payout
+            </Badge>
+            <span className="text-xs md:text-sm font-mono text-muted-foreground whitespace-nowrap">
+              {format(new Date(payout.timestamp), 'yyyy-MM-dd')}
+            </span>
+            <span className="text-xs md:text-sm font-mono whitespace-nowrap">
+              Val #{payout.validatorIndex}
+            </span>
+            <span className="text-xs md:text-sm font-normal text-success ml-auto whitespace-nowrap">
+              {payout.amount} {tokenSymbol}
+            </span>
+          </div>
+
+          <ArrowRight
+            className={cn(
+              'size-4 text-foreground/60 transition-transform flex-shrink-0',
+              isOpen && 'rotate-90',
+              'group-hover:text-foreground',
+            )}
+          />
+        </div>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <div className="px-3 py-3 ml-6 md:ml-11 space-y-2 text-sm border-l-2 border-border">
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Payout Index</span>
+            <span className="font-mono text-xs md:text-sm">{payout.index}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Validator Index</span>
+            <span className="font-mono text-xs md:text-sm">{payout.validatorIndex}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Slot</span>
+            <span className="font-mono text-xs md:text-sm">{payout.slot.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Amount</span>
+            <span className="font-normal text-success text-xs md:text-sm">
+              {payout.amount} {tokenSymbol}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Timestamp</span>
+            <span className="font-mono text-xs break-all">
+              {new Date(payout.timestamp).toISOString()}
+            </span>
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/webapp/components/cluster/events/withdrawal-events.tsx
+++ b/packages/webapp/components/cluster/events/withdrawal-events.tsx
@@ -22,7 +22,7 @@ export function WithdrawalEvents({ clusterId }: WithdrawalEventsProps) {
     <UnderlineTabs defaultValue="payouts">
       <UnderlineTabsList>
         <UnderlineTabsTrigger value="payouts">Payouts</UnderlineTabsTrigger>
-        <UnderlineTabsTrigger value="withdrawals">Withdrawals</UnderlineTabsTrigger>
+        <UnderlineTabsTrigger value="withdrawals">Withdrawal Requests</UnderlineTabsTrigger>
       </UnderlineTabsList>
 
       <UnderlineTabsContent value="payouts" className="space-y-2 mt-4">

--- a/packages/webapp/components/cluster/events/withdrawal-events.tsx
+++ b/packages/webapp/components/cluster/events/withdrawal-events.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { PayoutsTab } from './payouts-tab';
+import { WithdrawalsTab } from './withdrawals-tab';
+
+import {
+  UnderlineTabs,
+  UnderlineTabsContent,
+  UnderlineTabsList,
+  UnderlineTabsTrigger,
+} from '@/components/underline-tabs';
+
+interface WithdrawalEventsProps {
+  clusterId: string | null;
+}
+
+/**
+ * Separates completed payouts from operator-initiated withdrawal requests.
+ */
+export function WithdrawalEvents({ clusterId }: WithdrawalEventsProps) {
+  return (
+    <UnderlineTabs defaultValue="payouts">
+      <UnderlineTabsList>
+        <UnderlineTabsTrigger value="payouts">Payouts</UnderlineTabsTrigger>
+        <UnderlineTabsTrigger value="withdrawals">Withdrawals</UnderlineTabsTrigger>
+      </UnderlineTabsList>
+
+      <UnderlineTabsContent value="payouts" className="space-y-2 mt-4">
+        <PayoutsTab clusterId={clusterId} />
+      </UnderlineTabsContent>
+
+      <UnderlineTabsContent value="withdrawals" className="space-y-2 mt-4">
+        <WithdrawalsTab clusterId={clusterId} />
+      </UnderlineTabsContent>
+    </UnderlineTabs>
+  );
+}

--- a/packages/webapp/components/cluster/events/withdrawals-tab.tsx
+++ b/packages/webapp/components/cluster/events/withdrawals-tab.tsx
@@ -1,8 +1,161 @@
 'use client';
 
-import { EmptyStateTab } from './empty-state-tab';
+import { format } from 'date-fns';
+import { useState } from 'react';
 
-/** Renders the withdrawals tab placeholder. */
-export function WithdrawalsTab() {
-  return <EmptyStateTab message="No withdrawals" />;
+import { EmptyStateTab } from './empty-state-tab';
+import { EventsTabPagination } from './events-tab-pagination';
+
+import ArrowRight from '@/components/icons/arrow-right';
+import { Badge } from '@/components/ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { env } from '@/env';
+import type { WithdrawalEvent } from '@/hooks/use-withdrawals';
+import { useWithdrawals } from '@/hooks/use-withdrawals';
+import { cn, getTokenSymbol } from '@/lib/utils';
+
+interface WithdrawalsTabProps {
+  clusterId: string | null;
+}
+
+interface WithdrawalItemProps {
+  tokenSymbol: string;
+  withdrawal: WithdrawalEvent;
+}
+
+/**
+ * Renders the paginated withdrawals list for the selected cluster.
+ */
+export function WithdrawalsTab({ clusterId }: WithdrawalsTabProps) {
+  const [withdrawalsPage, setWithdrawalsPage] = useState(1);
+  const { data: withdrawalsData, error, isLoading } = useWithdrawals(clusterId, withdrawalsPage);
+  const totalWithdrawalPages = withdrawalsData
+    ? Math.ceil(withdrawalsData.totalCount / withdrawalsData.pageSize)
+    : 0;
+  const tokenSymbol = getTokenSymbol(env.NEXT_PUBLIC_CHAIN);
+
+  if (!clusterId) {
+    return <EmptyStateTab message="Select a cluster" />;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="h-16 bg-foreground/5 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-destructive text-center py-8">{error.message}</p>;
+  }
+
+  if (!withdrawalsData || withdrawalsData.withdrawals.length === 0) {
+    return <EmptyStateTab message="No withdrawals" />;
+  }
+
+  return (
+    <div className="space-y-2">
+      {withdrawalsData.withdrawals.map((withdrawal) => (
+        <WithdrawalItem
+          key={`${withdrawal.slot}-${withdrawal.source}-${withdrawal.index}`}
+          tokenSymbol={tokenSymbol}
+          withdrawal={withdrawal}
+        />
+      ))}
+      {totalWithdrawalPages > 1 && (
+        <EventsTabPagination
+          currentPage={withdrawalsPage}
+          totalPages={totalWithdrawalPages}
+          onPreviousPage={() => setWithdrawalsPage((page) => Math.max(1, page - 1))}
+          onNextPage={() => setWithdrawalsPage((page) => Math.min(totalWithdrawalPages, page + 1))}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Renders one withdrawal row and expands into withdrawal details.
+ */
+function WithdrawalItem({ tokenSymbol, withdrawal }: WithdrawalItemProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const sourceLabel =
+    withdrawal.source === 'execution_request' ? 'Execution Request' : 'Execution Payload';
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger className="w-full">
+        <div className="flex items-center gap-2 md:gap-3 p-2 md:p-3 rounded-lg bg-accent hover:bg-accent/80 transition-colors group cursor-pointer border border-border/50 hover:border-border">
+          <div className="flex-1 flex items-center gap-2 text-left min-w-0">
+            <Badge variant="default" className="uppercase shrink-0">
+              Withdrawal
+            </Badge>
+            <span className="text-xs md:text-sm font-mono text-muted-foreground whitespace-nowrap">
+              {format(new Date(withdrawal.timestamp), 'yyyy-MM-dd')}
+            </span>
+            <span className="text-xs md:text-sm font-mono whitespace-nowrap">
+              Val #{withdrawal.validatorIndex}
+            </span>
+            <span className="text-xs md:text-sm font-normal text-success ml-auto whitespace-nowrap">
+              {withdrawal.amount} {tokenSymbol}
+            </span>
+          </div>
+
+          <ArrowRight
+            className={cn(
+              'size-4 text-foreground/60 transition-transform flex-shrink-0',
+              isOpen && 'rotate-90',
+              'group-hover:text-foreground',
+            )}
+          />
+        </div>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <div className="px-3 py-3 ml-6 md:ml-11 space-y-2 text-sm border-l-2 border-border">
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Validator Index</span>
+            <span className="font-mono text-xs md:text-sm">{withdrawal.validatorIndex}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Slot</span>
+            <span className="font-mono text-xs md:text-sm">{withdrawal.slot.toLocaleString()}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Source</span>
+            <span className="font-mono text-xs md:text-sm">{sourceLabel}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Amount</span>
+            <span className="font-normal text-success text-xs md:text-sm">
+              {withdrawal.amount} {tokenSymbol}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Timestamp</span>
+            <span className="font-mono text-xs break-all">
+              {new Date(withdrawal.timestamp).toISOString()}
+            </span>
+          </div>
+          {withdrawal.pubkey && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground text-xs md:text-sm">Pubkey</span>
+              <span className="font-mono text-xs break-all text-right">{withdrawal.pubkey}</span>
+            </div>
+          )}
+          {withdrawal.sourceAddress && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground text-xs md:text-sm">Source Address</span>
+              <span className="font-mono text-xs break-all text-right">
+                {withdrawal.sourceAddress}
+              </span>
+            </div>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
 }

--- a/packages/webapp/components/cluster/events/withdrawals-tab.tsx
+++ b/packages/webapp/components/cluster/events/withdrawals-tab.tsx
@@ -24,7 +24,7 @@ interface WithdrawalItemProps {
 }
 
 /**
- * Renders the paginated withdrawals list for the selected cluster.
+ * Renders paginated operator-initiated withdrawal requests for the selected cluster.
  */
 export function WithdrawalsTab({ clusterId }: WithdrawalsTabProps) {
   const [withdrawalsPage, setWithdrawalsPage] = useState(1);
@@ -57,7 +57,7 @@ export function WithdrawalsTab({ clusterId }: WithdrawalsTabProps) {
     <div className="space-y-2">
       {withdrawalsData.withdrawals.map((withdrawal) => (
         <WithdrawalItem
-          key={`${withdrawal.slot}-${withdrawal.source}-${withdrawal.index}`}
+          key={`${withdrawal.slot}-${withdrawal.requestIndex}`}
           tokenSymbol={tokenSymbol}
           withdrawal={withdrawal}
         />
@@ -75,12 +75,12 @@ export function WithdrawalsTab({ clusterId }: WithdrawalsTabProps) {
 }
 
 /**
- * Renders one withdrawal row and expands into withdrawal details.
+ * Renders one operator withdrawal request and its execution-request details.
  */
 function WithdrawalItem({ tokenSymbol, withdrawal }: WithdrawalItemProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const sourceLabel =
-    withdrawal.source === 'execution_request' ? 'Execution Request' : 'Execution Payload';
+  const isFullExit = withdrawal.type === 'full_exit';
+  const requestLabel = isFullExit ? 'Full Exit' : 'Withdrawal';
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
@@ -88,7 +88,7 @@ function WithdrawalItem({ tokenSymbol, withdrawal }: WithdrawalItemProps) {
         <div className="flex items-center gap-2 md:gap-3 p-2 md:p-3 rounded-lg bg-accent hover:bg-accent/80 transition-colors group cursor-pointer border border-border/50 hover:border-border">
           <div className="flex-1 flex items-center gap-2 text-left min-w-0">
             <Badge variant="default" className="uppercase shrink-0">
-              Withdrawal
+              {requestLabel}
             </Badge>
             <span className="text-xs md:text-sm font-mono text-muted-foreground whitespace-nowrap">
               {format(new Date(withdrawal.timestamp), 'yyyy-MM-dd')}
@@ -97,7 +97,7 @@ function WithdrawalItem({ tokenSymbol, withdrawal }: WithdrawalItemProps) {
               Val #{withdrawal.validatorIndex}
             </span>
             <span className="text-xs md:text-sm font-normal text-success ml-auto whitespace-nowrap">
-              {withdrawal.amount} {tokenSymbol}
+              {isFullExit ? 'Full exit' : `${withdrawal.amount} ${tokenSymbol}`}
             </span>
           </div>
 
@@ -114,6 +114,14 @@ function WithdrawalItem({ tokenSymbol, withdrawal }: WithdrawalItemProps) {
       <CollapsibleContent>
         <div className="px-3 py-3 ml-6 md:ml-11 space-y-2 text-sm border-l-2 border-border">
           <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Request Type</span>
+            <span className="font-mono text-xs md:text-sm">{requestLabel}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Request Index</span>
+            <span className="font-mono text-xs md:text-sm">{withdrawal.requestIndex}</span>
+          </div>
+          <div className="flex items-center justify-between gap-4">
             <span className="text-muted-foreground text-xs md:text-sm">Validator Index</span>
             <span className="font-mono text-xs md:text-sm">{withdrawal.validatorIndex}</span>
           </div>
@@ -121,28 +129,24 @@ function WithdrawalItem({ tokenSymbol, withdrawal }: WithdrawalItemProps) {
             <span className="text-muted-foreground text-xs md:text-sm">Slot</span>
             <span className="font-mono text-xs md:text-sm">{withdrawal.slot.toLocaleString()}</span>
           </div>
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-muted-foreground text-xs md:text-sm">Source</span>
-            <span className="font-mono text-xs md:text-sm">{sourceLabel}</span>
-          </div>
-          <div className="flex items-center justify-between gap-4">
-            <span className="text-muted-foreground text-xs md:text-sm">Amount</span>
-            <span className="font-normal text-success text-xs md:text-sm">
-              {withdrawal.amount} {tokenSymbol}
-            </span>
-          </div>
+          {!isFullExit && (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground text-xs md:text-sm">Amount</span>
+              <span className="font-normal text-success text-xs md:text-sm">
+                {withdrawal.amount} {tokenSymbol}
+              </span>
+            </div>
+          )}
           <div className="flex items-center justify-between gap-4">
             <span className="text-muted-foreground text-xs md:text-sm">Timestamp</span>
             <span className="font-mono text-xs break-all">
               {new Date(withdrawal.timestamp).toISOString()}
             </span>
           </div>
-          {withdrawal.pubkey && (
-            <div className="flex items-center justify-between gap-4">
-              <span className="text-muted-foreground text-xs md:text-sm">Pubkey</span>
-              <span className="font-mono text-xs break-all text-right">{withdrawal.pubkey}</span>
-            </div>
-          )}
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground text-xs md:text-sm">Pubkey</span>
+            <span className="font-mono text-xs break-all text-right">{withdrawal.pubkey}</span>
+          </div>
           {withdrawal.sourceAddress && (
             <div className="flex items-center justify-between gap-4">
               <span className="text-muted-foreground text-xs md:text-sm">Source Address</span>

--- a/packages/webapp/components/cluster/events/withdrawals-tab.tsx
+++ b/packages/webapp/components/cluster/events/withdrawals-tab.tsx
@@ -29,9 +29,6 @@ interface WithdrawalItemProps {
 export function WithdrawalsTab({ clusterId }: WithdrawalsTabProps) {
   const [withdrawalsPage, setWithdrawalsPage] = useState(1);
   const { data: withdrawalsData, error, isLoading } = useWithdrawals(clusterId, withdrawalsPage);
-  const totalWithdrawalPages = withdrawalsData
-    ? Math.ceil(withdrawalsData.totalCount / withdrawalsData.pageSize)
-    : 0;
   const tokenSymbol = getTokenSymbol(env.NEXT_PUBLIC_CHAIN);
 
   if (!clusterId) {
@@ -65,12 +62,12 @@ export function WithdrawalsTab({ clusterId }: WithdrawalsTabProps) {
           withdrawal={withdrawal}
         />
       ))}
-      {totalWithdrawalPages > 1 && (
+      {(withdrawalsPage > 1 || withdrawalsData.hasNextPage) && (
         <EventsTabPagination
           currentPage={withdrawalsPage}
-          totalPages={totalWithdrawalPages}
+          hasNextPage={withdrawalsData.hasNextPage}
           onPreviousPage={() => setWithdrawalsPage((page) => Math.max(1, page - 1))}
-          onNextPage={() => setWithdrawalsPage((page) => Math.min(totalWithdrawalPages, page + 1))}
+          onNextPage={() => setWithdrawalsPage((page) => page + 1)}
         />
       )}
     </div>

--- a/packages/webapp/components/cluster/events/withdrawals-tab.tsx
+++ b/packages/webapp/components/cluster/events/withdrawals-tab.tsx
@@ -50,7 +50,7 @@ export function WithdrawalsTab({ clusterId }: WithdrawalsTabProps) {
   }
 
   if (!withdrawalsData || withdrawalsData.withdrawals.length === 0) {
-    return <EmptyStateTab message="No withdrawals" />;
+    return <EmptyStateTab message="No withdrawal requests" />;
   }
 
   return (

--- a/packages/webapp/hooks/use-payouts.ts
+++ b/packages/webapp/hooks/use-payouts.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { orpcClient } from '@/lib/orpc';
+
+export interface PayoutEvent {
+  slot: number;
+  index: string;
+  validatorIndex: number;
+  amount: string;
+  timestamp: number;
+}
+
+export interface PayoutsResult {
+  payouts: PayoutEvent[];
+  hasNextPage: boolean;
+  page: number;
+}
+
+/**
+ * Fetches paginated completed payouts for the selected cluster.
+ */
+export function usePayouts(clusterId: string | null, page: number) {
+  return useQuery({
+    queryKey: ['payouts', clusterId, page],
+    queryFn: async () => {
+      if (!clusterId) throw new Error('No cluster provided');
+
+      const response = await orpcClient.payouts.list({
+        clusterId,
+        page,
+      });
+
+      if (!response.success) {
+        throw new Error(response.error?.message || 'Failed to fetch payouts');
+      }
+
+      return response.data as PayoutsResult;
+    },
+    enabled: Boolean(clusterId),
+  });
+}

--- a/packages/webapp/hooks/use-withdrawals.ts
+++ b/packages/webapp/hooks/use-withdrawals.ts
@@ -17,9 +17,8 @@ export interface WithdrawalEvent {
 
 export interface WithdrawalsResult {
   withdrawals: WithdrawalEvent[];
-  totalCount: number;
+  hasNextPage: boolean;
   page: number;
-  pageSize: number;
 }
 
 /**

--- a/packages/webapp/hooks/use-withdrawals.ts
+++ b/packages/webapp/hooks/use-withdrawals.ts
@@ -6,10 +6,10 @@ import { orpcClient } from '@/lib/orpc';
 
 export interface WithdrawalEvent {
   slot: number;
-  source: 'payload' | 'execution_request';
-  index: string;
+  requestIndex: number;
+  type: 'partial' | 'full_exit';
   validatorIndex: number;
-  pubkey: string | null;
+  pubkey: string;
   sourceAddress: string | null;
   amount: string;
   timestamp: number;
@@ -22,7 +22,7 @@ export interface WithdrawalsResult {
 }
 
 /**
- * Fetches paginated withdrawals for the selected cluster.
+ * Fetches paginated operator withdrawal requests for the selected cluster.
  */
 export function useWithdrawals(clusterId: string | null, page: number) {
   return useQuery({

--- a/packages/webapp/hooks/use-withdrawals.ts
+++ b/packages/webapp/hooks/use-withdrawals.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { orpcClient } from '@/lib/orpc';
+
+export interface WithdrawalEvent {
+  slot: number;
+  source: 'payload' | 'execution_request';
+  index: string;
+  validatorIndex: number;
+  pubkey: string | null;
+  sourceAddress: string | null;
+  amount: string;
+  timestamp: number;
+}
+
+export interface WithdrawalsResult {
+  withdrawals: WithdrawalEvent[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+/**
+ * Fetches paginated withdrawals for the selected cluster.
+ */
+export function useWithdrawals(clusterId: string | null, page: number) {
+  return useQuery({
+    queryKey: ['withdrawals', clusterId, page],
+    queryFn: async () => {
+      if (!clusterId) throw new Error('No cluster provided');
+
+      const response = await orpcClient.withdrawals.list({
+        clusterId,
+        page,
+      });
+
+      if (!response.success) {
+        throw new Error(response.error?.message || 'Failed to fetch withdrawals');
+      }
+
+      return response.data as WithdrawalsResult;
+    },
+    enabled: Boolean(clusterId),
+  });
+}


### PR DESCRIPTION
## Summary
- add a secured withdrawals API route and storage query for payload and request withdrawals
- add a webapp withdrawals query hook
- replace the withdrawals placeholder with a paginated expandable events tab

## Validation
- pnpm --filter @beacon-indexer/api exec tsc --noEmit
- pnpm --filter @beacon-indexer/api build
- pnpm --filter @beacon-indexer/webapp exec tsc --noEmit
- git push hook ran pnpm -r run lint