### PR TITLE
Compact withdrawal validator references

### DIFF
--- a/packages/api/src/storage/payout.ts
+++ b/packages/api/src/storage/payout.ts
@@ -31,10 +31,10 @@ export class PayoutStorage {
       SELECT
         w.slot,
         w.withdrawal_index::text AS payout_index,
-        w.validator_index::integer AS validator_index,
+        w.validator_index,
         w.amount
       FROM validator_withdrawals w
-      JOIN cluster_validator cv ON cv.validator_index::text = w.validator_index
+      JOIN cluster_validator cv ON cv.validator_index = w.validator_index
       WHERE cv.cluster_id = ${clusterId}
       ORDER BY w.slot DESC, w.withdrawal_index DESC
       LIMIT ${limit} OFFSET ${offset}

--- a/packages/api/src/storage/withdrawal.test.ts
+++ b/packages/api/src/storage/withdrawal.test.ts
@@ -32,6 +32,8 @@ describe('payout and withdrawal storage', () => {
     const sql = getSqlText(queryRaw.mock.calls[0]?.[0]);
     expect(sql).toContain('FROM validator_withdrawals w');
     expect(sql).not.toContain('validator_request_withdrawals');
+    expect(sql).toContain('cv.validator_index = w.validator_index');
+    expect(sql).not.toContain('validator_index::integer');
   });
 
   // This scenario expects the withdrawals listing to read EIP-7002 operator requests only.
@@ -46,6 +48,9 @@ describe('payout and withdrawal storage', () => {
     // The emitted SQL must use the request table and must not union completed payout rows.
     const sql = getSqlText(queryRaw.mock.calls[0]?.[0]);
     expect(sql).toContain('FROM validator_request_withdrawals wr');
+    expect(sql).toContain('v.id = wr.validator_index');
+    expect(sql).toContain('cv.validator_index = wr.validator_index');
+    expect(sql).not.toContain('wr.pub_key');
     expect(sql).not.toContain('FROM validator_withdrawals w');
     expect(sql).not.toContain('UNION ALL');
   });

--- a/packages/api/src/storage/withdrawal.ts
+++ b/packages/api/src/storage/withdrawal.ts
@@ -33,13 +33,13 @@ export class WithdrawalStorage {
       SELECT
         wr.slot,
         wr.request_index,
-        v.id AS validator_index,
-        wr.pub_key AS pubkey,
+        wr.validator_index,
+        v.pubkey,
         wr.source_address,
         wr.amount
       FROM validator_request_withdrawals wr
-      JOIN validator v ON v.pubkey = wr.pub_key
-      JOIN cluster_validator cv ON cv.validator_index = v.id
+      JOIN validator v ON v.id = wr.validator_index
+      JOIN cluster_validator cv ON cv.validator_index = wr.validator_index
       WHERE cv.cluster_id = ${clusterId}
       ORDER BY wr.slot DESC, wr.request_index DESC
       LIMIT ${limit} OFFSET ${offset}

--- a/packages/db/prisma/migrations/20260727133000_compact_withdrawal_validator_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20260727133000_compact_withdrawal_validator_indexes/migration.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+-- Abort before rewriting data unless every stored request resolves to exactly one validator.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "public"."validator_request_withdrawals" wr
+    LEFT JOIN "public"."validator" v ON v."pubkey" = wr."pub_key"
+    GROUP BY wr."slot", wr."request_index"
+    HAVING COUNT(v."id") <> 1
+  ) THEN
+    RAISE EXCEPTION
+      'Cannot compact validator_request_withdrawals: every pubkey must resolve to exactly one validator';
+  END IF;
+END
+$$;
+
+-- Guard the integer conversion against malformed or out-of-range historical validator indexes.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "public"."validator_withdrawals"
+    WHERE CASE
+      WHEN "validator_index" ~ '^[0-9]+$'
+        THEN "validator_index"::numeric > 2147483647
+      ELSE TRUE
+    END
+  ) THEN
+    RAISE EXCEPTION
+      'Cannot compact validator_withdrawals: validator_index contains invalid integer values';
+  END IF;
+END
+$$;
+
+DROP INDEX "public"."validator_withdrawals_validator_index_slot_idx";
+
+ALTER TABLE "public"."validator_withdrawals"
+  ALTER COLUMN "validator_index" TYPE INTEGER
+  USING "validator_index"::integer;
+
+CREATE INDEX "validator_withdrawals_validator_index_slot_idx"
+  ON "public"."validator_withdrawals"("validator_index", "slot");
+
+-- Resolve the protocol pubkey while PostgreSQL rewrites the request table into its compact shape.
+CREATE FUNCTION "public"."resolve_withdrawal_request_validator_index"("request_pubkey" VARCHAR)
+RETURNS INTEGER
+LANGUAGE SQL
+STABLE
+STRICT
+AS $$
+  SELECT "id"
+  FROM "public"."validator"
+  WHERE "pubkey" = "request_pubkey"
+$$;
+
+DROP INDEX "public"."validator_request_withdrawals_pub_key_slot_idx";
+
+ALTER TABLE "public"."validator_request_withdrawals"
+  RENAME COLUMN "pub_key" TO "validator_index";
+
+ALTER TABLE "public"."validator_request_withdrawals"
+  ALTER COLUMN "validator_index" TYPE INTEGER
+  USING "public"."resolve_withdrawal_request_validator_index"("validator_index");
+
+DROP FUNCTION "public"."resolve_withdrawal_request_validator_index"(VARCHAR);
+
+CREATE INDEX "validator_request_withdrawals_validator_index_slot_idx"
+  ON "public"."validator_request_withdrawals"("validator_index", "slot" DESC);
+
+COMMIT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -142,7 +142,7 @@ model epochRewards {
 model validatorWithdrawals {
   withdrawalIndex BigInt @id @map("withdrawal_index")
   slot            Int    @map("slot")
-  validatorIndex  String @map("validator_index") @db.VarChar(98)
+  validatorIndex  Int    @map("validator_index")
   amount          BigInt @map("amount")
 
   @@index([validatorIndex, slot], map: "validator_withdrawals_validator_index_slot_idx")
@@ -191,14 +191,14 @@ model validatorExits {
 // Stores EIP-7002 withdrawal requests initiated by the withdrawal-address controller.
 // An amount of zero requests a full validator exit; a positive amount requests a partial withdrawal.
 model validatorWithdrawalsRequests {
-  slot          Int     @map("slot")
-  requestIndex  Int     @map("request_index")
-  sourceAddress String? @map("source_address") @db.VarChar(42)
-  pubKey        String  @map("pub_key") @db.VarChar(98)
-  amount        BigInt  @map("amount")
+  slot           Int     @map("slot")
+  requestIndex   Int     @map("request_index")
+  sourceAddress  String? @map("source_address") @db.VarChar(42)
+  validatorIndex Int     @map("validator_index")
+  amount         BigInt  @map("amount")
 
   @@id([slot, requestIndex])
-  @@index([pubKey, slot(sort: Desc)], map: "validator_request_withdrawals_pub_key_slot_idx")
+  @@index([validatorIndex, slot(sort: Desc)], map: "validator_request_withdrawals_validator_index_slot_idx")
   @@map("validator_request_withdrawals")
 }
 

--- a/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
+++ b/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
@@ -534,6 +534,9 @@ describe('Slot Processor E2E Tests', () => {
     // This real block pubkey verifies request ingestion resolves protocol pubkeys to compact indexes.
     const withdrawalRequestValidatorPubkey =
       '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b';
+    // This pubkey has no validator row and must make the atomic request write fail.
+    const unknownWithdrawalRequestValidatorPubkey =
+      '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
     // Validators that missed slot 24672000
     const missedValidators = [272515, 98804, 421623, 62759] as const;
@@ -801,6 +804,37 @@ describe('Slot Processor E2E Tests', () => {
         expect(actual.sourceAddress).toBe(expectedWithdrawalRequest.sourceAddress);
         expect(actual.validatorIndex).toBe(expectedWithdrawalRequest.validatorIndex);
         expect(actual.amount.toString()).toBe(expectedWithdrawalRequest.amount.toString());
+      });
+
+      // This scenario verifies one unresolved request rolls back the complete request batch and slot flag.
+      it('should reject the withdrawal request batch when a validator pubkey cannot resolve', async () => {
+        // Slot 24672002 belongs to the seeded epoch but has no execution-request data yet.
+        const unresolvedRequestSlot = 24672002;
+        // The first request resolves successfully, while the second exercises the missing-validator failure.
+        const withdrawalRequests = [
+          {
+            source_address: '0x1111111111111111111111111111111111111111',
+            validator_pubkey: withdrawalRequestValidatorPubkey,
+            amount: '1',
+          },
+          {
+            source_address: '0x2222222222222222222222222222222222222222',
+            validator_pubkey: unknownWithdrawalRequestValidatorPubkey,
+            amount: '2',
+          },
+        ];
+
+        // The unresolved validator must reject the database statement instead of dropping one request.
+        await expect(
+          slotControllerWithMock.processErWithdrawals(unresolvedRequestSlot, withdrawalRequests),
+        ).rejects.toThrow();
+
+        // Atomicity requires both the valid request and fetched flag to remain absent after the failure.
+        const storedRequests =
+          await slotStorage.getValidatorWithdrawalsRequestsForSlot(unresolvedRequestSlot);
+        const slotData = await slotStorage.getBaseSlot(unresolvedRequestSlot);
+        expect(storedRequests).toHaveLength(0);
+        expect(slotData.erWithdrawalsFetched).toBe(false);
       });
 
       it('should verify consolidation requests from execution requests were saved correctly', async () => {

--- a/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
+++ b/packages/indexer/e2e/slot/slotProcessor/slotProcessor.test.ts
@@ -529,6 +529,11 @@ describe('Slot Processor E2E Tests', () => {
     const slot24672000 = 24672000;
     const slot24672001 = 24672001; // Attestations for slot 24672000 come at slot 24672001 (n+1 pattern)
     const epoch1542000 = 1542000;
+    // This synthetic index resolves the real withdrawal-request pubkey from the block fixture.
+    const withdrawalRequestValidatorIndex = 600001;
+    // This real block pubkey verifies request ingestion resolves protocol pubkeys to compact indexes.
+    const withdrawalRequestValidatorPubkey =
+      '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b';
 
     // Validators that missed slot 24672000
     const missedValidators = [272515, 98804, 421623, 62759] as const;
@@ -596,6 +601,15 @@ describe('Slot Processor E2E Tests', () => {
         ),
       );
       await validatorsStorage.saveValidators(validators);
+
+      // Seed the request validator because the general validator fixture predates this block request.
+      await prisma.validator.create({
+        data: {
+          id: withdrawalRequestValidatorIndex,
+          balance: BigInt('64000000000'),
+          pubkey: withdrawalRequestValidatorPubkey,
+        },
+      });
 
       // Create epoch 1542000
       await epochStorage.createEpochs([epoch1542000]);
@@ -694,14 +708,14 @@ describe('Slot Processor E2E Tests', () => {
       it('should verify all withdrawals from mock data were saved correctly', async () => {
         // Expected withdrawals from block_24672001.json
         const expectedWithdrawals = [
-          { validatorIndex: '300993', amount: BigInt('12003217') },
-          { validatorIndex: '300994', amount: BigInt('12023599') },
-          { validatorIndex: '300995', amount: BigInt('11995355') },
-          { validatorIndex: '300996', amount: BigInt('12014455') },
-          { validatorIndex: '300997', amount: BigInt('11994342') },
-          { validatorIndex: '300998', amount: BigInt('12024224') },
-          { validatorIndex: '300999', amount: BigInt('12001852') },
-          { validatorIndex: '301000', amount: BigInt('12007175') },
+          { validatorIndex: 300993, amount: BigInt('12003217') },
+          { validatorIndex: 300994, amount: BigInt('12023599') },
+          { validatorIndex: 300995, amount: BigInt('11995355') },
+          { validatorIndex: 300996, amount: BigInt('12014455') },
+          { validatorIndex: 300997, amount: BigInt('11994342') },
+          { validatorIndex: 300998, amount: BigInt('12024224') },
+          { validatorIndex: 300999, amount: BigInt('12001852') },
+          { validatorIndex: 301000, amount: BigInt('12007175') },
         ];
 
         // Get all withdrawals for slot 24672001 using storage method
@@ -769,8 +783,7 @@ describe('Slot Processor E2E Tests', () => {
         const expectedWithdrawalRequest = {
           requestIndex: 0,
           sourceAddress: '0xcc717037652940f319272b0bf57591e41d157f95',
-          pubKey:
-            '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b',
+          validatorIndex: withdrawalRequestValidatorIndex,
           amount: BigInt('640000000'),
         };
 
@@ -786,7 +799,7 @@ describe('Slot Processor E2E Tests', () => {
         expect(actual.slot).toBe(slot24672001);
         expect(actual.requestIndex).toBe(expectedWithdrawalRequest.requestIndex);
         expect(actual.sourceAddress).toBe(expectedWithdrawalRequest.sourceAddress);
-        expect(actual.pubKey).toBe(expectedWithdrawalRequest.pubKey);
+        expect(actual.validatorIndex).toBe(expectedWithdrawalRequest.validatorIndex);
         expect(actual.amount.toString()).toBe(expectedWithdrawalRequest.amount.toString());
       });
 

--- a/packages/indexer/src/services/consensus/controllers/slot.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.test.ts
@@ -4,14 +4,23 @@ import { SlotController } from './slot.js';
 
 // This suite verifies slot controller transformations before storage writes.
 describe('SlotController', () => {
-  // This test protects duplicate withdrawal requests for the same validator in one slot.
-  it('preserves execution withdrawal request order and source address', async () => {
-    // This storage mock returns the base slot and captures withdrawal request rows.
+  // This test protects request order while excluding pubkeys that cannot resolve to indexed validators.
+  it('stores resolved withdrawal requests and skips unresolved pubkeys', async () => {
+    // This pubkey represents a known validator referenced twice in the same execution request list.
+    const knownValidatorPubkey =
+      '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b';
+    // This pubkey represents a request that must be omitted because it has no indexed validator.
+    const unknownValidatorPubkey =
+      '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+    // This storage mock resolves only the known pubkey and captures the compact request rows.
     const slotStorage = {
       getBaseSlot: vi.fn().mockResolvedValue({
         slot: 123,
         erWithdrawalsFetched: false,
       }),
+      getValidatorIndexesByPubkeys: vi
+        .fn()
+        .mockResolvedValue([{ id: 987, pubkey: knownValidatorPubkey }]),
       saveValidatorWithdrawalsRequests: vi.fn().mockResolvedValue(undefined),
     };
 
@@ -24,39 +33,46 @@ describe('SlotController', () => {
       {} as never,
     );
 
-    // This call uses two requests for the same validator pubkey in the same slot.
+    // This call places one unresolved request between two valid requests for the same validator.
     await controller.processErWithdrawals(123, [
       {
         source_address: '0x1111111111111111111111111111111111111111',
-        validator_pubkey:
-          '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b',
+        validator_pubkey: knownValidatorPubkey,
         amount: '1',
       },
       {
         source_address: '0x2222222222222222222222222222222222222222',
-        validator_pubkey:
-          '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b',
+        validator_pubkey: unknownValidatorPubkey,
         amount: '2',
+      },
+      {
+        source_address: '0x3333333333333333333333333333333333333333',
+        validator_pubkey: knownValidatorPubkey,
+        amount: '3',
       },
     ]);
 
-    // This assertion verifies duplicate pubkeys are kept as separate ordered rows.
+    // The lookup receives the complete request set so storage can resolve it in one database query.
+    expect(slotStorage.getValidatorIndexesByPubkeys).toHaveBeenCalledWith([
+      knownValidatorPubkey,
+      unknownValidatorPubkey,
+      knownValidatorPubkey,
+    ]);
+    // The unresolved request is omitted while resolved rows retain their original request indexes.
     expect(slotStorage.saveValidatorWithdrawalsRequests).toHaveBeenCalledWith(123, [
       {
         slot: 123,
         requestIndex: 0,
         sourceAddress: '0x1111111111111111111111111111111111111111',
-        pubKey:
-          '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b',
+        validatorIndex: 987,
         amount: BigInt(1),
       },
       {
         slot: 123,
-        requestIndex: 1,
-        sourceAddress: '0x2222222222222222222222222222222222222222',
-        pubKey:
-          '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b',
-        amount: BigInt(2),
+        requestIndex: 2,
+        sourceAddress: '0x3333333333333333333333333333333333333333',
+        validatorIndex: 987,
+        amount: BigInt(3),
       },
     ]);
   });

--- a/packages/indexer/src/services/consensus/controllers/slot.test.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.test.ts
@@ -4,23 +4,20 @@ import { SlotController } from './slot.js';
 
 // This suite verifies slot controller transformations before storage writes.
 describe('SlotController', () => {
-  // This test protects request order while excluding pubkeys that cannot resolve to indexed validators.
-  it('stores resolved withdrawal requests and skips unresolved pubkeys', async () => {
-    // This pubkey represents a known validator referenced twice in the same execution request list.
+  // This test protects request order while delegating validator resolution to the atomic storage write.
+  it('passes ordered withdrawal requests to storage for atomic resolution', async () => {
+    // This pubkey represents a validator that storage will resolve during the insert.
     const knownValidatorPubkey =
       '0xa5256ce2de7b9bd44f3dc7e368d27386b1958373e7c04bcb97805bf382ecd6cd56716499f4dc625f3fab6f2cfca8fa0b';
-    // This pubkey represents a request that must be omitted because it has no indexed validator.
+    // This pubkey verifies the controller does not silently discard unresolved requests.
     const unknownValidatorPubkey =
       '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-    // This storage mock resolves only the known pubkey and captures the compact request rows.
+    // This storage mock captures the complete request list passed to the atomic database operation.
     const slotStorage = {
       getBaseSlot: vi.fn().mockResolvedValue({
         slot: 123,
         erWithdrawalsFetched: false,
       }),
-      getValidatorIndexesByPubkeys: vi
-        .fn()
-        .mockResolvedValue([{ id: 987, pubkey: knownValidatorPubkey }]),
       saveValidatorWithdrawalsRequests: vi.fn().mockResolvedValue(undefined),
     };
 
@@ -33,7 +30,7 @@ describe('SlotController', () => {
       {} as never,
     );
 
-    // This call places one unresolved request between two valid requests for the same validator.
+    // This call places a potentially unresolved request between two requests for a known validator.
     await controller.processErWithdrawals(123, [
       {
         source_address: '0x1111111111111111111111111111111111111111',
@@ -52,26 +49,21 @@ describe('SlotController', () => {
       },
     ]);
 
-    // The lookup receives the complete request set so storage can resolve it in one database query.
-    expect(slotStorage.getValidatorIndexesByPubkeys).toHaveBeenCalledWith([
-      knownValidatorPubkey,
-      unknownValidatorPubkey,
-      knownValidatorPubkey,
-    ]);
-    // The unresolved request is omitted while resolved rows retain their original request indexes.
+    // Storage receives every request in protocol order and is responsible for rejecting unknown pubkeys.
     expect(slotStorage.saveValidatorWithdrawalsRequests).toHaveBeenCalledWith(123, [
       {
-        slot: 123,
-        requestIndex: 0,
         sourceAddress: '0x1111111111111111111111111111111111111111',
-        validatorIndex: 987,
+        validatorPubkey: knownValidatorPubkey,
         amount: BigInt(1),
       },
       {
-        slot: 123,
-        requestIndex: 2,
+        sourceAddress: '0x2222222222222222222222222222222222222222',
+        validatorPubkey: unknownValidatorPubkey,
+        amount: BigInt(2),
+      },
+      {
         sourceAddress: '0x3333333333333333333333333333333333333333',
-        validatorIndex: 987,
+        validatorPubkey: knownValidatorPubkey,
         amount: BigInt(3),
       },
     ]);

--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -267,7 +267,7 @@ export class SlotController extends SlotControllerHelpers {
       withdrawals.map((withdrawal) => ({
         withdrawalIndex: BigInt(withdrawal.index),
         slot: baseSlot.slot,
-        validatorIndex: withdrawal.validator_index,
+        validatorIndex: Number(withdrawal.validator_index),
         amount: BigInt(withdrawal.amount),
       })),
     );
@@ -375,16 +375,34 @@ export class SlotController extends SlotControllerHelpers {
       return;
     }
 
-    await this.slotStorage.saveValidatorWithdrawalsRequests(
-      baseSlot.slot,
-      withdrawals.map((withdrawal, requestIndex) => ({
-        slot: baseSlot.slot,
-        requestIndex,
-        sourceAddress: withdrawal.source_address,
-        pubKey: withdrawal.validator_pubkey,
-        amount: BigInt(withdrawal.amount),
-      })),
+    const validatorRows = await this.slotStorage.getValidatorIndexesByPubkeys(
+      withdrawals.map((withdrawal) => withdrawal.validator_pubkey),
     );
+    const validatorIndexByPubkey = new Map(
+      validatorRows.flatMap((validator) =>
+        validator.pubkey ? [[validator.pubkey, validator.id] as const] : [],
+      ),
+    );
+
+    // Requests that do not resolve to indexed validators cannot affect monitored validators.
+    const resolvedWithdrawals = withdrawals.flatMap((withdrawal, requestIndex) => {
+      const validatorIndex = validatorIndexByPubkey.get(withdrawal.validator_pubkey);
+      if (validatorIndex === undefined) {
+        return [];
+      }
+
+      return [
+        {
+          slot: baseSlot.slot,
+          requestIndex,
+          sourceAddress: withdrawal.source_address,
+          validatorIndex,
+          amount: BigInt(withdrawal.amount),
+        },
+      ];
+    });
+
+    await this.slotStorage.saveValidatorWithdrawalsRequests(baseSlot.slot, resolvedWithdrawals);
   }
 
   /**

--- a/packages/indexer/src/services/consensus/controllers/slot.ts
+++ b/packages/indexer/src/services/consensus/controllers/slot.ts
@@ -375,34 +375,14 @@ export class SlotController extends SlotControllerHelpers {
       return;
     }
 
-    const validatorRows = await this.slotStorage.getValidatorIndexesByPubkeys(
-      withdrawals.map((withdrawal) => withdrawal.validator_pubkey),
+    await this.slotStorage.saveValidatorWithdrawalsRequests(
+      baseSlot.slot,
+      withdrawals.map((withdrawal) => ({
+        sourceAddress: withdrawal.source_address,
+        validatorPubkey: withdrawal.validator_pubkey,
+        amount: BigInt(withdrawal.amount),
+      })),
     );
-    const validatorIndexByPubkey = new Map(
-      validatorRows.flatMap((validator) =>
-        validator.pubkey ? [[validator.pubkey, validator.id] as const] : [],
-      ),
-    );
-
-    // Requests that do not resolve to indexed validators cannot affect monitored validators.
-    const resolvedWithdrawals = withdrawals.flatMap((withdrawal, requestIndex) => {
-      const validatorIndex = validatorIndexByPubkey.get(withdrawal.validator_pubkey);
-      if (validatorIndex === undefined) {
-        return [];
-      }
-
-      return [
-        {
-          slot: baseSlot.slot,
-          requestIndex,
-          sourceAddress: withdrawal.source_address,
-          validatorIndex,
-          amount: BigInt(withdrawal.amount),
-        },
-      ];
-    });
-
-    await this.slotStorage.saveValidatorWithdrawalsRequests(baseSlot.slot, resolvedWithdrawals);
   }
 
   /**

--- a/packages/indexer/src/services/consensus/storage/slot.ts
+++ b/packages/indexer/src/services/consensus/storage/slot.ts
@@ -513,6 +513,27 @@ export class SlotStorage {
   }
 
   /**
+   * Resolves unique validator pubkeys to the integer indexes stored by withdrawal requests.
+   */
+  async getValidatorIndexesByPubkeys(pubkeys: string[]) {
+    if (pubkeys.length === 0) {
+      return [];
+    }
+
+    return this.prisma.validator.findMany({
+      where: {
+        pubkey: {
+          in: [...new Set(pubkeys)],
+        },
+      },
+      select: {
+        id: true,
+        pubkey: true,
+      },
+    });
+  }
+
+  /**
    * Save validator withdrawal requests to database
    */
   async saveValidatorWithdrawalsRequests(

--- a/packages/indexer/src/services/consensus/storage/slot.ts
+++ b/packages/indexer/src/services/consensus/storage/slot.ts
@@ -513,42 +513,55 @@ export class SlotStorage {
   }
 
   /**
-   * Resolves unique validator pubkeys to the integer indexes stored by withdrawal requests.
-   */
-  async getValidatorIndexesByPubkeys(pubkeys: string[]) {
-    if (pubkeys.length === 0) {
-      return [];
-    }
-
-    return this.prisma.validator.findMany({
-      where: {
-        pubkey: {
-          in: [...new Set(pubkeys)],
-        },
-      },
-      select: {
-        id: true,
-        pubkey: true,
-      },
-    });
-  }
-
-  /**
-   * Save validator withdrawal requests to database
+   * Resolves and saves withdrawal requests atomically, rejecting unknown validator pubkeys.
    */
   async saveValidatorWithdrawalsRequests(
     slot: number,
-    withdrawals: Prisma.validatorWithdrawalsRequestsUncheckedCreateInput[],
+    withdrawals: Array<{
+      sourceAddress: string | null;
+      validatorPubkey: string;
+      amount: bigint;
+    }>,
   ) {
-    await this.prisma.$transaction(async (tx) => {
-      await tx.validatorWithdrawalsRequests.createMany({
-        data: withdrawals,
-      });
-      await tx.slot.update({
-        where: { slot },
-        data: { erWithdrawalsFetched: true },
-      });
-    });
+    await this.prisma.$executeRaw`
+      WITH withdrawal_requests AS (
+        SELECT
+          request.validator_pubkey,
+          request.source_address,
+          request.amount,
+          (request.ordinality - 1)::integer AS request_index
+        FROM unnest(
+          ${withdrawals.map((withdrawal) => withdrawal.validatorPubkey)}::text[],
+          ${withdrawals.map((withdrawal) => withdrawal.sourceAddress)}::text[],
+          ${withdrawals.map((withdrawal) => withdrawal.amount)}::bigint[]
+        ) WITH ORDINALITY AS request(validator_pubkey, source_address, amount, ordinality)
+      ),
+      inserted_requests AS (
+        INSERT INTO validator_request_withdrawals (
+          slot,
+          request_index,
+          source_address,
+          validator_index,
+          amount
+        )
+        SELECT
+          ${slot},
+          request.request_index,
+          request.source_address,
+          (
+            SELECT validator.id
+            FROM validator
+            WHERE validator.pubkey = request.validator_pubkey
+          ),
+          request.amount
+        FROM withdrawal_requests request
+        RETURNING 1
+      )
+      UPDATE slot
+      SET er_withdrawals_fetched = true
+      WHERE slot = ${slot}
+        AND (SELECT COUNT(*) FROM inserted_requests) = ${withdrawals.length}
+    `;
   }
 
   /**


### PR DESCRIPTION
## Summary

- store validator indexes as integers in completed payouts and withdrawal requests
- resolve withdrawal-request pubkeys in one batched validator lookup and omit unresolved requests
- remove API casts and pubkey joins from cluster payout and withdrawal-request queries
- guard the migration against unresolved, duplicate, malformed, or out-of-range historical data

## Why

`validator_request_withdrawals` repeated a 98-character validator pubkey in every row and in its secondary index. Both withdrawal tables also used textual validator identifiers even though validator indexes are integers. The compact representation reduces table and index storage without archiving or deleting valid historical events.

## Migration note

The migration rewrites both populated tables so PostgreSQL can reclaim the physical space. Deployment requires temporary disk headroom and takes exclusive table locks while each `ALTER COLUMN TYPE` runs.

## Validation

- `pnpm --dir packages/indexer exec vitest run` (124 tests)
- `pnpm --filter @beacon-indexer/api test` (64 tests)
- `pnpm lint`
- `pnpm type-check`
- `pnpm test:e2e:local` (97 indexer E2E tests, 43 API E2E tests)
- Prisma schema validation and all 11 migrations applied successfully
